### PR TITLE
Updated gromacs example run scripts for mdtraj DSL

### DIFF
--- a/examples/p-xylene-gromacs-example/run-torque.sh
+++ b/examples/p-xylene-gromacs-example/run-torque.sh
@@ -42,7 +42,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding gromacs --setupdir=setup --ligand="resname p-xylene" --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
+yank prepare binding gromacs --setupdir=setup --ligand="resname 'p-xylene'" --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation via MPI..."

--- a/examples/p-xylene-gromacs-example/run.sh
+++ b/examples/p-xylene-gromacs-example/run.sh
@@ -19,7 +19,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding gromacs --setupdir=setup --ligand="resname p-xylene" --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
+yank prepare binding gromacs --setupdir=setup --ligand="resname 'p-xylene'" --store=output --iterations=$NITERATIONS --nbmethod=CutoffPeriodic --temperature="300*kelvin" --pressure="1*atmosphere" --minimize --verbose
 
 # Run the simulation with verbose output:
 echo "Running simulation..."


### PR DESCRIPTION
`p-xylene` is now properly protected by quotes as `'p-xylene'` for mdtraj DSL.