### PR TITLE
[WIP] Use logging to control verbosity

### DIFF
--- a/Yank/alchemy.py
+++ b/Yank/alchemy.py
@@ -42,9 +42,6 @@ import simtk.unit as unit
 import logging
 logger = logging.getLogger(__name__)
 
-# DEBUG
-logging.basicConfig(level=logging.DEBUG)
-
 #=============================================================================================
 # PARAMETERS
 #=============================================================================================

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -427,9 +427,6 @@ def analyze(source_directory, verbose=False):
        If True, verbose output will be generated.
 
     """
-    # Turn on debug info.
-    # TODO: Control verbosity of logging output using verbose optional flag.
-    logging.basicConfig(level=logging.DEBUG)
 
     # Storage for different phases.
     data = dict()

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -81,20 +81,22 @@ def show_mixing_statistics(ncfile, cutoff=0.05, nequil=0):
             Tij[istate,istate] = 1.0
 
     # Print observed transition probabilities.
-    print "Cumulative symmetrized state mixing transition matrix:"
-    print "%6s" % "",
+    logger.info("Cumulative symmetrized state mixing transition matrix:")
+    str_row = "%6s" % ""
     for jstate in range(nstates):
-        print "%6d" % jstate,
-    print ""
+        str_row += "%6d" % jstate
+    logger.info(str_row)
+
+    str_row = ""
     for istate in range(nstates):
-        print "%-6d" % istate,
+        str_row += "%-6d" % istate
         for jstate in range(nstates):
             P = Tij[istate,jstate]
             if (P >= cutoff):
-                print "%6.3f" % P,
+                str_row += "%6.3f" % P
             else:
-                print "%6s" % "",
-        print ""
+                str_row += "%6s" % ""
+        logger.info(str_row)
 
     # Estimate second eigenvalue and equilibration time.
     mu = np.linalg.eigvals(Tij)
@@ -199,17 +201,19 @@ def estimate_free_energies(ncfile, ndiscard=0, nuse=None, g=None):
 #    # Matrix of free energy differences
     logger.info("Deltaf_ij:")
     for i in range(nstates):
+        str_row = ""
         for j in range(nstates):
-            print "%8.3f" % Deltaf_ij[i,j],
-        print ""
+            str_row += "%8.3f" % Deltaf_ij[i, j]
+        logger.info(str_row)
 
 #    print Deltaf_ij
 #    # Matrix of uncertainties in free energy difference (expectations standard deviations of the estimator about the true free energy)
     logger.info("dDeltaf_ij:")
     for i in range(nstates):
+        str_row = ""
         for j in range(nstates):
-            print "%8.3f" % dDeltaf_ij[i,j],
-        print ""
+            str_row += "%8.3f" % dDeltaf_ij[i, j]
+        logger.info(str_row)
 
     # Return free energy differences and an estimate of the covariance.
     return (Deltaf_ij, dDeltaf_ij)
@@ -359,7 +363,7 @@ def extract_u_n(ncfile):
 # SHOW STATUS OF STORE FILES
 #=============================================================================================
 
-def print_status(store_directory, verbose=False):
+def print_status(store_directory):
     """
     Print a quick summary of simulation progress.
 
@@ -367,7 +371,6 @@ def print_status(store_directory, verbose=False):
     ----------
     store_directory : string
        The location of the NetCDF simulation output files.
-    verbose : bool, optional, default=False
 
     Returns
     -------
@@ -385,12 +388,12 @@ def print_status(store_directory, verbose=False):
         # Check that the file exists.
         if (not os.path.exists(fullpath)):
             # Report failure.
-            print "File %s not found." % fullpath
-            print "Check to make sure the right directory was specified, and 'yank setup' has been run."
+            logger.info("File %s not found." % fullpath)
+            logger.info("Check to make sure the right directory was specified, and 'yank setup' has been run.")
             return False
 
         # Open NetCDF file for reading.
-        if verbose: print "Opening NetCDF trajectory file '%(fullpath)s' for reading..." % vars()
+        logger.debug("Opening NetCDF trajectory file '%(fullpath)s' for reading..." % vars())
         ncfile = netcdf.Dataset(fullpath, 'r')
 
         # Read dimensions.
@@ -399,10 +402,10 @@ def print_status(store_directory, verbose=False):
         natoms = ncfile.variables['positions'].shape[2]
 
         # Print summary.
-        print "%s" % phase
-        print "  %8d iterations completed" % niterations
-        print "  %8d alchemical states" % nstates
-        print "  %8d atoms" % natoms
+        logger.info("%s" % phase)
+        logger.info("  %8d iterations completed" % niterations)
+        logger.info("  %8d alchemical states" % nstates)
+        logger.info("  %8d atoms" % natoms)
 
         # TODO: Print average ns/day and estimated completion time.
 
@@ -415,7 +418,7 @@ def print_status(store_directory, verbose=False):
 # ANALYZE STORE FILES
 #=============================================================================================
 
-def analyze(source_directory, verbose=False):
+def analyze(source_directory):
     """
     Analyze contents of store files to compute free energy differences.
 
@@ -423,8 +426,6 @@ def analyze(source_directory, verbose=False):
     ----------
     source_directory : string
        The location of the NetCDF simulation storage files.
-    verbose : bool, optional, default=False
-       If True, verbose output will be generated.
 
     """
 
@@ -442,7 +443,7 @@ def analyze(source_directory, verbose=False):
         for suffix in suffixes:
             # Construct full path to NetCDF file.
             fullpath = os.path.join(source_directory, '%s-%s.nc' % (phase, suffix))
-            if verbose: print "Attempting to open %s..." % fullpath
+            logger.debug("Attempting to open %s..." % fullpath)
 
             # Skip if the file doesn't exist.
             if (not os.path.exists(fullpath)): continue
@@ -452,7 +453,7 @@ def analyze(source_directory, verbose=False):
             try:
                 ncfile = netcdf.Dataset(fullpath, 'r')
             except Exception as e:
-                print str(e)
+                logger.error(e.message)
                 raise Exception("Error opening NetCDF trajectory file '%(fullpath)s' for reading..." % vars())
 
             # DEBUG

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -21,7 +21,6 @@ from yank import utils
 
 def dispatch(args):
     from yank import analyze
-    verbose = args['--verbose']
-    utils.config_root_logger(verbose)
-    analyze.analyze(args['--store'], verbose=verbose)
+    utils.config_root_logger(args['--verbose'])
+    analyze.analyze(args['--store'])
     return True

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -13,6 +13,7 @@ Analyze YANK output file.
 # MODULE IMPORTS
 #=============================================================================================
 
+from yank import utils
 
 #=============================================================================================
 # COMMAND DISPATCH
@@ -20,5 +21,7 @@ Analyze YANK output file.
 
 def dispatch(args):
     from yank import analyze
-    analyze.analyze(args['--store'], verbose=args['--verbose'])
+    verbose = args['--verbose']
+    utils.config_root_logger(verbose)
+    analyze.analyze(args['--store'], verbose=verbose)
     return True

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -19,6 +19,7 @@ from simtk import openmm
 from simtk import unit
 from simtk.openmm import app
 
+from yank import utils
 from yank.yank import Yank # TODO: Fix this weird import path to something more sane, like 'from yank import Yank'
 from yank.repex import ThermodynamicState # TODO: Fix this weird import path to something more sane, like 'from yank.repex import ThermodynamicState'
 
@@ -269,6 +270,8 @@ def dispatch_binding(args):
     """
 
     verbose = args['--verbose']
+    store_dir = args['--store']
+    utils.config_root_logger(verbose, log_file_path=os.path.join(store_dir, 'prepare.log'))
 
     #
     # Determine simulation options.
@@ -302,7 +305,7 @@ def dispatch_binding(args):
             print "  solvent and ions : %9d" % len(atom_indices[phase]['solvent'])
 
     # Initialize YANK object.
-    yank = Yank(args['--store'], verbose=verbose)
+    yank = Yank(store_dir, verbose=verbose)
 
     # Set options.
     options = dict()

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -307,7 +307,7 @@ def dispatch_binding(args):
             logger.info("solvent and ions : %9d" % len(atom_indices[phase]['solvent']))
 
     # Initialize YANK object.
-    yank = Yank(store_dir, verbose=verbose)
+    yank = Yank(store_dir)
 
     # Set options.
     options = dict()

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -10,10 +10,12 @@ Set up YANK calculations.
 """
 
 #=============================================================================================
-# MODULE IMPORTS
+# GLOBAL IMPORTS
 #=============================================================================================
 
 import os, os.path
+import logging
+logger = logging.getLogger(__name__)
 
 from simtk import openmm
 from simtk import unit
@@ -192,14 +194,14 @@ def setup_binding_amber(args):
     atom_indices = dict() # ligand_atoms[phase] is a list of ligand atom indices associated with phase 'phase'
     setup_directory = args['--setupdir'] # Directory where prmtop/inpcrd files are to be found
     for phase_prefix in phase_prefixes:
-        if verbose: print "reading phase %s: " % phase_prefix
+        if verbose: logger.info("reading phase %s: " % phase_prefix)
         # Read Amber prmtop and create System object.
         prmtop_filename = os.path.join(setup_directory, '%s.prmtop' % phase_prefix)
-        if verbose: print "  prmtop: %s" % prmtop_filename
+        if verbose: logger.info("prmtop: %s" % prmtop_filename)
         prmtop = app.AmberPrmtopFile(prmtop_filename)
         # Read Amber inpcrd and load positions.
         inpcrd_filename = os.path.join(setup_directory, '%s.inpcrd' % phase_prefix)
-        if verbose: print "  inpcrd: %s" % inpcrd_filename
+        if verbose: logger.info("inpcrd: %s" % inpcrd_filename)
         inpcrd = app.AmberInpcrdFile(inpcrd_filename)
         # Determine if this will be an explicit or implicit solvent simulation.
         phase_suffix = 'implicit'
@@ -288,7 +290,7 @@ def dispatch_binding(args):
     elif args['systembuilder']:
         [phases, systems, positions, atom_indices] = setup_binding_systembuilder(args)
     else:
-        print "No valid binding free energy calculation setup command specified: Must be one of ['amber', 'systembuilder']."
+        logger.error("No valid binding free energy calculation setup command specified: Must be one of ['amber', 'systembuilder'].")
         # Trigger help argument to be returned.
         return False
 
@@ -298,11 +300,11 @@ def dispatch_binding(args):
             phase = 'complex-explicit'
         else:
             phase = 'complex-implicit'
-        print "  TOTAL ATOMS      : %9d" % len(atom_indices[phase]['complex'])
-        print "  receptor         : %9d" % len(atom_indices[phase]['receptor'])
-        print "  ligand           : %9d" % len(atom_indices[phase]['ligand'])
+        logger.info("TOTAL ATOMS      : %9d" % len(atom_indices[phase]['complex']))
+        logger.info("receptor         : %9d" % len(atom_indices[phase]['receptor']))
+        logger.info("ligand           : %9d" % len(atom_indices[phase]['ligand']))
         if phase == 'complex-explicit':
-            print "  solvent and ions : %9d" % len(atom_indices[phase]['solvent'])
+            logger.info("solvent and ions : %9d" % len(atom_indices[phase]['solvent']))
 
     # Initialize YANK object.
     yank = Yank(store_dir, verbose=verbose)

--- a/Yank/commands/run.py
+++ b/Yank/commands/run.py
@@ -14,6 +14,9 @@ Run a YANK calculation.
 #=============================================================================================
 
 import os
+import logging
+logger = logging.getLogger(__name__)
+
 from simtk import openmm
 from simtk import unit
 from simtk.openmm import app
@@ -57,11 +60,8 @@ def dispatch(args):
         # Initialize MPI.
         from mpi4py import MPI
         hostname = os.uname()[1]
-        if not MPI.COMM_WORLD.rank == 0:
-            yank.verbose = False
-            utils.config_root_logger(False, overwrite=True)
         MPI.COMM_WORLD.barrier()
-        if MPI.COMM_WORLD.rank == 0: print "Initialized MPI on %d processes." % (MPI.COMM_WORLD.size)
+        logger.info("Initialized MPI on %d processes." % (MPI.COMM_WORLD.size))
         mpicomm = MPI
 
     # Run simulation.

--- a/Yank/commands/run.py
+++ b/Yank/commands/run.py
@@ -18,6 +18,8 @@ from simtk import openmm
 from simtk import unit
 from simtk.openmm import app
 
+from yank import utils
+
 #=============================================================================================
 # COMMAND DISPATCH
 #=============================================================================================
@@ -40,6 +42,10 @@ def dispatch(args):
     if args['--platform'] not in [None, 'None']:
         options['platform'] = openmm.Platform.getPlatformByName(args['--platform'])
 
+    # Configure logger
+    utils.config_root_logger(options['verbose'],
+                             log_file_path=os.path.join(store_directory, 'run.log'))
+
     # Set YANK to resume from the store file.
     phases = None # By default, resume from all phases found in store_directory
     if args['--phase']: phases=[args['--phase']]
@@ -53,6 +59,7 @@ def dispatch(args):
         hostname = os.uname()[1]
         if not MPI.COMM_WORLD.rank == 0:
             yank.verbose = False
+            utils.config_root_logger(False, overwrite=True)
         MPI.COMM_WORLD.barrier()
         if MPI.COMM_WORLD.rank == 0: print "Initialized MPI on %d processes." % (MPI.COMM_WORLD.size)
         mpicomm = MPI

--- a/Yank/commands/selftest.py
+++ b/Yank/commands/selftest.py
@@ -17,6 +17,8 @@ import doctest
 import pkgutil
 import sys
 
+from yank import utils
+
 #=============================================================================================
 # COMMAND DISPATCH
 #=============================================================================================
@@ -26,6 +28,7 @@ def dispatch(args):
 
     print "Running doctests for all modules..."
     verbose = args['--verbose']
+    utils.config_root_logger(verbose)
     # Run tests on main module.
     import yank
     (failure_count, test_count) = doctest.testmod(yank, verbose=verbose)

--- a/Yank/commands/selftest.py
+++ b/Yank/commands/selftest.py
@@ -28,7 +28,6 @@ def dispatch(args):
 
     print "Running doctests for all modules..."
     verbose = args['--verbose']
-    utils.config_root_logger(verbose)
     # Run tests on main module.
     import yank
     (failure_count, test_count) = doctest.testmod(yank, verbose=verbose)

--- a/Yank/commands/status.py
+++ b/Yank/commands/status.py
@@ -13,11 +13,14 @@ Query output files for quick status.
 # MODULE IMPORTS
 #=============================================================================================
 
+from yank import utils
+
 #=============================================================================================
 # COMMAND DISPATCH
 #=============================================================================================
 
 def dispatch(args):
     from yank import analyze
-    success = analyze.print_status(args['--store'], verbose=args['--verbose'])
+    utils.config_root_logger(args['--verbose'])
+    success = analyze.print_status(args['--store'])
     return success

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -73,6 +73,8 @@ from simtk import openmm
 from simtk import unit
 import netCDF4 as netcdf
 
+from utils import is_terminal_verbose
+
 #=============================================================================================
 # MODULE CONSTANTS
 #=============================================================================================
@@ -1026,7 +1028,7 @@ class ReplicaExchange(object):
             logger.debug("Initialized node %d / %d" % (self.mpicomm.rank, self.mpicomm.size))
 
         # Display papers to be cited.
-        if logger.isEnabledFor(logging.DEBUG):
+        if is_terminal_verbose():
             self._display_citations()
 
         # Determine number of alchemical states.
@@ -1096,7 +1098,7 @@ class ReplicaExchange(object):
             logger.debug("Initialized node %d / %d" % (self.mpicomm.rank, self.mpicomm.size))
 
         # Display papers to be cited.
-        if logger.isEnabledFor(logging.DEBUG):
+        if is_terminal_verbose():
             self._display_citations()
 
         # Determine number of alchemical states.

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -968,7 +968,7 @@ class ReplicaExchange(object):
                 self._analysis()
 
             # Show timing statistics if debug level is activated
-            if logger.level <= logging.DEBUG:
+            if logger.isEnabledFor(logging.DEBUG):
                 final_time = time.time()
                 elapsed_time = final_time - initial_time
                 estimated_time_remaining = (final_time - run_start_time) / (self.iteration - run_start_iteration) * (self.number_of_iterations - self.iteration)
@@ -1026,7 +1026,7 @@ class ReplicaExchange(object):
             logger.debug("Initialized node %d / %d" % (self.mpicomm.rank, self.mpicomm.size))
 
         # Display papers to be cited.
-        if logger.level <= logging.DEBUG:
+        if logger.isEnabledFor(logging.DEBUG):
             self._display_citations()
 
         # Determine number of alchemical states.
@@ -1096,7 +1096,7 @@ class ReplicaExchange(object):
             logger.debug("Initialized node %d / %d" % (self.mpicomm.rank, self.mpicomm.size))
 
         # Display papers to be cited.
-        if logger.level <= logging.DEBUG:
+        if logger.isEnabledFor(logging.DEBUG):
             self._display_citations()
 
         # Determine number of alchemical states.
@@ -1363,7 +1363,7 @@ class ReplicaExchange(object):
         elapsed_time = end_time - start_time
         # Collect elapsed time.
         node_elapsed_times = self.mpicomm.gather(elapsed_time, root=0) # barrier
-        if logger.level <= logging.DEBUG:
+        if logger.isEnabledFor(logging.DEBUG):
             node_elapsed_times = np.array(node_elapsed_times)
             end_time = time.time()
             elapsed_time = end_time - start_time
@@ -1775,7 +1775,7 @@ class ReplicaExchange(object):
 
         if self.iteration < 2:
             return
-        if logger.level > logging.DEBUG:
+        if not logger.isEnabledFor(logging.DEBUG):
             return
 
         Tij = self._accumulate_mixing_statistics()
@@ -2252,7 +2252,7 @@ class ReplicaExchange(object):
 
         """
 
-        if logger.level > logging.DEBUG:
+        if not logger.isEnabledFor(logging.DEBUG):
             return
 
         # print header
@@ -2414,7 +2414,7 @@ class ReplicaExchange(object):
             return str_row
 
         # Print estimate
-        if logger.level <= logging.DEBUG:
+        if logger.isEnabledFor(logging.DEBUG):
             logger.debug("================================================================================")
             logger.debug("Online analysis estimate of free energies:")
             logger.debug("  equilibration end: %d iterations" % t0)
@@ -2434,7 +2434,6 @@ class ReplicaExchange(object):
             logger.debug("dDelta_s_ij")
             logger.debug(matrix2str(dDelta_s_ij))
             logger.debug("================================================================================")
-
 
         self.analysis = analysis
 

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -538,7 +538,7 @@ class FlatBottomReceptorLigandRestraint(ReceptorLigandRestraint):
             r0 = 2*sigma + 5.0 * units.angstroms
         else:
             DEFAULT_DISTANCE = 15.0 * units.angstroms
-            print "WARNING: receptor only contains %d atoms; using default distance of %s" % (natoms, str(DEFAULT_DISTANCE))
+            logger.warning("Receptor only contains %d atoms; using default distance of %s" % (natoms, str(DEFAULT_DISTANCE)))
             r0 = DEFAULT_DISTANCE
 
         logger.debug("restraint distance r0 = %.1f A" % (r0 / units.angstroms))

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -18,6 +18,8 @@ import os.path
 import sys
 import copy
 import time
+import logging
+logger = logging.getLogger(__name__)
 
 import numpy
 import numpy.random
@@ -381,9 +383,8 @@ class ModifiedHamiltonianExchange(HamiltonianExchange):
                 from mpi4py import MPI
                 self.displacement_trials_accepted = self.mpicomm.reduce(self.displacement_trials_accepted, op=MPI.SUM)
                 self.rotation_trials_accepted = self.mpicomm.reduce(self.rotation_trials_accepted, op=MPI.SUM)
-            if self.verbose:
-                total_mc_time = self.displacement_trial_time + self.rotation_trial_time
-                print "Rotation and displacement MC trial times consumed %.3f s (%d translation | %d rotation accepted)" % (total_mc_time, self.displacement_trials_accepted, self.rotation_trials_accepted)
+            total_mc_time = self.displacement_trial_time + self.rotation_trial_time
+            logger.debug("Rotation and displacement MC trial times consumed %.3f s (%d translation | %d rotation accepted)" % (total_mc_time, self.displacement_trials_accepted, self.rotation_trials_accepted))
 
         return
 

--- a/Yank/tests/test_alchemy.py
+++ b/Yank/tests/test_alchemy.py
@@ -447,7 +447,7 @@ def lambda_trace(reference_system, positions, receptor_atoms, ligand_atoms, plat
         alchemical_system = factory.createPerturbedSystem(AlchemicalState(0, lambda_value, lambda_value, lambda_value))
         lambda_i[i] = lambda_value
         u_i[i] = compute_potential(alchemical_system, positions, platform)
-        print "%12.9f %24.8f kcal/mol" % (lambda_i[i], u_i[i] / units.kilocalories_per_mole)
+        logger.info("%12.9f %24.8f kcal/mol" % (lambda_i[i], u_i[i] / units.kilocalories_per_mole))
 
     # Write figure as PDF.
     import pylab

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -26,6 +26,12 @@ def config_root_logger(verbose, log_file_path=None, overwrite=False):
      to print logging.INFO messages, and stderr for the others. The root logger's
      configuration is inherited by the loggers created by logging.getLogger(name).
 
+     Different formats are used to display messages on the terminal and on the log
+     file. For example, in the log file every entry has a timestamp which does not
+     appear in the terminal. Moreover, the log file always shows the module that
+     generate the message, while in the terminal this happens only for messages
+     of level WARNING and higher.
+
      In order to overwrite the root logger's configuration overwrite must be True
      or an Exception will be raised. This helps to control if parts of the code
      attempt to modify the user's configuration.
@@ -33,7 +39,7 @@ def config_root_logger(verbose, log_file_path=None, overwrite=False):
     Parameters
     ----------
     verbose : bool
-        Control the verbosity of the messages printed on stdout. The logger
+        Control the verbosity of the messages printed in the terminal. The logger
         displays messages of level logging.INFO and higher when verbose=False.
         Otherwise those of level logging.DEBUG and higher are printed.
     log_file_path : str, optional, default = None
@@ -52,18 +58,22 @@ def config_root_logger(verbose, log_file_path=None, overwrite=False):
 
     class TerminalFormatter(logging.Formatter):
         """
-        Simplified format for INFO level log messages.
+        Simplified format for INFO and DEBUG level log messages.
 
+        This allows to keep the logging.info() and debug() format separated from
+        the other levels where more information may be needed. For example, for
+        warning and error messages it is convenient to know also the module that
+        generates them.
         """
 
         # This is the cleanest way I found to make the code compatible with both
         # Python 2 and Python 3
-        info_fmt = logging.Formatter('%(message)s')
+        simple_fmt = logging.Formatter('%(message)s')
         default_fmt = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 
         def format(self, record):
-            if record.levelno == logging.INFO:
-                return self.info_fmt.format(record)
+            if record.levelno <= logging.INFO:
+                return self.simple_fmt.format(record)
             else:
                 return self.default_fmt.format(record)
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -55,15 +55,17 @@ def config_root_logger(verbose, log_file_path=None, overwrite=False):
             raise OverwriteLogException('Attempted to overwrite logging configuration.')
 
     # Configure verbosity of stdout and stderr messages
+    log_format = '%(name)s - %(levelname)s - %(message)s'
     if verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG, format=log_format)
     else:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.INFO, format=log_format)
 
     # Add file handler to root logger
     if log_file_path is not None:
         file_handler = logging.FileHandler(log_file_path)
         file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - ' + log_format))
         logging.getLogger().addHandler(file_handler)
 
 def get_data_filename(relative_path):

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1,5 +1,71 @@
-from pkg_resources import resource_filename
 import os
+import sys
+import logging
+
+from pkg_resources import resource_filename
+
+#========================================================================================
+# Exceptions
+#========================================================================================
+
+class OverwriteLogException(Exception):
+    """
+    Exception denoting an attempt to overwrite logging's configuration.
+
+    """
+    pass
+
+#========================================================================================
+# Utility functions
+#========================================================================================
+
+def config_root_logger(verbose, log_file_path=None, overwrite=False):
+    """Setup the the root logger's configuration.
+
+     The log messages are saved in the file specified by log_file_path (if not
+     None) and printed. Note that logging use sys.stdout to print logging.INFO
+     messages, and stderr for the others. The root logger's configuration is
+     inherited by the others module loggers created by logging.getLogger(name).
+
+     In order to overwrite the root logger's configuration one must set
+     overwrite=True or an Exception will be raised. This helps to control if
+     parts of the code attempt to modify the user's configuration.
+
+    Parameters
+    ----------
+    verbose : bool
+        Control the verbosity of the messages printed on stdout. The logger
+        displays messages of level logging.INFO and higher when verbose=False.
+        Otherwise those of level logging.DEBUG and higher are printed.
+    log_file_path : str, optional, default = None
+        If not None, this is the path where all the logger's messages of level
+        logging.DEBUG or higher are saved.
+    overwrite : bool, optional, default = False
+        Set to True to force overwriting an eventual existing configuration. An
+        attempt to do so when overwrite=False raises an Exception.
+
+    """
+    # Check if root logger is already configured
+    n_handlers = len(logging.getLogger().handlers)
+    if n_handlers > 0:
+        if overwrite:
+            root_logger = logging.getLogger()
+            for i in xrange(n_handlers):
+                root_logger.removeHandler(root_logger.handlers[0])
+        else:
+            raise OverwriteLogException('Attempted to overwrite logging configuration.')
+
+    # Configure verbosity of stdout and stderr messages
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    # Add file handler to root logger
+    if log_file_path is not None:
+        file_handler = logging.FileHandler(log_file_path)
+        file_handler.setLevel(logging.DEBUG)
+        logging.getLogger().addHandler(file_handler)
 
 def get_data_filename(relative_path):
     """Get the full path to one of the reference files shipped for testing

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import logging
 
 from pkg_resources import resource_filename

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -33,7 +33,9 @@ def is_terminal_verbose():
     is_verbose = False
 
     for handler in logging.root.handlers:
-        if issubclass(handler, logging.StreamHandler):
+        # logging.FileHandler is a subclass of logging.StreamHandler so
+        # isinstance and issubclass do not work in this case
+        if type(handler) is logging.StreamHandler and handler.level <= logging.DEBUG:
             is_verbose = True
             break
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -18,6 +18,27 @@ class OverwriteLogException(Exception):
 # Utility functions
 #========================================================================================
 
+def is_terminal_verbose():
+    """Check whether the logging on the terminal is configured to be verbose.
+
+    This is useful in case one wants to occasionally print something that is not really
+    relevant to yank's log (e.g. external library verbose, citations, etc.).
+
+    Returns
+    is_verbose : bool
+        True if the terminal is configured to be verbose, False otherwise.
+    """
+
+    # If logging.root has no handlers this will ensure that False is returned
+    is_verbose = False
+
+    for handler in logging.root.handlers:
+        if issubclass(handler, logging.StreamHandler):
+            is_verbose = True
+            break
+
+    return is_verbose
+
 def config_root_logger(verbose, log_file_path=None, overwrite=False):
     """Setup the the root logger's configuration.
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -49,7 +49,7 @@ class Yank(object):
 
     """
 
-    def __init__(self, store_directory, verbose=False):
+    def __init__(self, store_directory):
         """
         Initialize YANK object with default parameters.
 
@@ -57,8 +57,6 @@ class Yank(object):
         ----------
         store_directory : str
            The storage directory in which output NetCDF files are read or written.
-        verbose : bool, optional, default=False
-           If True, will turn on verbose output.
 
         """
 
@@ -69,7 +67,6 @@ class Yank(object):
         self._store_directory = store_directory
 
         # Public attributes.
-        self.verbose = verbose
         self.restraint_type = 'flat-bottom' # default to a flat-bottom restraint between the ligand and receptor
         self.randomize_ligand = True
         self.randomize_ligand_sigma_multiplier = 2.0
@@ -92,7 +89,7 @@ class Yank(object):
         self.default_options = dict()
         self.default_options['number_of_equilibration_iterations'] = 0
         self.default_options['number_of_iterations'] = 100
-        self.default_options['verbose'] = self.verbose
+        self.default_options['number_of_iterations'] = 100
         self.default_options['timestep'] = 2.0 * unit.femtoseconds
         self.default_options['collision_rate'] = 5.0 / unit.picoseconds
         self.default_options['minimize'] = False
@@ -138,8 +135,6 @@ class Yank(object):
         phases : list of str, optional, default=None
            The list of calculation phases (e.g. ['solvent', 'complex']) to resume.
            If not specified, all simulations in the store_directory will be resumed.
-        verbose : bool, optional, default=True
-           If True, will give verbose output
 
         """
         # If no phases specified, construct a list of phases from the filename prefixes in the store directory.
@@ -185,8 +180,6 @@ class Yank(object):
            If specified, the alchemical protocol protocols[phase] will be used for phase 'phase' instead of the default.
         options : dict of str, optional, default=None
            If specified, these options will override default repex simulation options.
-        verbose : bool, optional, default=True
-           If True, will give verbose output
 
         """
 
@@ -350,7 +343,6 @@ class Yank(object):
         simulation.create(thermodynamic_state, systems, positions,
                           displacement_sigma=self.mc_displacement_sigma, mc_atoms=mc_atoms,
                           options=options, metadata=metadata)
-        simulation.verbose = self.verbose
 
         # Initialize simulation.
         # TODO: Use the right scheme for initializing the simulation without running.
@@ -386,10 +378,6 @@ class Yank(object):
 
         # Handle some logistics necessary for MPI.
         if mpicomm:
-            # Turn off output from non-root nodes:
-            if not (mpicomm.rank==0):
-                self.verbose = False
-
             # Make sure each thread's random number generators have unique seeds.
             # TODO: Do we need to store seed in repex object?
             seed = np.random.randint(sys.maxint - mpicomm.size) + mpicomm.rank


### PR DESCRIPTION
#3 

I added a function in yank.utils that can be used to easily configure the root logger. This function is called in the different dispatch() functions in yank.commands to make the logging command-based. Commands "run" and "prepare" save the log files "run.log" and "prepare.log" in the store folder, the other commands don't save any file.

I'm not sure how to handle the mpi case so this doesn't completely fix the issue. Right now, when the "--mpi" argument is used the logging level is set to logging.INFO and the file is not saved.

I also plan to substitute all the print() functions (at least the ones called during the commands run and prepare) with logger.info() calls. Otherwise those won't be included in the log file.