### PR TITLE
Fix dev package upload

### DIFF
--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -13,7 +13,7 @@ fi
 
 
 if [[ "2.7 3.3" =~ "$python" ]]; then
-    conda install --yes binstar jinja2
+    conda install --yes binstar conda-server anaconda-client jinja2
     binstar -t $BINSTAR_TOKEN upload --force -u omnia -p yank-dev $HOME/miniconda/conda-bld/*/yank-dev-*.tar.bz2
 fi
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - ambermini
     - docopt
     - openmoltools
-    - jinja2
     - sphinxcontrib-bibtex
 
   run:
@@ -38,7 +37,6 @@ requirements:
     - openmoltools
     - mpi4py
     - pyyaml
-    - jinja2
     - clusterutils
     - sphinxcontrib-bibtex
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - scipy
     - setuptools
     - netcdf4
-    - openmm-dev
+    - openmm >=6.3.0
     - openmmtools
     - pymbar ==2.1.0b0
     - ambermini
@@ -30,7 +30,7 @@ requirements:
     - scipy
     - cython
     - netcdf4
-    - openmm-dev
+    - openmm >=6.3.0
     - openmmtools
     - pymbar ==2.1.0b0
     - ambermini


### PR DESCRIPTION
Anaconda keeps changing its mind about where the `binstar` executable lives.