### PR TITLE
Updated arguments to build_mpirun_configfile in p-xylene examples

### DIFF
--- a/examples/p-xylene-explicit/run-torque.sh
+++ b/examples/p-xylene-explicit/run-torque.sh
@@ -46,7 +46,7 @@ yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=outpu
 
 # Run the simulation with verbose output:
 echo "Running simulation via MPI..."
-build_mpirun_configfile "yank run --store=output --verbose --mpi"
+build_mpirun_configfile --mpitype=conda "yank run --store=output --verbose --mpi"
 mpirun -configfile configfile
 
 # Analyze the data

--- a/examples/p-xylene-implicit/run-torque.sh
+++ b/examples/p-xylene-implicit/run-torque.sh
@@ -45,7 +45,7 @@ yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=outpu
 
 # Run the simulation with verbose output:
 echo "Running simulation via MPI..."
-build_mpirun_configfile "yank run --store=output --verbose --mpi"
+build_mpirun_configfile  --mpitype=conda "yank run --store=output --verbose --mpi"
 mpirun -configfile configfile
 
 # Analyze the data


### PR DESCRIPTION
This change is needed for the conda-installed `mpirun` in cases when many GPUs are used.