### PR TITLE
Fixes for MPI errors with root logger on some platforms

### DIFF
--- a/Yank/commands/run.py
+++ b/Yank/commands/run.py
@@ -37,11 +37,21 @@ def dispatch(args):
     # Set override options.
     options = dict()
 
+    # Configure MPI, if requested.
+    mpicomm = None
+    if args['--mpi']:
+        # Initialize MPI.
+        from mpi4py import MPI
+        hostname = os.uname()[1]
+        MPI.COMM_WORLD.barrier()
+        logger.info("Initialized MPI on %d processes." % (MPI.COMM_WORLD.size))
+        mpicomm = MPI.COMM_WORLD
+
     # Configure logger
     if args['--verbose']:
         options['verbose'] = True
     utils.config_root_logger(options['verbose'],
-                             log_file_path=os.path.join(store_directory, 'run.log'))
+                             log_file_path=os.path.join(store_directory, 'run.log'), mpicomm=mpicomm)
 
     if args['--iterations']:
         options['number_of_iterations'] = int(args['--iterations'])
@@ -76,16 +86,6 @@ def dispatch(args):
     phases = None # By default, resume from all phases found in store_directory
     if args['--phase']: phases=[args['--phase']]
     yank.resume(phases=phases)
-
-    # Configure MPI, if requested.
-    mpicomm = None
-    if args['--mpi']:
-        # Initialize MPI.
-        from mpi4py import MPI
-        hostname = os.uname()[1]
-        MPI.COMM_WORLD.barrier()
-        logger.info("Initialized MPI on %d processes." % (MPI.COMM_WORLD.size))
-        mpicomm = MPI.COMM_WORLD
 
     # Run simulation.
     yank.run(mpicomm=mpicomm, options=options)

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -53,6 +53,9 @@ def config_root_logger(verbose, log_file_path=None, mpicomm=None):
     log_file_path : str, optional, default = None
         If not None, this is the path where all the logger's messages of level
         logging.DEBUG or higher are saved.
+    mpicomm : mpi4py.MPI.COMM communicator, optional, default=None
+        If specified, this communicator will be used to determine node rank.
+
     """
 
     class TerminalFormatter(logging.Formatter):

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -30,7 +30,7 @@ def is_terminal_verbose():
 
     return is_verbose
 
-def config_root_logger(verbose, log_file_path=None):
+def config_root_logger(verbose, log_file_path=None, mpicomm=None):
     """Setup the the root logger's configuration.
 
      The log messages are printed in the terminal and saved in the file specified
@@ -84,10 +84,9 @@ def config_root_logger(verbose, log_file_path=None):
             root_logger.removeHandler(root_logger.handlers[0])
 
     # If this is a worker node, don't save any log file
-    try:
-        from mpi4py import MPI
-        rank = MPI.COMM_WORLD.rank
-    except ImportError:
+    if mpicomm:
+        rank = mpicomm.rank
+    else:
         rank = 0
 
     if rank != 0:


### PR DESCRIPTION
This fixes an issue in which an ungraceful exit by MPI on some platforms (e.g. `osx`) would not cause an exception but a program crash.  Instead, we now pass `mpicomm` to the root logger config if we want to use the node's rank.