### PR TITLE
Updated conda recipe to install examples

### DIFF
--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -4,6 +4,6 @@ cp -r $RECIPE_DIR/../.. $SRC_DIR
 $PYTHON setup.py clean
 $PYTHON setup.py install
 
-# Eventually we want to push examples to some place like ~/anaconda/share/yank/examples/
+# Push examples to anaconda/share/yank/examples/
 mkdir $PREFIX/share/yank
 cp -r $RECIPE_DIR/../../examples $PREFIX/share/yank/

--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py clean
 $PYTHON setup.py install
 
 # Eventually we want to push examples to some place like ~/anaconda/share/yank/examples/
-#mkdir $PREFIX/share/yank/
-#cp -r $RECIPE_DIR/../../examples/ $PREFIX/share/yank/
+mkdir $PREFIX/share/yank
+cp -r $RECIPE_DIR/../../examples $PREFIX/share/yank/

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -2,6 +2,10 @@ package:
   name: yank-dev
   version: !!str 0.0.0
 
+#source:
+#    git_url: https://github.com/choderalab/yank.git
+#    git_tag: 0.6.1
+
 build:
   preserve_egg_dir: True
   number: 0

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -2,10 +2,6 @@ package:
   name: yank-dev
   version: !!str 0.0.0
 
-#source:
-#    git_url: https://github.com/choderalab/yank.git
-#    git_tag: 0.6.1
-
 build:
   preserve_egg_dir: True
   number: 0


### PR DESCRIPTION
This change to the conda dev package installs the examples in `anaconda/share/yank/examples/`, which is the most logical place for them to go.

I'll also update the `omnia` package recipe.