### PR TITLE
Add YAML configuration file to specify options

### DIFF
--- a/Yank/cli.py
+++ b/Yank/cli.py
@@ -27,8 +27,8 @@ Usage:
   yank [-h | --help] [-c | --cite]
   yank selftest [-v | --verbose]
   yank platforms
-  yank prepare binding amber --setupdir=DIRECTORY --ligand=DSLSTRING (-s=STORE | --store=STORE) [-n=NSTEPS | --nsteps=NSTEPS] [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--cutoff=CUTOFF] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [--minimize] [-v | --verbose]
-  yank prepare binding gromacs --setupdir=DIRECTORY --ligand=DSLSTRING (-s=STORE | --store=STORE) [--gromacsinclude=DIRECTORY] [-n=NSTEPS | --nsteps=NSTEPS] [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--cutoff=CUTOFF] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [--minimize] [-v | --verbose]
+  yank prepare binding amber --setupdir=DIRECTORY --ligand=DSLSTRING (-s=STORE | --store=STORE) [-n=NSTEPS | --nsteps=NSTEPS] [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--cutoff=CUTOFF] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [--minimize] [--yaml=FILEPATH] [-v | --verbose]
+  yank prepare binding gromacs --setupdir=DIRECTORY --ligand=DSLSTRING (-s=STORE | --store=STORE) [--gromacsinclude=DIRECTORY] [-n=NSTEPS | --nsteps=NSTEPS] [-i=NITER | --iterations=NITER] [--equilibrate=NEQUIL] [--restraints <restraint_type>] [--randomize-ligand] [--nbmethod=METHOD] [--cutoff=CUTOFF] [--gbsa=GBSA] [--constraints=CONSTRAINTS] [--temperature=TEMPERATURE] [--pressure=PRESSURE] [--minimize] [--yaml=FILEPATH] [-v | --verbose]
   yank run (-s=STORE | --store=STORE) [-m | --mpi] [-i=NITER | --iterations=NITER] [--platform=PLATFORM] [--precision=PRECISION] [--phase=PHASE] [-o | --online-analysis] [-v | --verbose]
   yank status (-s=STORE | --store=STORE) [-v | --verbose]
   yank analyze (-s STORE | --store=STORE) [-v | --verbose]
@@ -58,6 +58,7 @@ General options:
   --equilibrate=NEQUIL          Number of equilibration iterations
   --minimize                    Minimize configurations before running simulation.
   -m, --mpi                     Use MPI to parallelize the calculation
+  --yaml=FILEPATH               Use options specified in the YAML configuration file. Command-line options have priority.
 
 Simulation options:
   --restraints=TYPE             Restraint type to add between protein and ligand in implicit solvent (harmonic, flat-bottom) [default: flat-bottom]

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -116,44 +116,6 @@ def find_components(topology, ligand_dsl, solvent_resnames=_SOLVENT_RESNAMES):
 
     return atom_indices
 
-def process_unit_bearing_argument(args, argname, compatible_units):
-    """
-    Process a unit-bearing command-line argument to produce a Quantity.
-
-    Parameters
-    ----------
-    args : dict
-       Command-line arguments dict from docopt.
-    argname : str
-       Key to use to extract value from args.
-    compatible_units : simtk.unit.Unit
-       The result will be checked for compatibility with specified units, and an exception raised if not compatible.
-
-    Returns
-    -------
-    quantity : simtk.unit.Quantity
-       The specified parameter, returned as a Quantity.
-
-    """
-
-    # WARNING: This is dangerous!
-    # See: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
-    # TODO: Can we use a safer form of (or alternative to) 'eval' here?
-    quantity = eval(args[argname], unit.__dict__)
-    # Unpack quantity if it was surrounded by quotes.
-    if isinstance(quantity, str):
-        quantity = eval(quantity, unit.__dict__)
-    # Check to make sure units are compatible with expected units.
-    try:
-        quantity.unit.is_compatible(compatible_units)
-    except:
-        raise Exception("Argument %s does not have units attached." % args[argname])
-    # Check that units are compatible with what we expect.
-    if not quantity.unit.is_compatible(compatible_units):
-        raise Exception("Argument %s must be compatible with units %s" % (agname, str(compatible_units)))
-    # Return unit-bearing quantity.
-    return quantity
-
 def setup_binding_amber(args):
     """
     Set up ligand binding free energy calculation using AMBER prmtop/inpcrd files.
@@ -198,7 +160,7 @@ def setup_binding_amber(args):
 
     # Cutoff
     if args['--cutoff']:
-        nonbondedCutoff = process_unit_bearing_argument(args, '--cutoff', unit.nanometers)
+        nonbondedCutoff = utils.process_unit_bearing_argument(args, '--cutoff', unit.nanometers)
     else:
         nonbondedCutoff = None
 
@@ -304,7 +266,7 @@ def setup_binding_gromacs(args):
 
     # Cutoff
     if args['--cutoff']:
-        nonbondedCutoff = process_unit_bearing_argument(args, '--cutoff', unit.nanometers)
+        nonbondedCutoff = utils.process_unit_bearing_argument(args, '--cutoff', unit.nanometers)
     else:
         nonbondedCutoff = None
 
@@ -400,8 +362,8 @@ def dispatch_binding(args):
     #
 
     # Specify thermodynamic parameters.
-    temperature = process_unit_bearing_argument(args, '--temperature', unit.kelvin)
-    pressure = process_unit_bearing_argument(args, '--pressure', unit.atmospheres)
+    temperature = utils.process_unit_bearing_argument(args, '--temperature', unit.kelvin)
+    pressure = utils.process_unit_bearing_argument(args, '--pressure', unit.atmospheres)
     thermodynamic_state = ThermodynamicState(temperature=temperature, pressure=pressure)
 
     # Create systems according to specified setup/import method.

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -116,6 +116,35 @@ def find_components(topology, ligand_dsl, solvent_resnames=_SOLVENT_RESNAMES):
 
     return atom_indices
 
+def process_unit_bearing_arg(args, argname, compatible_units):
+    """
+    Process a unit-bearing command-line argument and handle eventual errors.
+
+    Parameters
+    ----------
+    args : dict
+       Command-line arguments dict from docopt.
+    argname : str
+       Key to use to extract value from args.
+    compatible_units : simtk.unit.Unit
+       The result will be checked for compatibility with specified units, and an exception raised if not compatible.
+
+    Returns
+    -------
+    quantity : simtk.unit.Quantity
+       The specified parameter, returned as a Quantity.
+
+    See also
+    --------
+    yank.utils.process_unit_bearing_str : function used for the actual conversion.
+
+    """
+    try:
+        return utils.process_unit_bearing_str(args[argname], compatible_units)
+    except (TypeError, ValueError) as e:
+        logger.error('Error while processing argument %s: %s' % (argname, str(e)))
+        raise e
+
 def setup_binding_amber(args):
     """
     Set up ligand binding free energy calculation using AMBER prmtop/inpcrd files.
@@ -160,7 +189,7 @@ def setup_binding_amber(args):
 
     # Cutoff
     if args['--cutoff']:
-        nonbondedCutoff = utils.process_unit_bearing_argument(args, '--cutoff', unit.nanometers)
+        nonbondedCutoff = process_unit_bearing_arg(args, '--cutoff', unit.nanometers)
     else:
         nonbondedCutoff = None
 
@@ -266,7 +295,7 @@ def setup_binding_gromacs(args):
 
     # Cutoff
     if args['--cutoff']:
-        nonbondedCutoff = utils.process_unit_bearing_argument(args, '--cutoff', unit.nanometers)
+        nonbondedCutoff = process_unit_bearing_arg(args, '--cutoff', unit.nanometers)
     else:
         nonbondedCutoff = None
 
@@ -362,8 +391,8 @@ def dispatch_binding(args):
     #
 
     # Specify thermodynamic parameters.
-    temperature = utils.process_unit_bearing_argument(args, '--temperature', unit.kelvin)
-    pressure = utils.process_unit_bearing_argument(args, '--pressure', unit.atmospheres)
+    temperature = process_unit_bearing_arg(args, '--temperature', unit.kelvin)
+    pressure = process_unit_bearing_arg(args, '--pressure', unit.atmospheres)
     thermodynamic_state = ThermodynamicState(temperature=temperature, pressure=pressure)
 
     # Create systems according to specified setup/import method.

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -25,6 +25,7 @@ from simtk.openmm import app
 from yank import utils
 from yank.yank import Yank # TODO: Fix this weird import path to something more sane, like 'from yank import Yank'
 from yank.repex import ThermodynamicState # TODO: Fix this weird import path to something more sane, like 'from yank.repex import ThermodynamicState'
+from yank.yamlbuild import YamlBuilder
 
 #=============================================================================================
 # SUBROUTINES
@@ -463,8 +464,14 @@ def dispatch_binding(args):
             else:
                 raise Exception("Platform selection logic is outdated and needs to be updated to add platform '%s'." % platform_name)
 
+    yank.options.cli = options
+
+    # Parse YAML configuration file and create YankOptions object
+    if args['--yaml']:
+        yank.options.yaml = YamlBuilder(args['--yaml']).options
+
     # Create new simulation.
-    yank.create(phases, systems, positions, atom_indices, thermodynamic_state, options=options)
+    yank.create(phases, systems, positions, atom_indices, thermodynamic_state)
 
     # Report success.
     return True

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -34,7 +34,12 @@ def test_yank_options():
     del yank_opt['option1']
     assert yank_opt['option1'] == 1
 
+    # modify specific priority level
+    yank_opt.default = {'option3': -2}
+    assert len(yank_opt) == 3
+    assert yank_opt['option3'] == -2
+
     # test iteration interface
-    assert yank_opt.items() == [('option1', 1), ('option2', 'test')]
-    assert yank_opt.keys() == ['option1', 'option2']
+    assert yank_opt.items() == [('option1', 1), ('option2', 'test'), ('option3', -2)]
+    assert yank_opt.keys() == ['option1', 'option2', 'option3']
 

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -1,0 +1,40 @@
+#!/usr/local/bin/env python
+
+"""
+Test various utility functions.
+
+"""
+
+#=============================================================================================
+# GLOBAL IMPORTS
+#=============================================================================================
+
+from yank.utils import YankOptions
+
+#=============================================================================================
+# TESTING FUNCTIONS
+#=============================================================================================
+
+def test_yank_options():
+    """Test option priorities and handling."""
+
+    cl_opt = {'option1': 1}
+    yaml_opt = {'option1': 2, 'option2': 'test'}
+    yank_opt = YankOptions(cl_opt=cl_opt, yaml_opt=yaml_opt)
+
+    assert yank_opt['option2'] == 'test'
+    assert yank_opt['option1'] == 1  # command line > yaml
+    assert len(yank_opt) == 2
+
+    # runtime > command line
+    yank_opt['option1'] = 0
+    assert yank_opt['option1'] == 0
+
+    # restore old option when deleted at runtime
+    del yank_opt['option1']
+    assert yank_opt['option1'] == 1
+
+    # test iteration interface
+    assert yank_opt.items() == [('option1', 1), ('option2', 'test')]
+    assert yank_opt.keys() == ['option1', 'option2']
+

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -63,7 +63,7 @@ def test_yaml_parsing():
         nsteps_per_iteration: 2500
         number_of_iterations: 10
         minimize: false
-        equilibrate: true
+        equilibrate: yes
         equilibration_timestep: 1.0 * femtoseconds
         number_of_equilibration_iterations: 1000
     """
@@ -87,5 +87,15 @@ def test_yaml_unknown_options():
     ---
     options:
         wrong_option: 3
+    """
+    parse_yaml_str(yaml_content)
+
+@raises(YamlParseError)
+def test_yaml_wrong_option_value():
+    """Check that YamlBuilder raises an exception when option type is wrong."""
+    yaml_content = """
+    ---
+    options:
+        equilibrate: 1000
     """
     parse_yaml_str(yaml_content)

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -20,36 +20,46 @@ import textwrap
 from yank.yamlbuild import YamlBuilder
 
 #=============================================================================================
+# SUBROUTINES FOR TESTING
+#=============================================================================================
+
+def parse_yaml_str(yaml_content):
+    """Parse the YAML string and return the YamlBuilder object used."""
+    yaml_file = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        # Check that handles no options
+        yaml_file.write(textwrap.dedent(yaml_content))
+        yaml_file.close()
+        yaml_builder = YamlBuilder(yaml_file.name)
+    finally:
+        os.remove(yaml_file.name)
+    return yaml_builder
+
+#=============================================================================================
 # UNIT TESTS
 #=============================================================================================
 
-def test_yaml_parse():
+def test_yaml_parsing():
     """Check that YAML file is parsed correctly."""
 
-    yaml_text = """
+    # Parser handles no options
+    yaml_content = """
+    ---
+    test: 2
+    """
+    yaml_builder = parse_yaml_str(yaml_content)
+    assert len(yaml_builder.options) == 0
+
+    # Parser handles unknown options
+    yaml_content = """
     ---
     options:
         wrong_option: 3
         timestep: 1.0 * femtoseconds
         nsteps_per_iteration: 2500
     """
-
-    yaml_file = tempfile.NamedTemporaryFile(delete=False)
-    try:
-        # Check that handles no options
-        yaml_file.write('---\ntest: 2')
-        yaml_file.close()
-        yaml_builder = YamlBuilder(yaml_file.name)
-        assert len(yaml_builder.options) == 0
-
-        # Check that handle unknown options
-        with open(yaml_file.name, 'w') as f:
-            f.write(textwrap.dedent(yaml_text))
-            f.close()
-        yaml_builder = YamlBuilder(yaml_file.name)
-        assert len(yaml_builder.options) == 2
-        assert 'timestep' in yaml_builder.options
-        assert yaml_builder.options['nsteps_per_iteration'] == 2500
-    finally:
-        os.remove(yaml_file.name)
+    yaml_builder = parse_yaml_str(yaml_content)
+    assert len(yaml_builder.options) == 2
+    assert 'timestep' in yaml_builder.options
+    assert yaml_builder.options['nsteps_per_iteration'] == 2500
 

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -56,6 +56,8 @@ def test_yaml_parsing():
     # Correct parsing
     yaml_content = """
     ---
+    metadata:
+        title: Test YANK YAML YAY!
     options:
         timestep: 2.0 * femtoseconds
         nsteps_per_iteration: 2500
@@ -67,7 +69,8 @@ def test_yaml_parsing():
     """
 
     yaml_builder = parse_yaml_str(yaml_content)
-    assert len(yaml_builder.options) == 7
+    assert len(yaml_builder.options) == 8
+    assert yaml_builder.options['title'] == 'Test YANK YAML YAY!'
     assert yaml_builder.options['timestep'] == 2.0 * unit.femtoseconds
     assert yaml_builder.options['nsteps_per_iteration'] == 2500
     assert yaml_builder.options['number_of_iterations'] == 10

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -17,7 +17,9 @@ import os
 import tempfile
 import textwrap
 
-from yank.yamlbuild import YamlBuilder
+from nose.tools import raises
+
+from yank.yamlbuild import YamlBuilder, YamlParseError
 
 #=============================================================================================
 # SUBROUTINES FOR TESTING
@@ -50,11 +52,10 @@ def test_yaml_parsing():
     yaml_builder = parse_yaml_str(yaml_content)
     assert len(yaml_builder.options) == 0
 
-    # Parser handles unknown options
+    # Correct parsing
     yaml_content = """
     ---
     options:
-        wrong_option: 3
         timestep: 1.0 * femtoseconds
         nsteps_per_iteration: 2500
     """
@@ -63,3 +64,13 @@ def test_yaml_parsing():
     assert 'timestep' in yaml_builder.options
     assert yaml_builder.options['nsteps_per_iteration'] == 2500
 
+@raises(YamlParseError)
+def test_yaml_unknown_options():
+    """Check that YamlBuilder raises an exception when an unknown option is found."""
+    # Raise exception on unknown options
+    yaml_content = """
+    ---
+    options:
+        wrong_option: 3
+    """
+    yaml_builder = parse_yaml_str(yaml_content)

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+#=============================================================================================
+# MODULE DOCSTRING
+#=============================================================================================
+
+"""
+Test YAML functions.
+
+"""
+
+#=============================================================================================
+# GLOBAL IMPORTS
+#=============================================================================================
+
+import os
+import tempfile
+import textwrap
+
+from yank.yamlbuild import YamlBuilder
+
+#=============================================================================================
+# UNIT TESTS
+#=============================================================================================
+
+def test_yaml_parse():
+    """Check that YAML file is parsed correctly."""
+
+    yaml_text = """
+    ---
+    options:
+        wrong_option: 3
+        timestep: 1.0 * femtoseconds
+        nsteps_per_iteration: 2500
+    """
+
+    yaml_file = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        # Check that handles no options
+        yaml_file.write('---\ntest: 2')
+        yaml_file.close()
+        yaml_builder = YamlBuilder(yaml_file.name)
+        assert len(yaml_builder.options) == 0
+
+        # Check that handle unknown options
+        with open(yaml_file.name, 'w') as f:
+            f.write(textwrap.dedent(yaml_text))
+            f.close()
+        yaml_builder = YamlBuilder(yaml_file.name)
+        assert len(yaml_builder.options) == 2
+        assert 'timestep' in yaml_builder.options
+        assert yaml_builder.options['nsteps_per_iteration'] == 2500
+    finally:
+        os.remove(yaml_file.name)
+

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -57,13 +57,24 @@ def test_yaml_parsing():
     yaml_content = """
     ---
     options:
-        timestep: 1.0 * femtoseconds
+        timestep: 2.0 * femtoseconds
         nsteps_per_iteration: 2500
+        number_of_iterations: 10
+        minimize: false
+        equilibrate: true
+        equilibration_timestep: 1.0 * femtoseconds
+        number_of_equilibration_iterations: 1000
     """
+
     yaml_builder = parse_yaml_str(yaml_content)
-    assert len(yaml_builder.options) == 2
-    assert yaml_builder.options['timestep'] == 1.0 * unit.femtoseconds
+    assert len(yaml_builder.options) == 7
+    assert yaml_builder.options['timestep'] == 2.0 * unit.femtoseconds
     assert yaml_builder.options['nsteps_per_iteration'] == 2500
+    assert yaml_builder.options['number_of_iterations'] == 10
+    assert yaml_builder.options['minimize'] is False
+    assert yaml_builder.options['equilibrate'] is True
+    assert yaml_builder.options['equilibration_timestep'] == 1.0 * unit.femtoseconds
+    assert yaml_builder.options['number_of_equilibration_iterations'] == 1000
 
 @raises(YamlParseError)
 def test_yaml_unknown_options():

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -17,6 +17,7 @@ import os
 import tempfile
 import textwrap
 
+from simtk import unit
 from nose.tools import raises
 
 from yank.yamlbuild import YamlBuilder, YamlParseError
@@ -61,7 +62,7 @@ def test_yaml_parsing():
     """
     yaml_builder = parse_yaml_str(yaml_content)
     assert len(yaml_builder.options) == 2
-    assert 'timestep' in yaml_builder.options
+    assert yaml_builder.options['timestep'] == 1.0 * unit.femtoseconds
     assert yaml_builder.options['nsteps_per_iteration'] == 2500
 
 @raises(YamlParseError)
@@ -73,4 +74,4 @@ def test_yaml_unknown_options():
     options:
         wrong_option: 3
     """
-    yaml_builder = parse_yaml_str(yaml_content)
+    parse_yaml_str(yaml_content)

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -227,30 +227,41 @@ def get_data_filename(relative_path):
 
     return fn
 
-def process_unit_bearing_argument(args, argname, compatible_units):
+def process_unit_bearing_str(quantity_str, compatible_units):
     """
-    Process a unit-bearing command-line argument to produce a Quantity.
+    Process a unit-bearing string to produce a Quantity.
 
     Parameters
     ----------
-    args : dict
-       Command-line arguments dict from docopt.
-    argname : str
-       Key to use to extract value from args.
+    quantity_str : str
+        A string containing a value with a unit of measure.
     compatible_units : simtk.unit.Unit
-       The result will be checked for compatibility with specified units, and an exception raised if not compatible.
+       The result will be checked for compatibility with specified units, and an
+       exception raised if not compatible.
 
     Returns
     -------
     quantity : simtk.unit.Quantity
-       The specified parameter, returned as a Quantity.
+       The specified string, returned as a Quantity.
+
+    Raises
+    ------
+    TypeError
+        If quantity_str does not contains units.
+    ValueError
+        If the units attached to quantity_str are incompatible with compatible_units
+
+    Examples
+    --------
+    >>> process_unit_bearing_str('1.0*micrometers', unit.nanometers)
+    Quantity(value=1.0, unit=micrometer)
 
     """
 
     # WARNING: This is dangerous!
     # See: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
     # TODO: Can we use a safer form of (or alternative to) 'eval' here?
-    quantity = eval(args[argname], unit.__dict__)
+    quantity = eval(quantity_str, unit.__dict__)
     # Unpack quantity if it was surrounded by quotes.
     if isinstance(quantity, str):
         quantity = eval(quantity, unit.__dict__)
@@ -258,12 +269,34 @@ def process_unit_bearing_argument(args, argname, compatible_units):
     try:
         quantity.unit.is_compatible(compatible_units)
     except:
-        raise Exception("Argument %s does not have units attached." % args[argname])
+        raise TypeError("String %s does not have units attached." % quantity_str)
     # Check that units are compatible with what we expect.
     if not quantity.unit.is_compatible(compatible_units):
-        raise Exception("Argument %s must be compatible with units %s" % (argname, str(compatible_units)))
+        raise ValueError("Units of %s must be compatible with %s" % (quantity_str,
+                                                                     str(compatible_units)))
     # Return unit-bearing quantity.
     return quantity
+
+def process_second_compatible_quantity(quantity_str):
+    """
+    Shortcut to process a string containing a quantity compatible with seconds.
+
+    Parameters
+    ----------
+    quantity_str : str
+         A string containing a value with a unit of measure for time.
+
+    Returns
+    -------
+    quantity : simtk.unit.Quantity
+       The specified string, returned as a Quantity.
+
+    See Also
+    --------
+    process_unit_bearing_str : the function used for the actual conversion.
+
+    """
+    return process_unit_bearing_str(quantity_str, unit.seconds)
 
 #=============================================================================================
 # Main and tests

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -298,27 +298,6 @@ def process_unit_bearing_str(quantity_str, compatible_units):
     # Return unit-bearing quantity.
     return quantity
 
-def process_second_compatible_quantity(quantity_str):
-    """
-    Shortcut to process a string containing a quantity compatible with seconds.
-
-    Parameters
-    ----------
-    quantity_str : str
-         A string containing a value with a unit of measure for time.
-
-    Returns
-    -------
-    quantity : simtk.unit.Quantity
-       The specified string, returned as a Quantity.
-
-    See Also
-    --------
-    process_unit_bearing_str : the function used for the actual conversion.
-
-    """
-    return process_unit_bearing_str(quantity_str, unit.seconds)
-
 #=============================================================================================
 # Main and tests
 #=============================================================================================

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -17,6 +17,9 @@ import yaml
 import logging
 logger = logging.getLogger(__name__)
 
+from simtk import unit
+
+from yank.utils import process_unit_bearing_argument
 
 #=============================================================================================
 # BUILDER CLASS
@@ -78,6 +81,11 @@ class YamlBuilder:
         except KeyError:
             self._options = {}
             logger.warning('No YAML options found.')
+
+        # Enforce types that are not automatically recognized by yaml
+        if 'timestep' in self._options:
+            self._options['timestep'] = process_unit_bearing_argument(
+                self._options, 'timestep', unit.femtoseconds)
 
     def build_experiment(self):
         """Build the Yank experiment (TO BE IMPLEMENTED)."""

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -21,6 +21,55 @@ from simtk import unit
 
 import utils
 
+
+#=============================================================================================
+# UTILITY FUNCTIONS
+#=============================================================================================
+
+def process_second_compatible_quantity(quantity_str):
+    """
+    Shortcut to process a string containing a quantity compatible with seconds.
+
+    Parameters
+    ----------
+    quantity_str : str
+         A string containing a value with a unit of measure for time.
+
+    Returns
+    -------
+    quantity : simtk.unit.Quantity
+       The specified string, returned as a Quantity.
+
+    See Also
+    --------
+    utils.process_unit_bearing_str : the function used for the actual conversion.
+
+    """
+    return utils.process_unit_bearing_str(quantity_str, unit.seconds)
+
+def process_bool(bool_val):
+    """Raise ValueError if this an ambiguous representation of a bool.
+
+    PyYAML load a boolean the following words: true, True, yes, Yes, false, False,
+    no and No, but in Python strings and numbers can be used as booleans and create
+    subtle errors. This function ensure that the value is a true boolean.
+
+    Returns
+    -------
+    bool
+        bool_val only if it is a boolean.
+
+    Raises
+    ------
+    ValueError
+        If bool_var is not a boolean.
+
+    """
+    if isinstance(bool_val, bool):
+        return bool_val
+    else:
+        raise ValueError('The value must be true, yes, false, or no.')
+
 #=============================================================================================
 # BUILDER CLASS
 #=============================================================================================
@@ -43,8 +92,13 @@ class YamlBuilder:
                                    'timestep', 'nsteps_per_iteration', 'number_of_iterations',
                                    'minimize','equilibrate', 'equilibration_timestep',
                                    'number_of_equilibration_iterations'])
-    _special_options_types = (('timestep', utils.process_second_compatible_quantity),
-                              ('equilibration_timestep', utils.process_second_compatible_quantity))
+    _expected_options_types = (('timestep', process_second_compatible_quantity),
+                               ('nsteps_per_iteration', int),
+                               ('number_of_iterations', int),
+                               ('minimize', process_bool),
+                               ('equilibrate', process_bool),
+                               ('equilibration_timestep', process_second_compatible_quantity),
+                               ('number_of_equilibration_iterations', int))
 
     @property
     def options(self):
@@ -94,9 +148,14 @@ class YamlBuilder:
             raise YamlParseError(error_msg)
 
         # Enforce types that are not automatically recognized by yaml
-        for special_opt, casting_func in YamlBuilder._special_options_types:
+        for special_opt, casting_func in YamlBuilder._expected_options_types:
             if special_opt in self._options:
-                self._options[special_opt] = casting_func(self._options[special_opt])
+                try:
+                    self._options[special_opt] = casting_func(self._options[special_opt])
+                except (TypeError, ValueError) as e:
+                    error_msg = 'YAML option %s: %s' % (special_opt, str(e))
+                    logger.error(error_msg)
+                    raise YamlParseError(error_msg)
 
     def build_experiment(self):
         """Build the Yank experiment (TO BE IMPLEMENTED)."""

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 # BUILDER CLASS
 #=============================================================================================
 
+class YamlParseError(Exception):
+    """Represent errors occurring during parsing of Yank YAML file."""
+    pass
+
 class YamlBuilder:
     """Parse YAML configuration file and build the experiment.
 
@@ -59,14 +63,18 @@ class YamlBuilder:
         if yaml_config is None:
             error_msg = 'The YAML file is empty!'
             logger.error(error_msg)
-            raise ValueError(error_msg)
+            raise YamlParseError(error_msg)
 
         # Set options only accepted options
         try:
             opts = yaml_config['options']
             self._options = {x: opts[x] for x in opts if x in YamlBuilder._accepted_options}
             if len(self._options) != len(yaml_config['options']):
-                logger.warning('YAML configuration contains unidentifiable options.')
+                unknown_opts = {x for x in opts if x not in YamlBuilder._accepted_options}
+                error_msg = 'YAML configuration contains unidentifiable options: '
+                error_msg += ', '.join(unknown_opts)
+                logger.error(error_msg)
+                raise YamlParseError(error_msg)
         except KeyError:
             self._options = {}
             logger.warning('No YAML options found.')

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 from simtk import unit
 
-from yank.utils import process_unit_bearing_argument
+import utils
 
 #=============================================================================================
 # BUILDER CLASS
@@ -40,6 +40,7 @@ class YamlBuilder:
     """
 
     _accepted_options = frozenset(['timestep', 'nsteps_per_iteration'])
+    _special_options_types = (('timestep', utils.process_second_compatible_quantity),)
 
     @property
     def options(self):
@@ -83,9 +84,9 @@ class YamlBuilder:
             logger.warning('No YAML options found.')
 
         # Enforce types that are not automatically recognized by yaml
-        if 'timestep' in self._options:
-            self._options['timestep'] = process_unit_bearing_argument(
-                self._options, 'timestep', unit.femtoseconds)
+        for special_opt, casting_func in YamlBuilder._special_options_types:
+            if special_opt in self._options:
+                self._options[special_opt] = casting_func(self._options[special_opt])
 
     def build_experiment(self):
         """Build the Yank experiment (TO BE IMPLEMENTED)."""

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+#=============================================================================================
+# MODULE DOCSTRING
+#=============================================================================================
+
+"""
+Tools to build Yank experiments from a YAML configuration file.
+
+"""
+
+#=============================================================================================
+# GLOBAL IMPORTS
+#=============================================================================================
+
+import yaml
+import logging
+logger = logging.getLogger(__name__)
+
+
+#=============================================================================================
+# BUILDER CLASS
+#=============================================================================================
+
+class YamlBuilder:
+    """Parse YAML configuration file and build the experiment.
+
+    Properties
+    ----------
+    options : dict
+        The options specified in the parsed YAML file.
+
+    """
+
+    _accepted_options = frozenset(['timestep', 'nsteps_per_iteration'])
+
+    @property
+    def options(self):
+        return self._options
+
+    def __init__(self, yaml_file):
+        """Parse the given YAML configuration file.
+
+        This does not build the actual experiment but simply checks that the syntax
+        is correct and loads the configuration into memory.
+
+        Parameters
+        ----------
+        yaml_file : str
+            A relative or absolute path to the YAML configuration file.
+
+        """
+
+        # TODO check version of yank-yaml language
+        # TODO what if there are multiple streams in the YAML file?
+        with open(yaml_file, 'r') as f:
+            yaml_config = yaml.load(f)
+
+        if yaml_config is None:
+            error_msg = 'The YAML file is empty!'
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        # Set options only accepted options
+        try:
+            opts = yaml_config['options']
+            self._options = {x: opts[x] for x in opts if x in YamlBuilder._accepted_options}
+            if len(self._options) != len(yaml_config['options']):
+                logger.warning('YAML configuration contains unidentifiable options.')
+        except KeyError:
+            self._options = {}
+            logger.warning('No YAML options found.')
+
+    def build_experiment(self):
+        """Build the Yank experiment (TO BE IMPLEMENTED)."""
+        raise NotImplemented

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -39,8 +39,11 @@ class YamlBuilder:
 
     """
 
-    _accepted_options = frozenset(['timestep', 'nsteps_per_iteration'])
-    _special_options_types = (('timestep', utils.process_second_compatible_quantity),)
+    _accepted_options = frozenset(['timestep', 'nsteps_per_iteration', 'number_of_iterations',
+                                   'minimize', 'equilibrate', 'equilibration_timestep',
+                                   'number_of_equilibration_iterations'])
+    _special_options_types = (('timestep', utils.process_second_compatible_quantity),
+                              ('equilibration_timestep', utils.process_second_compatible_quantity))
 
     @property
     def options(self):

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -31,6 +31,7 @@ import simtk.openmm as openmm
 
 from . import sampling, repex, alchemy
 
+from utils import YankOptions
 from alchemy import AbsoluteAlchemicalFactory
 from repex import ThermodynamicState
 from sampling import ModifiedHamiltonianExchange # TODO: Modify to 'from yank.sampling import ModifiedHamiltonianExchange'?
@@ -83,16 +84,15 @@ class Yank(object):
         self.default_protocols['complex-explicit'] = AbsoluteAlchemicalFactory.defaultComplexProtocolExplicit()
 
         # Default options for repex.
-        self.default_options = dict()
-        self.default_options['number_of_equilibration_iterations'] = 0
-        self.default_options['number_of_iterations'] = 100
-        self.default_options['number_of_iterations'] = 100
-        self.default_options['timestep'] = 2.0 * unit.femtoseconds
-        self.default_options['collision_rate'] = 5.0 / unit.picoseconds
-        self.default_options['minimize'] = False
-        self.default_options['show_mixing_statistics'] = True # this causes slowdown with iteration and should not be used for production
-        self.default_options['platform'] = None
-        self.default_options['displacement_sigma'] = 1.0 * unit.nanometers # attempt to displace ligand by this stddev will be made each iteration
+        self.options = YankOptions()
+        self.options.default['number_of_equilibration_iterations'] = 0
+        self.options.default['number_of_iterations'] = 100
+        self.options.default['timestep'] = 2.0 * unit.femtoseconds
+        self.options.default['collision_rate'] = 5.0 / unit.picoseconds
+        self.options.default['minimize'] = False
+        self.options.default['show_mixing_statistics'] = True # this causes slowdown with iteration and should not be used for production
+        self.options.default['platform'] = None
+        self.options.default['displacement_sigma'] = 1.0 * unit.nanometers # attempt to displace ligand by this stddev will be made each iteration
 
         return
 
@@ -248,7 +248,10 @@ class Yank(object):
 
 
         # Combine simulation options with defaults to create repex options.
-        repex_options = dict(self.default_options.items() + options.items())
+        if options is None:
+            repex_options = dict(self.options.items())
+        else:
+            repex_options = dict(self.options.items() + options.items())
 
         # Make sure positions argument is a list of coordinate snapshots.
         if hasattr(positions, 'unit'):


### PR DESCRIPTION
This attempts to address #285 and #143.

Right now I've just created the utility class YankOptions which implements a dictionary interface (so that I won't need to modify much code) and can be used as a single point of entry to read hardcoded, command line and YAML options.

When the same option is specified both in command line and YAML, I thought it would be best to give priority to the command line, but I can change that easily.