### PR TITLE
Fix table printing in analyze, handle periodic box and implicit solvent.

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -87,8 +87,8 @@ def show_mixing_statistics(ncfile, cutoff=0.05, nequil=0):
         str_row += "%6d" % jstate
     logger.info(str_row)
 
-    str_row = ""
     for istate in range(nstates):
+        str_row = ""
         str_row += "%-6d" % istate
         for jstate in range(nstates):
             P = Tij[istate,jstate]

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -209,6 +209,9 @@ def setup_binding_amber(args):
         if inpcrd.boxVectors is not None:
             is_periodic = True
             phase_suffix = 'explicit'
+        # Check if both periodic box and implicit solvent are defined
+        if is_periodic and implicitSolvent is not None:
+            logger.warning('Detected both a periodic box and an implicit solvent.')
         # Adjust nonbondedMethod.
         # TODO: Ensure that selected method is appropriate.
         if nonbondedMethod == None:


### PR DESCRIPTION
This fix the state mixing transition matrix that got broken with pull request 249.

Also warn the user when both a periodic box and implicit solvent are detected. Should we just throw an error and abort the preparation? Are there cases in which one needs both?