### PR TITLE
Begin removing extraneous code from setup.py/cleaning up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,41 +109,6 @@ def find_package_data(data_root, package_root):
             files.append(relpath(join(root, fn), package_root))
     return files
 
-def check_dependencies():
-    from distutils.version import StrictVersion
-    found_openmm = True
-    found_openmm_61_or_later = True
-    found_numpy = True
-
-    try:
-        from simtk import openmm
-        openmm_version = StrictVersion(openmm.Platform.getOpenMMVersion())
-        if openmm_version < StrictVersion('6.1.0'):
-            found_openmm_61_or_later = False
-    except ImportError as err:
-        found_openmm = False
-
-    try:
-        import numpy
-    except:
-        found_numpy = False
-
-    msg = None
-    bar = ('-' * 70) + "\n" + ('-' * 70)
-    if found_openmm:
-        if not found_openmm_61_or_later:
-            msg = [bar, '[Unmet Dependency] YANK requires OpenMM version 6.1 or later. You have version %s.' % openmm_version, bar]
-    else:
-        msg = [bar, '[Unmet Dependency] YANK requires the OpenMM python package. Refer to <http://openmm.org> for details and installation instructions.', bar]
-
-    if not found_numpy:
-        msg = [bar, '[Unmet Dependency] YANK requires the numpy python package. Refer to <http://www.scipy.org/scipylib/download.html> for numpy installation instructions.', bar]
-
-    if msg is not None:
-        import textwrap
-        print()
-        print(os.linesep.join([line for e in msg for line in textwrap.wrap(e)]), file=sys.stderr)
-        #print('\n'.join(list(textwrap.wrap(e) for e in msg)))
 
 ################################################################################
 # SETUP
@@ -179,4 +144,4 @@ setup(
     ext_modules=cythonize(mixing_ext),
     entry_points={'console_scripts': ['yank = yank.cli:main']})
 
-check_dependencies()
+


### PR DESCRIPTION
Removed the `check_dependencies` function and the call to it to address #93 