### PR TITLE
Second draft YAML syntax

### DIFF
--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -464,14 +464,12 @@ def dispatch_binding(args):
             else:
                 raise Exception("Platform selection logic is outdated and needs to be updated to add platform '%s'." % platform_name)
 
-    yank.options.cli = options
-
-    # Parse YAML configuration file and create YankOptions object
+    # Parse YAML options, CLI options have priority
     if args['--yaml']:
-        yank.options.yaml = YamlBuilder(args['--yaml']).options
+        options.update(YamlBuilder(args['--yaml']).options)
 
     # Create new simulation.
-    yank.create(phases, systems, positions, atom_indices, thermodynamic_state)
+    yank.create(phases, systems, positions, atom_indices, thermodynamic_state, options=options)
 
     # Report success.
     return True

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -31,7 +31,6 @@ import simtk.openmm as openmm
 
 from . import sampling, repex, alchemy
 
-from utils import YankOptions
 from alchemy import AbsoluteAlchemicalFactory
 from repex import ThermodynamicState
 from sampling import ModifiedHamiltonianExchange # TODO: Modify to 'from yank.sampling import ModifiedHamiltonianExchange'?
@@ -84,15 +83,16 @@ class Yank(object):
         self.default_protocols['complex-explicit'] = AbsoluteAlchemicalFactory.defaultComplexProtocolExplicit()
 
         # Default options for repex.
-        self.options = YankOptions()
-        self.options.default['number_of_equilibration_iterations'] = 0
-        self.options.default['number_of_iterations'] = 100
-        self.options.default['timestep'] = 2.0 * unit.femtoseconds
-        self.options.default['collision_rate'] = 5.0 / unit.picoseconds
-        self.options.default['minimize'] = False
-        self.options.default['show_mixing_statistics'] = True # this causes slowdown with iteration and should not be used for production
-        self.options.default['platform'] = None
-        self.options.default['displacement_sigma'] = 1.0 * unit.nanometers # attempt to displace ligand by this stddev will be made each iteration
+        self._default_options = {
+            'number_of_equilibration_iterations': 0,
+            'number_of_iterations': 100,
+            'timestep': 2.0 * unit.femtoseconds,
+            'collision_rate': 5.0 / unit.picoseconds,
+            'minimize': False,
+            'show_mixing_statistics': True,  # this causes slowdown with iteration and should not be used for production
+            'platform': None,
+            'displacement_sigma': 1.0 * unit.nanometers  # attempt to displace ligand by this stddev will be made each iteration
+        }
 
         return
 
@@ -248,9 +248,9 @@ class Yank(object):
 
         # Combine simulation options with defaults to create repex options.
         if options is None:
-            repex_options = dict(self.options.items())
+            repex_options = copy.deepcopy(self._default_options)
         else:
-            repex_options = dict(self.options.items() + options.items())
+            repex_options = copy.deepcopy(self._default_options, **options)
 
         # Make sure positions argument is a list of coordinate snapshots.
         if hasattr(positions, 'unit'):

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -250,7 +250,7 @@ class Yank(object):
         if options is None:
             repex_options = copy.deepcopy(self._default_options)
         else:
-            repex_options = copy.deepcopy(self._default_options, **options)
+            repex_options = copy.deepcopy(dict(self._default_options, **options))
 
         # Make sure positions argument is a list of coordinate snapshots.
         if hasattr(positions, 'unit'):

--- a/examples/yank-yaml-cookbook/README.md
+++ b/examples/yank-yaml-cookbook/README.md
@@ -1,0 +1,4 @@
+* `p-xylene-explicit.yaml`: absolute binding calculation of p-xylene and T4 L99A lysozyme in explicit solvent, setup from protein PDB and ligand name.
+* `combination-solvation.yaml`: multiple absolute solvation calculations of 3 different ligands, setup from smiles.
+* `prmtop-abl-imatinib.yaml`: absolute binding calculation of Abl and imatinib starting from user-provided prmtop and inpcrd files for the system.
+* `relative-abl-imatinib-bosutinib.yaml`: relative binding calculation example in explicit solvent.

--- a/examples/yank-yaml-cookbook/combination-solvation.yaml
+++ b/examples/yank-yaml-cookbook/combination-solvation.yaml
@@ -1,0 +1,120 @@
+# This example shows how to setup multiple absolute solvation free energy calculations
+# with Yank.
+#----------------------------------------------------------------------------------
+
+
+#yank-yaml0.1
+---
+metadata:
+  title: Solvation free energy of imatinib, bosutinib and afatinib
+
+
+# General options
+#----------------------------------------------------------------------------------
+options:
+  yamlbuilder:
+    verbose: yes
+    mpi: yes
+    platform: CUDA
+    precision: mixed
+  yank:
+    restraint_type: none
+    randomize_ligand: no
+    minimize: no
+    output_directory: $HOME/yank/solvation/
+  repex:
+    timestep: 1.0 * femtoseconds
+    nsteps_per_iteration: 2500
+    number_of_iterations: 1000
+    equilibration_timestep = 1.0*femtoseconds
+    number_of_equilibration_iterations: 100
+    online_analysis: no
+  alchemy:
+    annihilate_sterics: False
+    annihilate_electrostatics: True
+
+
+# In "molecules" you specify the components of your systems. If you have a single
+# file specifying multiple molecules you can select which one to load and rename
+# them. The parameters and various options that you specify here will guide the
+# setup of the systems for each phase.
+#----------------------------------------------------------------------------------
+molecules:
+  FDA_approved:
+    filename: FDA-approved.smiles  # Generate molecule from name with OpenEye library
+    epik: 0  # Take 0th state proposed by Schodinger's Epik
+    parameters: antechamber  # parametrize and charge with GAFF and Antechamber
+    select:
+      imatinib: mol01
+      bosutinib: mol04
+      afatinib: mol08
+
+
+# Here you setup the solvents used during the calculation. We define an implicit
+# solvent with Particle-Mesh Ewald (PME) and TIP3P model for the solvent phase and
+# a vacuum.
+#----------------------------------------------------------------------------------
+solvents:
+  vacuum:
+    nonbondedMethod: NoCutoff
+  PMEtip3p:
+    nonbondedMethod: PME
+    nonbondedCutoff: 1*nanometer
+    solventmodel: tip3p
+    clearance: 10*angstroms
+
+
+# Define the alchemical protocols that you will need. You can use anchors and
+# aliases in YAML to avoid redundance.
+#----------------------------------------------------------------------------------
+alchemical_protocols:
+  10states_protocol: &10states_protocol
+    lambda_electrostatics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+    lambda_sterics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+
+
+# Define the phases for the alchemical calculation. The general "ligand" name will
+# be matched to a specific molecule according to the "components" defined in the
+# "experiment" section. This way you can use the same protocol for multiple
+# calculations.
+#----------------------------------------------------------------------------------
+phases:
+  solvent: &solvent_phase
+    components: [PMEtip3p, ligand]
+    alchemical_transformation: ligand->null
+    alchemical_protocol: *10states_protocol
+  vacuum: &vacuum_phase
+    components: [vacuum, ligand]
+    alchemical_transformation: p-ligand->null
+    alchemical_protocol: *10states_protocol
+    phase_options:
+      repex:
+        niterations: 200
+
+
+# Protocol for the alchemical calculation.
+#----------------------------------------------------------------------------------
+protocols:
+  absolute_solvation:
+    type: absolute-solvation
+    phases:
+      solvent: *solvent_phase
+      vacuum: *vacuum_phase
+
+
+# Here we define the actual experiment along with the thermodynamic state and the
+# algorithms to be used. In the section "components" we define the general name
+# "ligand" that will be matched to the components defined in the phases. Everything
+# in list is combinatorial here, so this will effectively generate three calculations
+# with respectively imatinib, bosutinib and afatinib.
+#----------------------------------------------------------------------------------
+experiment:
+  alchemical_factory: alchemy.AbsoluteAlchemicalFactory
+  components:
+    ligand: [imatinib, bosutinib, afatinib]
+  thermodynamics:
+    temperature: 300*kelvin
+    pressure: 1*atmosphere
+  setup: leap
+  protocols: absolute_solvation
+

--- a/examples/yank-yaml-cookbook/combination-solvation.yaml
+++ b/examples/yank-yaml-cookbook/combination-solvation.yaml
@@ -17,6 +17,7 @@ options:
     mpi: yes
     platform: CUDA
     precision: mixed
+    resume: yes
   yank:
     restraint_type: none
     randomize_ligand: no
@@ -26,7 +27,7 @@ options:
     timestep: 1.0 * femtoseconds
     nsteps_per_iteration: 2500
     number_of_iterations: 1000
-    equilibration_timestep = 1.0*femtoseconds
+    equilibration_timestep: 1.0*femtoseconds
     number_of_equilibration_iterations: 100
     online_analysis: no
   alchemy:

--- a/examples/yank-yaml-cookbook/p-xylene-explicit.yaml
+++ b/examples/yank-yaml-cookbook/p-xylene-explicit.yaml
@@ -22,6 +22,7 @@ options:
     mpi: yes
     platform: CUDA
     precision: mixed
+    resume: yes
   yank:
     restraint_type: none
     randomize_ligand: no
@@ -31,7 +32,7 @@ options:
     timestep: 1.0 * femtoseconds
     nsteps_per_iteration: 2500
     number_of_iterations: 1000
-    equilibration_timestep = 1.0*femtoseconds
+    equilibration_timestep: 1.0*femtoseconds
     number_of_equilibration_iterations: 100
     online_analysis: no
   alchemy:

--- a/examples/yank-yaml-cookbook/p-xylene-explicit.yaml
+++ b/examples/yank-yaml-cookbook/p-xylene-explicit.yaml
@@ -1,0 +1,116 @@
+# This example shows how to setup an absolute binding free energy calculation with
+# Yank. In particular, here we setup a simulation for p-xylene and T4 L99A lysozyme
+# in explicit solvent.
+#
+# The only required input file here is the pdb structure of the protein (181L.pdb
+# that went through pdbfixer). Yank will generate the ligand from its name and it
+# will take care of parametrizing the molecules and creating a system for each phase.
+#----------------------------------------------------------------------------------
+
+
+#yank-yaml0.1
+---
+metadata:
+  title: T4 L99A lysozyme and p-xylene in explicit solvent
+
+
+# General options
+#----------------------------------------------------------------------------------
+options:
+  yamlbuilder:
+    verbose: yes
+    mpi: yes
+    platform: CUDA
+    precision: mixed
+  yank:
+    restraint_type: none
+    randomize_ligand: no
+    minimize: no
+    output_directory: $HOME/yank/p-xylene-output/
+  repex:
+    timestep: 1.0 * femtoseconds
+    nsteps_per_iteration: 2500
+    number_of_iterations: 1000
+    equilibration_timestep = 1.0*femtoseconds
+    number_of_equilibration_iterations: 100
+    online_analysis: no
+  alchemy:
+    annihilate_sterics: False
+    annihilate_electrostatics: True
+
+
+# In "molecules" you specify the components of your systems. The parameters and
+# various options that you specify here will guide the setup of the systems for
+# each phase.
+#----------------------------------------------------------------------------------
+molecules:
+  t4-l99a:
+    filename: 181L.pdbfixer.pdb
+    parameters: oldff/leaprc.ff99SBildn  # we will use LEaP for parametrization
+  p-xylene:
+    name: p-xylene  # Generate molecule from name with OpenEye library
+    epik: 0  # Take 0th state proposed by Schodinger's Epik
+    parameters: antechamber  # parametrize and charge with GAFF and Antechamber
+
+
+# Here you setup the explicit solvent used during the calculation. We use the
+# Particle-Mesh Ewald (PME) and TIP3P model.
+#----------------------------------------------------------------------------------
+solvents:
+  PMEtip3p:
+    nonbondedMethod: PME
+    nonbondedCutoff: 1*nanometer
+    solventmodel: tip3p
+    clearance: 10*angstroms
+
+
+# Define the alchemical protocols that you will need. You can use anchors and
+# aliases in YAML to avoid redundance.
+#----------------------------------------------------------------------------------
+alchemical_protocols:
+  10states_protocol: &10states_protocol
+    lambda_electrostatics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+    lambda_sterics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+
+
+# Define the phases for the alchemical calculation.
+#----------------------------------------------------------------------------------
+phases:
+  complex: &complex_phase
+    components: [PMEtip3p, t4-l99a, p-xylene]
+    alchemical_transformation: p-xylene->null
+    alchemical_protocol: *10states_protocol
+  solvent: &solvent_phase
+    components: [PMEtip3p, p-xylene]
+    alchemical_transformation: p-xylene->null
+    alchemical_protocol: *10states_protocol
+    phase_options:
+      repex:
+        niterations: 200
+
+
+# Protocol for the alchemical calculation.
+#----------------------------------------------------------------------------------
+protocols:
+  absolute_binding:
+    type: absolute-binding
+    phases:
+      complex: *complex_phase
+      solvent: *solvent_phase
+
+
+# Here we define the actual experiment along with the thermodynamic state and the
+# algorithms to be used. You don't need to define the section "components" here
+# because the phases use exact molecule names instead of general ligands, solvents,
+# and receptors.
+#----------------------------------------------------------------------------------
+experiment:
+  alchemical_factory: alchemy.AbsoluteAlchemicalFactory
+  hydrogenMass: 4*amu
+  constraints: AllBonds
+  thermodynamics:
+    temperature: 300*kelvin
+    pressure: 1*atmosphere
+  setup: leap
+  protocols: absolute_binding
+

--- a/examples/yank-yaml-cookbook/prmtop-abl-imatinib.yaml
+++ b/examples/yank-yaml-cookbook/prmtop-abl-imatinib.yaml
@@ -1,0 +1,120 @@
+# This example shows how to setup an absolute binding free energy calculation with
+# Yank in case you already prepared AMBER prmtop and inpcrd files describing the
+# systems for the complex and solvent phases. In particular, here we setup a
+# simulation for Abl and imatinib in implicit solvent. The necessary 4 input files
+# are
+#     * complex.prmtop
+#     * complex.inpcrd
+#     * solvent.prmtop
+#     * solvent.inpcrd
+#
+# A similar structure of the YAML file could be used to setup calculations from
+# GROMACS input files.
+#----------------------------------------------------------------------------------
+
+
+#yank-yaml0.1
+---
+metadata:
+  title: Abl and imatinib in GBSA solvent
+
+
+# General options
+#----------------------------------------------------------------------------------
+options:
+  yamlbuilder:
+    verbose: yes
+    mpi: yes
+    platform: CUDA
+    precision: mixed
+  yank:
+    restraint_type: harmonic
+    randomize_ligand: no
+    minimize: no
+    output_directory: $HOME/yank/absolute-amber-output/
+  repex:
+    timestep: 1.0 * femtoseconds
+    nsteps_per_iteration: 2500
+    number_of_iterations: 1000
+    equilibration_timestep = 1.0*femtoseconds
+    number_of_equilibration_iterations: 100
+    online_analysis: no
+  alchemy:
+    annihilate_sterics: False
+    annihilate_electrostatics: True
+
+
+# In "molecules" you specify the components of your systems. You need to specify
+# only how to select the atoms of the molecule given the prmtop and inpcrd files.
+# The actual name of the files for each phase (i.e. complex.prmtop, solvent.inpcrd,
+# etc.) will be given in the description of the phases in the section below.
+#----------------------------------------------------------------------------------
+molecules:
+  abl:
+    select: "chain A"
+  imatinib:
+    select: "resname MOL"
+
+
+# Here you setup the implicit solvent used during the calculation.
+#----------------------------------------------------------------------------------
+solvents:
+  GBSAobc2:
+    nonbondedMethod: NoCutoff
+    gbsamodel: obc2
+
+
+# Define the alchemical protocols that you will need. You can use anchors and
+# aliases in YAML to avoid redundance.
+#----------------------------------------------------------------------------------
+alchemical_protocols:
+  10states_protocol: &10states_protocol
+    lambda_electrostatics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+    lambda_sterics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+
+
+# Define the phases for the alchemical calculation. Here we specify the file name
+# of the systems for each phase. The atoms of the components will be identified
+# according to the molecule section.
+#----------------------------------------------------------------------------------
+phases:
+  complex: &complex_phase
+    system: [complex.prmtop, complex.inpcrd]
+    components: [GBSAobc2, abl, imatinib]
+    alchemical_transformation: imatinib->null
+    alchemical_protocol: *10states_protocol
+  solvent: &solvent_phase
+    system: [solvent.prmtop, solvent.inpcrd]
+    components: [GBSAobc2, imatinib]
+    alchemical_transformation: imatinib->null
+    alchemical_protocol: *10states_protocol
+    phase_options:
+      repex:
+        niterations: 200
+
+
+# Protocol for the alchemical calculation.
+#----------------------------------------------------------------------------------
+protocols:
+  absolute_binding:
+    type: absolute-binding
+    phases:
+      complex: *complex_phase
+      solvent: *solvent_phase
+
+
+# Here we define the actual experiment along with the thermodynamic state and the
+# algorithms to be used. You don't need to define the section "components" here
+# because the phases use exact molecule names instead of general ligands, solvents,
+# and receptors. Also you don't need to define the section "setup" since you have
+# already files describing the whole system for each phase.
+#----------------------------------------------------------------------------------
+experiment:
+  alchemical_factory: alchemy.AbsoluteAlchemicalFactory
+  hydrogenMass: 4*amu
+  constraints: AllBonds
+  thermodynamics:
+    temperature: 300*kelvin
+    pressure: 1*atmosphere
+  protocols: absolute_binding
+

--- a/examples/yank-yaml-cookbook/prmtop-abl-imatinib.yaml
+++ b/examples/yank-yaml-cookbook/prmtop-abl-imatinib.yaml
@@ -27,6 +27,7 @@ options:
     mpi: yes
     platform: CUDA
     precision: mixed
+    resume: yes
   yank:
     restraint_type: harmonic
     randomize_ligand: no
@@ -36,7 +37,7 @@ options:
     timestep: 1.0 * femtoseconds
     nsteps_per_iteration: 2500
     number_of_iterations: 1000
-    equilibration_timestep = 1.0*femtoseconds
+    equilibration_timestep: 1.0*femtoseconds
     number_of_equilibration_iterations: 100
     online_analysis: no
   alchemy:

--- a/examples/yank-yaml-cookbook/relative-abl-imatinib-bosutinib.yaml
+++ b/examples/yank-yaml-cookbook/relative-abl-imatinib-bosutinib.yaml
@@ -1,0 +1,122 @@
+# This example shows how to setup an relative binding free energy calculation with
+# Yank. The input files of this example are:
+#     * 2HYY.pdbfixer.pdb: abl protein from 2hyy.pdb that went through pdbfixer
+#     * imatinib.mol2
+#     * bosutinib.mol2
+#
+# Yank will take care of parametrizing the molecules and creating a system for each
+# phase.
+#----------------------------------------------------------------------------------
+
+
+#yank-yaml0.1
+---
+metadata:
+  title: Relative binding energy of imatinib and bosutinib
+
+
+# General options
+#----------------------------------------------------------------------------------
+options:
+  yamlbuilder:
+    verbose: yes
+    mpi: yes
+    platform: CUDA
+    precision: mixed
+  yank:
+    restraint_type: none
+    randomize_ligand: no
+    minimize: no
+    output_directory: $HOME/yank/relative/
+  repex:
+    timestep: 1.0 * femtoseconds
+    nsteps_per_iteration: 2500
+    number_of_iterations: 1000
+    equilibration_timestep = 1.0*femtoseconds
+    number_of_equilibration_iterations: 100
+    online_analysis: no
+  alchemy:
+    annihilate_sterics: False
+    annihilate_electrostatics: True
+
+
+# In "molecules" you specify the components of your systems. The parameters and
+# various options that you specify here will guide the setup of the systems for
+# each phase.
+#----------------------------------------------------------------------------------
+molecules:
+  abl:
+    filename: 2HYY.pdbfixer.pdb
+    parameters: amber99sbildn.xml
+  imatinib:
+    name: imatinib.mol2
+    parameters: antechamber
+  bosutinib:
+    name: bosutinib.mol2
+    parameters: antechamber
+
+
+# Here you setup the explicit solvent used during the calculation. We use the
+# Reaction Field (RF) and TIP3P model.
+#----------------------------------------------------------------------------------
+solvents:
+  RFtip3p:
+    nonbondedMethod: RF
+    solventmodel: tip3p
+    clearance: 10*angstroms
+
+
+# Define the alchemical protocols that you will need. You can use anchors and
+# aliases in YAML to avoid redundance.
+#----------------------------------------------------------------------------------
+alchemical_protocols:
+  10states_protocol: &10states_protocol
+    lambda_electrostatics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+    lambda_sterics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+  imatinib_bosutinib_atoms: &imatinib_bosutinib_atoms
+    dummy_atoms: [imatinib12, imatinib13, bosutinb14]
+    transform_atoms: [imatinib15->bosutinib16, imatinib17->bosutinib18]
+
+
+# Define the phases for the alchemical calculation.
+#----------------------------------------------------------------------------------
+phases:
+  complex: &complex_phase
+    components: [RFtip3p, abl, imatinib]
+    alchemical_transformation: imatinib->bosutinib
+    alchemical_atoms: *imatinib_bosutinib_atoms
+    alchemical_protocol: *10states_protocol
+  solvent: &solvent_phase
+    components: [RFtip3p, imatinib]
+    alchemical_transformation: imatinib->bosutinib
+    alchemical_atoms: *imatinib_bosutinib_atoms
+    alchemical_protocol: *10states_protocol
+    phase_options:
+      repex:
+        niterations: 500
+
+
+# Protocol for the alchemical calculation.
+#----------------------------------------------------------------------------------
+protocols:
+  relative_binding:
+    type: relative-binding
+    phases:
+      complex: *complex_phase
+      solvent: *solvent_phase
+
+
+# Here we define the actual experiment along with the thermodynamic state and the
+# algorithms to be used. You don't need to define the section "components" here
+# because the phases use exact molecule names instead of general ligands, solvents,
+# and receptors.
+#----------------------------------------------------------------------------------
+experiment:
+  alchemical_factory: alchemy.AbsoluteAlchemicalFactory
+  constraints: HBonds
+  thermodynamics:
+    temperature: 300*kelvin
+    pressure: 1*atmosphere
+  setup: systembuilder
+  protocols: relative_binding
+

--- a/examples/yank-yaml-cookbook/relative-abl-imatinib-bosutinib.yaml
+++ b/examples/yank-yaml-cookbook/relative-abl-imatinib-bosutinib.yaml
@@ -23,6 +23,7 @@ options:
     mpi: yes
     platform: CUDA
     precision: mixed
+    resume: yes
   yank:
     restraint_type: none
     randomize_ligand: no
@@ -32,7 +33,7 @@ options:
     timestep: 1.0 * femtoseconds
     nsteps_per_iteration: 2500
     number_of_iterations: 1000
-    equilibration_timestep = 1.0*femtoseconds
+    equilibration_timestep: 1.0*femtoseconds
     number_of_equilibration_iterations: 100
     online_analysis: no
   alchemy:

--- a/examples/yank.yaml
+++ b/examples/yank.yaml
@@ -1,8 +1,12 @@
+# This file tries to sum up all the various things
+# that will be possible to do with yank-yaml
+
 #yank-yaml0.1
 ---
 metadata:
   title:
   email:
+
 
 # Separate options / yank block, or put all yank/repex/alchemy at base level?
 options:
@@ -16,6 +20,7 @@ options:
   alchemy:
     annihilate_sterics: False
     annihilate_electrostatics: True
+
 
 molecules:
   abl-2hyy:
@@ -38,6 +43,7 @@ molecules:
   p38-ligands:
     filename: p32_ligands.sdf
     select: [p38a_2n, p38a_3flz, p38a_2h]  # how do we handle multi-molecules files?
+
 
 solvents:
   vacuum:
@@ -70,95 +76,125 @@ solvents:
     nonbondedMethod: NoCutoff
     gbsamodel: obc2
 
-# we can have pre-set alchemical protocols similarly to phases
+
 alchemical_protocols:
-  standard_protocol:
+  10states_protocol:
     lambda_electrostatics: [1.0, 0.9, 0.8, ...]
     lambda_sterics: [1.0, 0.9, 0.8, ...]
   20states_protocol:
     lambda_electrostatics: [1.0, 0.95, 0.9, ...]
     lambda_sterics: [1.0, 0.95, 0.9, ...]
 
+
 # The names in components, alchemical_transformation and alchemical_atoms
 # are searched both in molecules and in experiment.components. Pre-set
 # phases don't have to be explicitly defined and can be overwritten by
 # the user. For pre-set phases alchemical_atoms and alchemical_protocol
-# assume their default values.
+# assume the value 'auto'.
 phases:
-  # Pre-set phases equivalents, these don't actually have to be defined
-  # -------------------------------------------------------------------
-  absolute_binding: &default_absolute_binding_phase
+  # Pre-set phases equivalents examples, these don't actually have to be defined
+  # ----------------------------------------------------------------------------
+  default_absolute_complex: &default_absolute_complex_phase
     components: [solvent, receptor, molecule]
     alchemical_transformation: molecule->null
-  absolute_solvation: &default_absolute_solvation_phase
+  default_absolute_solvent: &default_absolute_solvent_phase
     components: [solvent, molecule]
     alchemical_transformation: molecule->null
-  relative_binding: &default_relative_binding_phase
+  default_relative_complex: &default_relative_complex_phase
     components: [solvent, static, molecule1]
     alchemical_transformation: molecule1->molecule2
-  relative_solvation: &default_relative_solvation_phase
+  default_relative_solvent: &default_relative_solvent_phase
     components: [solvent, molecule1]
     alchemical_transformation: molecule1->molecule2
-  phase_change: &default_phase_change_phase
-    components: [solvent1, molecule]
-    alchemical_transformation: solvent1->solvent2
 
   # User-defined phases examples
   # ----------------------------
-  bosutinib-afatinib:
-    components: [vacuum, abl-2hyy, bosutinib]
-    alchemical_transformation: bosutinib->afatinib
-    alchemical_atoms: auto
-  imatinib-bosutinib:
-    components: [vacuum, abl-2hyy, imatinib]
+  imatinib_bosutinib: &imatinib_bosutinib_phase
     alchemical_transformation: imatinib->bosutinib
     alchemical_atoms:
       dummy_atoms: [imatinib12, imatinib13, bosutinb14]
       transform_atoms: [imatinib15->bosutinib16, imatinib17->bosutinib18]
     alchemical_protocol: 20states_protocol
 
-  # User-defined that "extend" pre-set phases using anchors
-  # -------------------------------------------------------
-  relative_complex1000:
-    <<: *default_relative_binding_phase
-    alchemical_protocol: 20states_protocol
-    phase_options:
-      repex.niterations: 1000
-  relative_complex2000:
-    <<: *default_relative_binding_phase
-    alchemical_protocol: 20states_protocol
-    phase_options:
-      repex.niterations: 2000
-  relative_solvent:
-    <<: *default_relative_solvation_phase
-    phase_options:
-      repex.niterations: 200
 
-# An example of experiment that uses only pre-set phases. The default alchemical
-# factory can be easily inferred from the phase and appropriate default protocol
-# can be used. In the future the user should be able to set its own alchemy class
-# alchemical_factory: mymodule.MyAbsoluteAlchemicalFactory
-basic_experiment:
+# Can we automatically infer the type of energy calculation from "components"
+# and "alchemical_transformation"?
+protocols:
+  # Pre-set phases equivalents examples, these don't actually have to be defined
+  # ----------------------------------------------------------------------------
+  default_absolute_binding:
+    type: absolute-binding
+    phases:
+      complex: *default_absolute_complex_phase
+      solvent: *default_absolute_solvent_phase
+  default_absolute_solvation:
+    type: absolute-solvation
+    phases:
+      solvent: *default_absolute_solvent_phase
+      vacuum:
+        <<: *default_absolute_solvent_phase
+        components: [vacuum, molecule]
+  default_relative_solvation:
+    type: relative-solvation
+    phases:
+      solvent: *default_relative_solvent_phase
+      vacuum:
+        <<: *default_relative_solvent_phase
+        components: [vacuum, molecule1, molecule2]
+  default_phase_change:
+    type: phase-change
+    phases:
+      solvent1:
+        <<: *default_absolute_solvent_phase
+        components: [solvent1, molecule]
+      solvent2:
+        <<: *default_absolute_solvent_phase
+        components: [solvent2, molecule]
+
+  # User-defined protocols
+  # ----------------------
+  my_absolute_binding:
+    type: absolute-binding
+    phases:
+      my_complex:
+        components: [solvent, receptor, ligand]
+        alchemical_transformation: ligand->null
+        alchemical_protocol: 20states_protocol
+      my_solvent:
+        components: [solvent, ligand]
+        alchemical_transformation: ligand->null
+        alchemical_protocol: 10states_protocol
+        phase_options:
+          repex.niterations: 200
+  my_relative_binding
+    type: relative-binding
+    phases:
+      relative_complex:
+        components: [GBSAobc2, abl-2hyy, imatinib]
+        <<: *imatinib_bosutinib_phase
+      relative_solvent:
+        components: [GBSAobc2, imatinib]
+        <<: *imatinib_bosutinib_phase
+
+
+# The default alchemical factory could be easily inferred from the protocol.
+absolute_experiment:
   components:
     receptor: [abl-2hyy, src]
     ligand: [imatinib, afatinib, bosutinib]
     solvent: [PMEtip3p, RFtip3p, PMEtip4p, GBSAobc1, GBSAobc2]
-  phases: [absolute_binding, absolute_solvation]
+  protocols: my_absolute_binding
 
-# An example of experiment with user-defined phases. The section "components" is not
-# needed here since the user-defined phases use directly molecules
+# An example of relative binding that uses a pre-set protocol. This will be
+# possible only after implementing automatic tuning of alchemical protocol
+# and automatic determination of the alchemical atoms.
 relative_experiment:
-  hmr: [yes, no]
-  phases: [imatinib-bosutinib, bosutinib-afatinib]
-
-# A similar example that uses the section "components"
-customized_experiment:
   components:
     static: abl-2hyy
     molecule1: imatinib
     molecule2: [bosutinib, afatinib]
-    solvent: [PMEtip3p, RFtip3p, PMEtip4p, GBSAobc1, GBSAobc2]
-  phases: [relative_complex1000, relative_complex2000, relative_solvent]
+    solvent: [GBSAobc1, GBSAobc2]
+  protocols: default_relative_binding
 
 # An example of experiment with protein mutations using pre-set phases.
 mutations_experiment:
@@ -167,7 +203,13 @@ mutations_experiment:
     molecule1: abl-2hyy
     molecule2: [abl-2hyy:VAL31ALA, abl-2hyy:ASP137ASH]
     solvent: vacuum
-  phases: [relative_binding, relative_solvation]
+  phases: default_relative_binding
 
-experiments: [basic_experiment, relative_experiment, customized_experiment]
+# In this example the section "components" is not needed here since the
+# user-defined phases here use precise solvents and molecules
+custom_experiment:
+  alchemical_factory: mymodule.MyAlchemicalFactory
+  hmr: [yes, no]
+  protocols: my_relative_binding
 
+experiments: [absolute_experiment, relative_experiment, mutations_experiment, custom_experiment]

--- a/examples/yank.yaml
+++ b/examples/yank.yaml
@@ -221,6 +221,10 @@ mutations_experiment:
 custom_experiment:
   alchemical_factory: mymodule.MyAlchemicalFactory
   hmr: [yes, no]
+  constraints: [HBonds, AllBonds]
+  thermodynamics:
+    temperature: 300*kelvin
+    pressure: 1*atmosphere
   protocols: my_relative_binding
 
 experiments: [absolute_experiment, relative_experiment, mutations_experiment, custom_experiment]

--- a/examples/yank.yaml
+++ b/examples/yank.yaml
@@ -220,7 +220,7 @@ mutations_experiment:
 # user-defined phases here use precise solvents and molecules
 custom_experiment:
   alchemical_factory: mymodule.MyAlchemicalFactory
-  hmr: [yes, no]
+  hydrogenMass: [3*amu, 5*amu]
   constraints: [HBonds, AllBonds]
   thermodynamics:
     temperature: 300*kelvin

--- a/examples/yank.yaml
+++ b/examples/yank.yaml
@@ -15,6 +15,7 @@ options:
     mpi: yes
     platform: CUDA
     precision: mixed
+    resume: yes
   yank:
     restraint_type: harmonic
     randomize_ligand: yes
@@ -24,7 +25,7 @@ options:
     timestep: 1.0 * femtoseconds
     nsteps_per_iteration: 2500
     number_of_iterations: 1000
-    equilibration_timestep = 1.0*femtoseconds
+    equilibration_timestep: 1.0*femtoseconds
     number_of_equilibration_iterations: 100
     online_analysis: no
   alchemy:

--- a/examples/yank.yaml
+++ b/examples/yank.yaml
@@ -10,13 +10,23 @@ metadata:
 
 # Separate options / yank block, or put all yank/repex/alchemy at base level?
 options:
+  yamlbuilder:
+    verbose: true
+    mpi: yes
+    platform: CUDA
+    precision: mixed
   yank:
+    restraint_type: harmonic
+    randomize_ligand: yes
     minimize: yes
     output_directory: /path/to/output/
   repex:
     timestep: 1.0 * femtoseconds
     nsteps_per_iteration: 2500
-    niterations: 1000
+    number_of_iterations: 1000
+    equilibration_timestep = 1.0*femtoseconds
+    number_of_equilibration_iterations: 100
+    online_analysis: no
   alchemy:
     annihilate_sterics: False
     annihilate_electrostatics: True
@@ -50,7 +60,7 @@ solvents:
     nonbondedMethod: NoCutoff
   PMEtip3p:
     nonbondedMethod: PME
-    solvate: PME
+    nonbondedCutoff: 1*nanometer
     solventmodel: tip3p
     salt:
       NaCl: 150*millimolar
@@ -65,6 +75,7 @@ solvents:
     clearance: 10*angstroms
   PMEtip4p:
     nonbondedMethod: PME
+    nonbondedCutoff: 1.2*nanometer
     solventmodel: tip4p
     salt:
       KCl: 150*millimolar


### PR DESCRIPTION
I figured it would be clearer to discuss few small use cases rather than a single monolithic one so I created a YAML cookbook.

Here's a possible pseudocode that matches the info in the YAML file to the code steps.

1. Unroll the experiment section of the YAML file
2. Create appropriate output folder(s).
  * A possibility here is to create a folder for each experiment and a subfolder (cleverly named) for each combination. The general molecule files created during setup should be kept in a single folder to avoid creating the same files in multiple places during combinatorial experiments.
3. Match the components described in the phases (ligand, receptor, imatinib, PMEtip3p)
  * Check both in section `molecules` and in `experiment.components`
  * Output a single experiment where molecules/solvents have been uniquely identified
4. Create a reference system for each phase
  * If the user has specified the prmtop/inpcrd (or gro/top) files we can use directly OpenMM
  * Otherwise parametrize, charge the molecule with `openmmtools` as specified in `molecule.parameters` and/or `molecule.charge`
  * Create the systems as specified in `experiment.setup` (e.g. `leap` or `systembuilder`)
  * In the future, at this point we could generate protonation states, add mutations and perform loop refinement.
5. Compute `atom_indices` as specified in `molecule.select`. If we built the system from leap or systembuilder we should already know how to select them.
6. For relative calculations we need to load the final ligand specified in `alchemical_transformation:ligand1->ligand2`.
7. Create thermodynamic state according to `experiment.thermodynamics`
8. Inizialize `Yank` and configure it with the alchemical factory object specified in `experiment.alchemical_factory`.
9. Call `yank.create()` with YAML `options` and `phases`, `systems`, `positions`, `atom_indices`, `thermodynamic_states` created. Setup the platform, precision, mpi, verbose according to `options.yamlbuilder` and call `yank.run()`.

About maximizing the use of unrolling argument idioms in the phase description. This will probably be highly dependent on the future alchemy classes API (which should probably be designed independently), but in general I think a good compromise between YAML clarity and ease of implementation would be to group the API arguments in a single YAML key (here `alchemical_protocol`). Something like
```yaml
phases:
  complex: &complex_phase
    components: [PMEtip3p, abl, imatinib]
    alchemical_transformation: imatinib->bosutinib
    alchemical_protocol:
      lambda_electrostatics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
      lambda_sterics: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
      molecule1_dummy_atoms_indices: [12, 13]  # imatinib dummy atoms
      molecule2_dummy_atoms_indices: [14]  # bosutinib dummy atoms
      transform_atoms_indices: [[15, 16], [16, 17]]  # couples of imatinib-bosutinib atoms
      any_other_API_parameter: value
```
The code then would look like
```python
experiments = CombinatorialTree(yaml.load('yank.yaml'))
for exp in experiments:
    # Do steps 2-7
    # To create the systems and load the final molecule object in relative calculations, we will
    # have to parse and process phase.components and phase.alchemical_transformation here
    yank = Yank(exp['options'])
    AlchemyClass = getattr('alchemymodule', exp['alchemical_factory'])
    yank.alchemy = AlchemyClass()

    # Isolate the 'alchemical_protocol' dictionary to pass to Yank.create()
    phases = {phase_name: phase['alchemical_protocol'] for phase_name, phase in exp['phases'].iteritems()}
    yank.create(systems, positions, ..., phases)
```
This way we could easily modify YAML syntax and API without changing the parsing code.

For now, I don't think we need to be specific about the syntax details for features that haven't been implemented yet in Yank, as long as we find a general structure that we like.