### PR TITLE
[WIP] Use MDTraj DSL to specify ligand atoms.

### DIFF
--- a/Yank/cli.py
+++ b/Yank/cli.py
@@ -27,7 +27,7 @@ Usage:
   yank [-h | --help] [-c | --cite]
   yank selftest [-v | --verbose]
   yank platforms
-  yank prepare binding amber --setupdir=DIRECTORY --ligname=RESNAME (-s=STORE | --store=STORE) [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [--minimize] [-v | --verbose]
+  yank prepare binding amber --setupdir=DIRECTORY --ligdsl=LIGANDDSL (-s=STORE | --store=STORE) [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [--minimize] [-v | --verbose]
   yank prepare binding systembuilder --ligand=FILENAME --receptor=FILENAME [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [-v | --verbose]
   yank run (-s=STORE | --store=STORE) [-m | --mpi] [-i=NITER | --iterations=NITER] [--platform=PLATFORM] [--phase=PHASE] [-o | --online-analysis] [-v | --verbose]
   yank status (-s=STORE | --store=STORE) [-v | --verbose]
@@ -67,7 +67,7 @@ Simulation options:
 
 Amber options:
   --setupdir=DIRECTORY          Setup directory to look for AMBER {receptor|ligand|complex}.{prmtop|inpcrd} files.
-  --ligname=RESNAME             Residue name of ligand [default: MOL]
+  --ligdsl=LIGANDDSL            Specification of the ligand atoms according to MDTraj DSL syntax [default: "resname MOL"]
 
 Systembuilder options:
   --ligand=FILENAME             Ligand filename (formats: mol2, sdf, pdb, smi, iupac, cdx)

--- a/Yank/cli.py
+++ b/Yank/cli.py
@@ -27,8 +27,7 @@ Usage:
   yank [-h | --help] [-c | --cite]
   yank selftest [-v | --verbose]
   yank platforms
-  yank prepare binding amber --setupdir=DIRECTORY --ligdsl=LIGANDDSL (-s=STORE | --store=STORE) [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [--minimize] [-v | --verbose]
-  yank prepare binding systembuilder --ligand=FILENAME --receptor=FILENAME [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [-v | --verbose]
+  yank prepare binding amber --setupdir=DIRECTORY --ligand=DSLSTRING (-s=STORE | --store=STORE) [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [--minimize] [-v | --verbose]
   yank run (-s=STORE | --store=STORE) [-m | --mpi] [-i=NITER | --iterations=NITER] [--platform=PLATFORM] [--phase=PHASE] [-o | --online-analysis] [-v | --verbose]
   yank status (-s=STORE | --store=STORE) [-v | --verbose]
   yank analyze (-s STORE | --store=STORE) [-v | --verbose]
@@ -67,11 +66,7 @@ Simulation options:
 
 Amber options:
   --setupdir=DIRECTORY          Setup directory to look for AMBER {receptor|ligand|complex}.{prmtop|inpcrd} files.
-  --ligdsl=LIGANDDSL            Specification of the ligand atoms according to MDTraj DSL syntax [default: "resname MOL"]
-
-Systembuilder options:
-  --ligand=FILENAME             Ligand filename (formats: mol2, sdf, pdb, smi, iupac, cdx)
-  --receptor=FILENAME           Receptor filename (formats: mol2, sdf, pdb, smi, iupac, cdx)
+  --ligand=DSLSTRING            Specification of the ligand atoms according to MDTraj DSL syntax [default: "resname MOL"]
 
 """
 

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -246,7 +246,7 @@ def setup_binding_amber(args):
             raise Exception("Atom number mismatch: prmtop %s has %d atoms; inpcrd %s has %d atoms." % (prmtop_filename, prmtop_natoms, inpcrd_filename, inpcrd_natoms))
 
         # Find ligand atoms and receptor atoms.
-        ligand_dsl = args['--ligdsl'] # MDTraj DSL that specifies ligand atoms
+        ligand_dsl = args['--ligand'] # MDTraj DSL that specifies ligand atoms
         atom_indices[phase] = find_components(prmtop.topology, ligand_dsl)
 
     phases = systems.keys()

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -106,11 +106,11 @@ def find_components(topology, ligand_dsl, solvent_resnames=_SOLVENT_RESNAMES):
 
     # Determine solvent and receptor atoms
     # I did some benchmarking and this is still faster than a single for loop
-    # through all the atoms in topology.atoms
-    atom_indices['solvent'] = [atom.index for atom in topology.atoms
+    # through all the atoms in mdtraj_top.atoms
+    atom_indices['solvent'] = [atom.index for atom in mdtraj_top.atoms
                                if atom.residue.name in solvent_resnames]
     not_receptor_set = frozenset(atom_indices['ligand'] + atom_indices['solvent'])
-    atom_indices['receptor'] = [atom.index for atom in topology.atoms
+    atom_indices['receptor'] = [atom.index for atom in mdtraj_top.atoms
                                 if atom.index not in not_receptor_set]
     atom_indices['complex'] = atom_indices['receptor'] + atom_indices['ligand']
 

--- a/Yank/tests/test_cli.py
+++ b/Yank/tests/test_cli.py
@@ -59,5 +59,5 @@ def test_prepare_binding():
     # NOTE: switched to yank p-xylene from openmmtools T4-lysozyme because of yank bugs.
     dirname = utils.get_data_filename("../examples/p-xylene-implicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
     storedir = tempfile.mkdtemp()
-    run_cli('prepare binding amber --setupdir=%(dirname)s --ligname MOL --store %(storedir)s --gbsa OBC1' % vars())
+    run_cli('prepare binding amber --setupdir=%(dirname)s --ligdsl="resname MOL" --store %(storedir)s --gbsa OBC1' % vars())
     # TODO: Clean up directory.

--- a/Yank/tests/test_cli.py
+++ b/Yank/tests/test_cli.py
@@ -59,5 +59,5 @@ def test_prepare_binding():
     # NOTE: switched to yank p-xylene from openmmtools T4-lysozyme because of yank bugs.
     dirname = utils.get_data_filename("../examples/p-xylene-implicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
     storedir = tempfile.mkdtemp()
-    run_cli('prepare binding amber --setupdir=%(dirname)s --ligdsl="resname MOL" --store %(storedir)s --gbsa OBC1' % vars())
+    run_cli('prepare binding amber --setupdir=%(dirname)s --ligand="resname MOL" --store %(storedir)s --gbsa OBC1' % vars())
     # TODO: Clean up directory.

--- a/Yank/tests/test_prepare.py
+++ b/Yank/tests/test_prepare.py
@@ -30,9 +30,10 @@ from yank import version, utils
 def test_prepare_amber_implicit(verbose=False):
     store_directory = tempfile.mkdtemp()
     examples_path = utils.get_data_filename("../examples/benzene-toluene-implicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
-    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligand="resname BEN" --store=%(store_directory)s --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin' % vars()
+    command = 'yank prepare binding amber --setupdir=%(examples_path)s --store=%(store_directory)s --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin' % vars()
     if verbose: command += ' --verbose'
     argv = command.split()
+    argv.append('--ligand=resname BEN') # if included in the command string it is split in two
     args = docopt(usage, version=version.version, argv=argv[1:])
     from yank.commands import prepare
     prepare.dispatch(args)
@@ -40,9 +41,10 @@ def test_prepare_amber_implicit(verbose=False):
 def test_prepare_amber_explicit(verbose=False):
     store_directory = tempfile.mkdtemp()
     examples_path = utils.get_data_filename("../examples/benzene-toluene-explicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
-    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligand="resname BEN" --store=%(store_directory)s --iterations=1 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres' % vars()
+    command = 'yank prepare binding amber --setupdir=%(examples_path)s --store=%(store_directory)s --iterations=1 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres' % vars()
     if verbose: command += ' --verbose'
     argv = command.split()
+    argv.append('--ligand=resname BEN') # if included in the command string it is split in two
     args = docopt(usage, version=version.version, argv=argv[1:])
     from yank.commands import prepare
     prepare.dispatch(args)

--- a/Yank/tests/test_prepare.py
+++ b/Yank/tests/test_prepare.py
@@ -30,7 +30,7 @@ from yank import version, utils
 def test_prepare_amber_implicit(verbose=False):
     store_directory = tempfile.mkdtemp()
     examples_path = utils.get_data_filename("../examples/benzene-toluene-implicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
-    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligname=BEN --store=%(store_directory)s --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin' % vars()
+    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligdsl="resname BEN" --store=%(store_directory)s --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin' % vars()
     if verbose: command += ' --verbose'
     argv = command.split()
     args = docopt(usage, version=version.version, argv=argv[1:])
@@ -40,7 +40,7 @@ def test_prepare_amber_implicit(verbose=False):
 def test_prepare_amber_explicit(verbose=False):
     store_directory = tempfile.mkdtemp()
     examples_path = utils.get_data_filename("../examples/benzene-toluene-explicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
-    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligname=BEN --store=%(store_directory)s --iterations=1 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres' % vars()
+    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligdsl="resname BEN" --store=%(store_directory)s --iterations=1 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres' % vars()
     if verbose: command += ' --verbose'
     argv = command.split()
     args = docopt(usage, version=version.version, argv=argv[1:])

--- a/Yank/tests/test_prepare.py
+++ b/Yank/tests/test_prepare.py
@@ -30,7 +30,7 @@ from yank import version, utils
 def test_prepare_amber_implicit(verbose=False):
     store_directory = tempfile.mkdtemp()
     examples_path = utils.get_data_filename("../examples/benzene-toluene-implicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
-    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligdsl="resname BEN" --store=%(store_directory)s --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin' % vars()
+    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligand="resname BEN" --store=%(store_directory)s --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin' % vars()
     if verbose: command += ' --verbose'
     argv = command.split()
     args = docopt(usage, version=version.version, argv=argv[1:])
@@ -40,7 +40,7 @@ def test_prepare_amber_implicit(verbose=False):
 def test_prepare_amber_explicit(verbose=False):
     store_directory = tempfile.mkdtemp()
     examples_path = utils.get_data_filename("../examples/benzene-toluene-explicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
-    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligdsl="resname BEN" --store=%(store_directory)s --iterations=1 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres' % vars()
+    command = 'yank prepare binding amber --setupdir=%(examples_path)s --ligand="resname BEN" --store=%(store_directory)s --iterations=1 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres' % vars()
     if verbose: command += ' --verbose'
     argv = command.split()
     args = docopt(usage, version=version.version, argv=argv[1:])

--- a/docs/examples/benzene-toluene-explicit.rst
+++ b/docs/examples/benzene-toluene-explicit.rst
@@ -15,7 +15,7 @@ Reaction field electrostatics (`--nbmethod=CutoffPeriodic`) is used, and the tem
 
 .. code-block:: none
 
-   $ yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres --verbose
+   $ yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres --verbose
 
 Run the simulation in serial mode with verbose output:
 

--- a/docs/examples/benzene-toluene-implicit.rst
+++ b/docs/examples/benzene-toluene-implicit.rst
@@ -15,7 +15,7 @@ The `OBC2` implicit solvent model is used, and the temperature is set to 300 Kel
 
 .. code-block:: none
 
-   $ yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
+   $ yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
 
 Run the simulation in serial mode with verbose output:
 

--- a/docs/examples/p-xylene-explicit.rst
+++ b/docs/examples/p-xylene-explicit.rst
@@ -15,7 +15,7 @@ Reaction field electrostatics (`--nbmethod=CutoffPeriodic`) is used, and the tem
 
 .. code-block:: none
 
-   $ yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres --verbose
+   $ yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmospheres --verbose
 
 Run the simulation in serial mode with verbose output:
 

--- a/docs/examples/p-xylene-implicit.rst
+++ b/docs/examples/p-xylene-implicit.rst
@@ -15,7 +15,7 @@ The `OBC2` implicit solvent model is used, and the temperature is set to 300 Kel
 
 .. code-block:: none
 
-   $ yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
+   $ yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
 
 Run the simulation in serial mode with verbose output:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -21,7 +21,7 @@ Use the `yank prepare` command to set up an alchemical free energy calculation u
 
 .. code-block:: none
 
-   $ yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 \
+   $ yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=1000 \
      --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
 
 Run the simulation in serial mode with:

--- a/examples/abl-imatinib-explicit/run-torque.sh
+++ b/examples/abl-imatinib-explicit/run-torque.sh
@@ -48,7 +48,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=100 --restraints=harmonic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=100 --restraints=harmonic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation via MPI..."

--- a/examples/abl-imatinib-explicit/run.sh
+++ b/examples/abl-imatinib-explicit/run.sh
@@ -18,7 +18,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=100 --restraints=harmonic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=100 --restraints=harmonic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."

--- a/examples/abl-imatinib-implicit/run-torque.sh
+++ b/examples/abl-imatinib-implicit/run-torque.sh
@@ -46,7 +46,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=100 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=100 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --minimize --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."

--- a/examples/abl-imatinib-implicit/run.sh
+++ b/examples/abl-imatinib-implicit/run.sh
@@ -20,7 +20,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --minimize --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."

--- a/examples/benzene-toluene-explicit/README.md
+++ b/examples/benzene-toluene-explicit/README.md
@@ -8,7 +8,7 @@ A harmonic restraint is used to keep the two molecules from drifting far away fr
 
 Set up the simulation to alchemically decouple benzene, putting all the output files in `output/`:
 ```tcsh
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 --restraints=harmonic --temperature="300*kelvin" --pressure=1*atmospheres --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=1000 --restraints=harmonic --temperature="300*kelvin" --pressure=1*atmospheres --minimize --verbose
 ```
 
 Run the simulation with verbose output:

--- a/examples/benzene-toluene-explicit/run.sh
+++ b/examples/benzene-toluene-explicit/run.sh
@@ -19,7 +19,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmospheres" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmospheres" --minimize --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."

--- a/examples/benzene-toluene-implicit/README.md
+++ b/examples/benzene-toluene-implicit/README.md
@@ -8,7 +8,7 @@ A harmonic restraint is used to keep the two molecules from drifting far away fr
 
 Set up the simulation to alchemically decouple benzene, putting all the output files in `output/`:
 ```tcsh
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --minimize --verbose
 ```
 
 Run the simulation with verbose output:

--- a/examples/benzene-toluene-implicit/run.sh
+++ b/examples/benzene-toluene-implicit/run.sh
@@ -19,7 +19,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."

--- a/examples/host-guest-implicit/README.md
+++ b/examples/host-guest-implicit/README.md
@@ -8,7 +8,7 @@ A harmonic restraint is used to keep the two molecules from drifting far away fr
 
 Set up the simulation to alchemically decouple benzene, putting all the output files in `output/`:
 ```tcsh
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
 ```
 
 Run the simulation with verbose output:

--- a/examples/host-guest-implicit/run.sh
+++ b/examples/host-guest-implicit/run.sh
@@ -19,7 +19,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."

--- a/examples/p-xylene-explicit/README.md
+++ b/examples/p-xylene-explicit/README.md
@@ -19,7 +19,7 @@ The mbondi2 radii are used, with OBC GBSA in YANK.
 
 Set up the simulation to alchemically decouple benzene, putting all the output files in `output/`:
 ```tcsh
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
 ```
 
 Run the simulation with verbose output:

--- a/examples/p-xylene-explicit/run-torque.csh
+++ b/examples/p-xylene-explicit/run-torque.csh
@@ -39,6 +39,6 @@
 cd $PBS_O_WORKDIR
 
 date
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
 date
 

--- a/examples/p-xylene-explicit/run.sh
+++ b/examples/p-xylene-explicit/run.sh
@@ -19,7 +19,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmosphere --equilibrate=5 --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature=300*kelvin --pressure=1*atmosphere --equilibrate=5 --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."

--- a/examples/p-xylene-implicit/README.md
+++ b/examples/p-xylene-implicit/README.md
@@ -19,7 +19,7 @@ The mbondi2 radii are used, with OBC GBSA in YANK.
 
 Set up the simulation to alchemically decouple benzene, putting all the output files in `output/`:
 ```tcsh
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --minimize --verbose
 ```
 
 Run the simulation with verbose output:

--- a/examples/p-xylene-implicit/run-torque.csh
+++ b/examples/p-xylene-implicit/run-torque.csh
@@ -49,7 +49,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
 
 date
 #mpirun -rmk pbs yank --mpi --verbose

--- a/examples/p-xylene-implicit/run-torque.sh
+++ b/examples/p-xylene-implicit/run-torque.sh
@@ -49,7 +49,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1 --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
 
 date
 yank run --store=output --verbose

--- a/examples/p-xylene-implicit/run.sh
+++ b/examples/p-xylene-implicit/run.sh
@@ -19,7 +19,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=MOL --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."

--- a/examples/tip3p-in-tip3p/README.md
+++ b/examples/tip3p-in-tip3p/README.md
@@ -14,7 +14,7 @@
 
 Set up the simulation to alchemically decouple water, putting all the output files in `output/`:
 ```tcsh
-yank prepare binding amber --setupdir=setup --ligname=LIG --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname LIG" --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
 ```
 
 Run the simulation with verbose output:

--- a/examples/tip3p-in-tip3p/run-torque.csh
+++ b/examples/tip3p-in-tip3p/run-torque.csh
@@ -39,6 +39,6 @@
 cd $PBS_O_WORKDIR
 
 date
-yank prepare binding amber --setupdir=setup --ligname=BEN --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname LIG" --store=output --iterations=1000 --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
 date
 

--- a/examples/tip3p-in-tip3p/run.sh
+++ b/examples/tip3p-in-tip3p/run.sh
@@ -19,7 +19,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligname=LIG --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname LIG" --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."


### PR DESCRIPTION
This address #161 .

I changed the parameter --ligname=RESNAME [default: MOL] to --ligdsl=LIGANDDSL [default: “resname MOL”] that takes a DSL string.

I wanted to call the parameter simply ligand but it’s in conflict with systembuilder --ligand and I got the error "docopt.DocoptLanguageError: --ligand is not a unique prefix: --ligand, --ligand?".

Should I change its name to something else? "--ligatoms=DSLSTRING" ? Or maybe change the name of the parameter for systembuilder?

Once the name is settled, I'll change also the syntax in the documentation, the examples and nosetests.