### PR TITLE
Implemented new options API

### DIFF
--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -418,9 +418,6 @@ def dispatch_binding(args):
         if phase == 'complex-explicit':
             logger.info("solvent and ions : %9d" % len(atom_indices[phase]['solvent']))
 
-    # Initialize YANK object.
-    yank = Yank(store_dir)
-
     # Set options.
     options = dict()
     if args['--nsteps']:
@@ -469,7 +466,8 @@ def dispatch_binding(args):
         options.update(YamlBuilder(args['--yaml']).options)
 
     # Create new simulation.
-    yank.create(phases, systems, positions, atom_indices, thermodynamic_state, options=options)
+    yank = Yank(store_dir, **options)
+    yank.create(phases, systems, positions, atom_indices, thermodynamic_state)
 
     # Report success.
     return True

--- a/Yank/commands/run.py
+++ b/Yank/commands/run.py
@@ -46,10 +46,8 @@ def dispatch(args):
         mpicomm = MPI.COMM_WORLD
 
     # Configure logger
-    if args['--verbose']:
-        options['verbose'] = True
-    utils.config_root_logger(options['verbose'],
-                             log_file_path=os.path.join(store_directory, 'run.log'), mpicomm=mpicomm)
+    utils.config_root_logger(args['--verbose'], mpicomm=mpicomm,
+                             log_file_path=os.path.join(store_directory, 'run.log'))
 
     if args['--iterations']:
         options['number_of_iterations'] = int(args['--iterations'])

--- a/Yank/commands/run.py
+++ b/Yank/commands/run.py
@@ -30,6 +30,8 @@ from yank import utils
 def dispatch(args):
     from yank.yank import Yank # TODO: Fix this awkward import syntax.
 
+    store_directory = args['--store']
+
     # Set override options.
     options = dict()
 
@@ -79,7 +81,6 @@ def dispatch(args):
                 raise Exception("Platform selection logic is outdated and needs to be updated to add platform '%s'." % platform_name)
 
     # Create YANK object associated with data storage directory.
-    store_directory = args['--store']
     yank = Yank(store_directory, mpicomm=mpicomm, **options)
 
     # Set YANK to resume from the store file.

--- a/Yank/commands/run.py
+++ b/Yank/commands/run.py
@@ -30,10 +30,6 @@ from yank import utils
 def dispatch(args):
     from yank.yank import Yank # TODO: Fix this awkward import syntax.
 
-    # Create YANK object associated with data storage directory.
-    store_directory = args['--store']
-    yank = Yank(store_directory)
-
     # Set override options.
     options = dict()
 
@@ -82,12 +78,16 @@ def dispatch(args):
             else:
                 raise Exception("Platform selection logic is outdated and needs to be updated to add platform '%s'." % platform_name)
 
+    # Create YANK object associated with data storage directory.
+    store_directory = args['--store']
+    yank = Yank(store_directory, mpicomm=mpicomm, **options)
+
     # Set YANK to resume from the store file.
     phases = None # By default, resume from all phases found in store_directory
     if args['--phase']: phases=[args['--phase']]
     yank.resume(phases=phases)
 
     # Run simulation.
-    yank.run(mpicomm=mpicomm, options=options)
+    yank.run()
 
     return True

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -521,10 +521,28 @@ class ReplicaExchange(object):
 
     """
 
+    default_parameters = {'collision_rate': 5.0 / unit.picosecond,
+                          'constraint_tolerance': 1.0e-6,
+                          'timestep': 2.0 * unit.femtosecond,
+                          'nsteps_per_iteration': 500,
+                          'number_of_iterations': 1,
+                          'equilibration_timestep': 1.0 * unit.femtosecond,
+                          'number_of_equilibration_iterations': 1,
+                          'title': 'Replica-exchange simulation created using ReplicaExchange class of repex.py on %s' % time.asctime(time.localtime()),
+                          'minimize': True,
+                          'minimize_tolerance': 1.0 * unit.kilojoules_per_mole / unit.nanometers,  # if specified, set minimization tolerance
+                          'minimize_maxIterations': 0,  # if nonzero, set maximum iterations
+                          'replica_mixing_scheme': 'swap-all',  # mix all replicas thoroughly
+                          'online_analysis': False,  # if True, analysis will occur each iteration
+                          'online_analysis_min_iterations': 20,  # minimum number of iterations needed to begin online analysis, if requested
+                          'show_energies': True,
+                          'show_mixing_statistics': True
+                          }
+
     # Options to store.
     options_to_store = ['collision_rate', 'constraint_tolerance', 'timestep', 'nsteps_per_iteration', 'number_of_iterations', 'equilibration_timestep', 'number_of_equilibration_iterations', 'title', 'minimize', 'replica_mixing_scheme', 'online_analysis', 'show_mixing_statistics']
 
-    def __init__(self, store_filename, mpicomm=None, mm=None):
+    def __init__(self, store_filename, mpicomm=None, mm=None, **kwargs):
         """
         Initialize replica-exchange simulation facility.
 
@@ -550,25 +568,16 @@ class ReplicaExchange(object):
 
         # Set default options.
         # These can be changed externally until object is initialized.
-        self.collision_rate = 5.0 / unit.picosecond
-        self.constraint_tolerance = 1.0e-6
-        self.timestep = 2.0 * unit.femtosecond
-        self.nsteps_per_iteration = 500
-        self.number_of_iterations = 1
-        self.equilibration_timestep = 1.0 * unit.femtosecond
-        self.number_of_equilibration_iterations = 1
-        self.title = 'Replica-exchange simulation created using ReplicaExchange class of repex.py on %s' % time.asctime(time.localtime())
-        self.minimize = True
-        self.minimize_tolerance = 1.0 * unit.kilojoules_per_mole / unit.nanometers # if specified, set minimization tolerance
-        self.minimize_maxIterations = 0 # if nonzero, set maximum iterations
         self.platform = None
         self.platform_name = None
         self.integrator = None # OpenMM integrator to use for propagating dynamics
-        self.replica_mixing_scheme = 'swap-all' # mix all replicas thoroughly
-        self.online_analysis = False # if True, analysis will occur each iteration
-        self.online_analysis_min_iterations = 20 # minimum number of iterations needed to begin online analysis, if requested
-        self.show_energies = True
-        self.show_mixing_statistics = True
+
+        # Initialize keywords parameters and check for unknown keywords parameters
+        for par, default in self.default_parameters.items():
+            setattr(self, par, kwargs.pop(par, default))
+        if kwargs:
+            raise TypeError('got an unexpected keyword arguments {}'.format(
+                ', '.join(kwargs.keys())))
 
         # Record store file filename
         self.store_filename = store_filename

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -60,7 +60,6 @@ from simtk import openmm
 from simtk import unit
 
 import os, os.path
-import sys
 import math
 import copy
 import time

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -470,6 +470,25 @@ class ReplicaExchange(object):
        Scheme used to swap replicas: 'swap-all' or 'swap-neighbors' (default: 'swap-all')
     online_analysis : bool
        If True, analysis will occur each iteration (default: False)
+    title : str
+       Title for the simulation.
+    minimize : bool
+       Minimize configurations before running the simulation (default: True)
+    minimize_tolerance : simtk.unit.Quantity (units: energy/mole/length)
+       Set minimization tolerance (default: 1.0 * unit.kilojoules_per_mole / unit.nanometers).
+    minimize_maxIterations : int
+       Maximum number of iterations for minimization.
+    replica_mixing_scheme : str
+       Specify how to mix replicas. Supported schemes are 'swap-neighbors' and
+       'swap-all' (default: 'swap-all').
+    online_analysis : bool
+       If True, analysis will occur each iteration (default: False).
+    online_analysis_min_iterations : int
+       Minimum number of iterations needed to begin online analysis (default: 20).
+    show_energies : bool
+       If True, will print energies at each iteration (default: True).
+    show_mixing_statistics : bool
+       If True, will show mixing statistics at each iteration (default: True).
 
     TODO
     ----
@@ -529,11 +548,11 @@ class ReplicaExchange(object):
                           'number_of_equilibration_iterations': 1,
                           'title': 'Replica-exchange simulation created using ReplicaExchange class of repex.py on %s' % time.asctime(time.localtime()),
                           'minimize': True,
-                          'minimize_tolerance': 1.0 * unit.kilojoules_per_mole / unit.nanometers,  # if specified, set minimization tolerance
-                          'minimize_maxIterations': 0,  # if nonzero, set maximum iterations
-                          'replica_mixing_scheme': 'swap-all',  # mix all replicas thoroughly
-                          'online_analysis': False,  # if True, analysis will occur each iteration
-                          'online_analysis_min_iterations': 20,  # minimum number of iterations needed to begin online analysis, if requested
+                          'minimize_tolerance': 1.0 * unit.kilojoules_per_mole / unit.nanometers,
+                          'minimize_maxIterations': 0,
+                          'replica_mixing_scheme': 'swap-all',
+                          'online_analysis': False,
+                          'online_analysis_min_iterations': 20,
                           'show_energies': True,
                           'show_mixing_statistics': True
                           }
@@ -553,6 +572,11 @@ class ReplicaExchange(object):
            OpenMM API implementation to use
         mpicomm : mpi4py communicator, optional, default=None
            MPI communicator, if parallel execution is desired
+
+        Other Parameters
+        ----------------
+        **kwargs
+            Parameters in ReplicaExchange.default_parameters corresponding public attributes.
 
         """
         # To allow for parameters to be modified after object creation, class is not initialized until a call to self._initialize().

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -26,6 +26,8 @@ import scipy.integrate
 import simtk.openmm as openmm
 import simtk.unit as units
 
+from nose import tools
+
 from openmmtools import testsystems
 
 from yank.repex import ThermodynamicState, ReplicaExchange, HamiltonianExchange, ParallelTempering
@@ -386,6 +388,16 @@ def test_hamiltonian_exchange(mpicomm=None, verbose=True):
 
     if verbose: print "PASSED."
     return
+
+@tools.raises(TypeError)
+def test_parameters():
+    # Check that default parameters initialization
+    repex = ReplicaExchange(store_filename='test', nsteps_per_iteration=1e6)
+    assert repex.nsteps_per_iteration == 1000000
+    assert repex.collision_rate == repex.default_parameters['collision_rate']
+
+    # Check that unknown parameters throw exception
+    ReplicaExchange(store_filename='test', wrong_parameter=False)
 
 #=============================================================================================
 # MAIN AND TESTS

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -389,16 +389,15 @@ def test_hamiltonian_exchange(mpicomm=None, verbose=True):
     if verbose: print "PASSED."
     return
 
-@tools.raises(TypeError)
 def test_parameters():
     """Test ReplicaExchange parameters initialization."""
-
-    # Check that default parameters initialization
     repex = ReplicaExchange(store_filename='test', nsteps_per_iteration=1e6)
     assert repex.nsteps_per_iteration == 1000000
     assert repex.collision_rate == repex.default_parameters['collision_rate']
 
-    # Check that unknown parameters throw exception
+@tools.raises(TypeError)
+def test_unknown_parameters():
+    """Test ReplicaExchange raises exception on wrong initialization."""
     ReplicaExchange(store_filename='test', wrong_parameter=False)
 
 #=============================================================================================

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -391,6 +391,8 @@ def test_hamiltonian_exchange(mpicomm=None, verbose=True):
 
 @tools.raises(TypeError)
 def test_parameters():
+    """Test ReplicaExchange parameters initialization."""
+
     # Check that default parameters initialization
     repex = ReplicaExchange(store_filename='test', nsteps_per_iteration=1e6)
     assert repex.nsteps_per_iteration == 1000000

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -86,13 +86,15 @@ def test_validate_parameters():
 
     # Convert float, length and time
     convert_pars = {
+        'bool': True,
         'int': 3.0,
         'length': '1.0*nanometers',
         'time': '1.0*femtoseconds'
     }
     convert_pars = validate_parameters(convert_pars, template_pars,
                                        process_units_str=True, float_to_int=True)
-    assert isinstance(convert_pars['int'], int)
+    assert type(convert_pars['bool']) is bool
+    assert type(convert_pars['int']) is int
     assert convert_pars['length'] == 1.0 * unit.nanometers
     assert convert_pars['time'] == 1.0 * unit.femtoseconds
 

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -9,7 +9,8 @@ Test various utility functions.
 # GLOBAL IMPORTS
 #=============================================================================================
 
-from yank.utils import YankOptions, CombinatorialTree, is_iterable_container
+from nose import tools
+from yank.utils import *
 
 #=============================================================================================
 # TESTING FUNCTIONS
@@ -59,6 +60,57 @@ def test_expand_tree():
               {'simple': {'scalar': 1, 'vector': 4, 'nested': {'leaf': 'b'}}},
               {'simple': {'scalar': 1, 'vector': 4, 'nested': {'leaf': 'c'}}}]
     assert result == [exp for exp in simple_tree]
+
+def test_validate_parameters():
+    """Test validate_parameters function."""
+
+    template_pars = {
+        'bool': True,
+        'int': 2,
+        'float': 1e4,
+        'str': 'default',
+        'length': 2.0 * unit.nanometers,
+        'time': 2.0 * unit.femtoseconds
+    }
+    input_pars = {
+        'bool': False,
+        'int': 4,
+        'float': 3.0,
+        'str': 'input',
+        'length': 1.0 * unit.nanometers,
+        'time': 1.0 * unit.femtoseconds
+    }
+
+    # Accept correct parameters
+    assert input_pars == validate_parameters(input_pars, template_pars)
+
+    # Convert float, length and time
+    convert_pars = {
+        'int': 3.0,
+        'length': '1.0*nanometers',
+        'time': '1.0*femtoseconds'
+    }
+    convert_pars = validate_parameters(convert_pars, template_pars,
+                                       process_units_str=True, float_to_int=True)
+    assert isinstance(convert_pars['int'], int)
+    assert convert_pars['length'] == 1.0 * unit.nanometers
+    assert convert_pars['time'] == 1.0 * unit.femtoseconds
+
+@tools.raises(ValueError)
+def test_incompatible_parameters():
+    """Check that validate_parameters raises exception with unknown parameter."""
+    template_pars = {'int': 3}
+    wrong_pars = {'int': 3.0}
+    validate_parameters(wrong_pars, template_pars)
+
+@tools.raises(TypeError)
+def test_unknown_parameters():
+    """Test that validate_parameters() raises exception with unknown parameter."""
+    template_pars = {'known_par': 3}
+    wrong_pars = {'unknown_par': 3}
+    validate_parameters(wrong_pars, template_pars, check_unknown=True)
+
+
 
 def test_yank_options():
     """Test option priorities and handling."""

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -96,6 +96,9 @@ def test_validate_parameters():
     assert convert_pars['length'] == 1.0 * unit.nanometers
     assert convert_pars['time'] == 1.0 * unit.femtoseconds
 
+    # If check_unknown flag is not True it should not raise an error
+    validate_parameters({'unkown': 0}, template_pars)
+
 @tools.raises(ValueError)
 def test_incompatible_parameters():
     """Check that validate_parameters raises exception with unknown parameter."""

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -51,33 +51,56 @@ def test_yaml_parsing():
     test: 2
     """
     yaml_builder = parse_yaml_str(yaml_content)
-    assert len(yaml_builder.options) == 0
+    assert len(yaml_builder.options) == len(yaml_builder.default_options)
 
     # Correct parsing
     yaml_content = """
     ---
     metadata:
         title: Test YANK YAML YAY!
+
     options:
-        timestep: 2.0 * femtoseconds
+        verbose: true
+        mpi: yes
+        platform: CUDA
+        precision: mixed
+        resume: true
+        output_directory: /path/to/output/
+        restraint_type: harmonic
+        randomize_ligand: yes
+        randomize_ligand_sigma_multiplier: 2.0
+        randomize_ligand_close_cutoff: 1.5 * angstrom
+        mc_displacement_sigma: 10.0 * angstroms
+        collision_rate: 5.0 / picosecond
+        constraint_tolerance: 1.0e-6
+        timestep: 2.0 * femtosecond
         nsteps_per_iteration: 2500
-        number_of_iterations: 10
-        minimize: false
-        equilibrate: yes
-        equilibration_timestep: 1.0 * femtoseconds
-        number_of_equilibration_iterations: 1000
+        number_of_iterations: 1000.999
+        equilibration_timestep: 1.0 * femtosecond
+        number_of_equilibration_iterations: 100
+        minimize: False
+        minimize_tolerance: 1.0 * kilojoules_per_mole / nanometers
+        minimize_maxIterations: 0
+        replica_mixing_scheme: swap-all
+        online_analysis: no
+        online_analysis_min_iterations: 20
+        show_energies: True
+        show_mixing_statistics: yes
     """
 
     yaml_builder = parse_yaml_str(yaml_content)
-    assert len(yaml_builder.options) == 8
-    assert yaml_builder.options['title'] == 'Test YANK YAML YAY!'
+    assert len(yaml_builder.options) == 27
+
+    # Check correct types
+    assert yaml_builder.options['replica_mixing_scheme'] == 'swap-all'
     assert yaml_builder.options['timestep'] == 2.0 * unit.femtoseconds
+    assert yaml_builder.options['constraint_tolerance'] == 1.0e-6
     assert yaml_builder.options['nsteps_per_iteration'] == 2500
-    assert yaml_builder.options['number_of_iterations'] == 10
+    assert type(yaml_builder.options['nsteps_per_iteration']) is int
+    assert yaml_builder.options['number_of_iterations'] == 1000
+    assert type(yaml_builder.options['number_of_iterations']) is int
     assert yaml_builder.options['minimize'] is False
-    assert yaml_builder.options['equilibrate'] is True
-    assert yaml_builder.options['equilibration_timestep'] == 1.0 * unit.femtoseconds
-    assert yaml_builder.options['number_of_equilibration_iterations'] == 1000
+    assert yaml_builder.options['show_mixing_statistics'] is True
 
 @raises(YamlParseError)
 def test_yaml_unknown_options():
@@ -96,6 +119,6 @@ def test_yaml_wrong_option_value():
     yaml_content = """
     ---
     options:
-        equilibrate: 1000
+        minimize: 100
     """
     parse_yaml_str(yaml_content)

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -134,8 +134,8 @@ def notest_LennardJonesPair(box_width_nsigma=6.0):
     atom_indices = { 'complex-explicit' : { 'ligand' : [1] } }
 
     # Create new simulation.
-    yank = Yank(store_dir)
-    yank.create(phases, systems, positions, atom_indices, thermodynamic_state, options=options, protocols=protocols)
+    yank = Yank(store_dir, **options)
+    yank.create(phases, systems, positions, atom_indices, thermodynamic_state, protocols=protocols)
 
     # Run the simulation.
     yank.run()

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -34,6 +34,8 @@ import numpy as np
 from simtk import openmm
 from openmmtools import testsystems
 
+from nose import tools
+
 from yank import Yank
 from yank.repex import ThermodynamicState
 
@@ -50,6 +52,15 @@ kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA # Boltzmann constant
 #=============================================================================================
 # MAIN AND TESTS
 #=============================================================================================
+
+@tools.raises(TypeError)
+def test_parameters():
+    # Check that both Yank and Repex parameters are accepted
+    Yank(store_directory='test', restraint_type='harmonic', nsteps_per_iteration=1)
+
+    # Check that unknown parameters raise exception
+    Yank(store_directory='test', wrong_parameter=False)
+
 
 def notest_LennardJonesPair(box_width_nsigma=6.0):
     """

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -53,14 +53,15 @@ kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA # Boltzmann constant
 # MAIN AND TESTS
 #=============================================================================================
 
-@tools.raises(TypeError)
 def test_parameters():
     """Test Yank parameters initialization."""
 
     # Check that both Yank and Repex parameters are accepted
     Yank(store_directory='test', restraint_type='harmonic', nsteps_per_iteration=1)
 
-    # Check that unknown parameters raise exception
+@tools.raises(TypeError)
+def test_unknown_parameters():
+    """Test whether Yank raises exception on wrong initialization."""
     Yank(store_directory='test', wrong_parameter=False)
 
 

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -55,6 +55,8 @@ kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA # Boltzmann constant
 
 @tools.raises(TypeError)
 def test_parameters():
+    """Test Yank parameters initialization."""
+
     # Check that both Yank and Repex parameters are accepted
     Yank(store_directory='test', restraint_type='harmonic', nsteps_per_iteration=1)
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -491,7 +491,7 @@ def validate_parameters(parameters, template_parameters, check_unknown=False,
                      if par in template_parameters}
 
     # Check for unknown parameters
-    if len(validated_par) < len(parameters):
+    if check_unknown and len(validated_par) < len(parameters):
         diff = set(parameters) - set(template_parameters)
         raise TypeError("found unknown parameter {}".format(', '.join(diff)))
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -499,16 +499,14 @@ def validate_parameters(parameters, template_parameters, check_unknown=False,
         templ_value = template_parameters[par]
 
         # Convert requested types
-        if float_to_int and isinstance(templ_value, int):
+        # bool inherits from int in Python so we can't simply use isinstance
+        if float_to_int and type(templ_value) is int:
             validated_par[par] = int(value)
         elif process_units_str and isinstance(templ_value, unit.Quantity):
-            if templ_value.unit.is_compatible(unit.seconds):
-                validated_par[par] = process_unit_bearing_str(value, unit.seconds)
-            elif templ_value.unit.is_compatible(unit.meters):
-                validated_par[par] = process_unit_bearing_str(value, unit.meters)
+            validated_par[par] = process_unit_bearing_str(value, templ_value.unit)
 
         # Check for incompatible types
-        if type(validated_par[par]) != type(templ_value):
+        if type(validated_par[par]) != type(templ_value) and templ_value is not None:
             raise ValueError("parameter {}={} is incompatible with {}".format(
                 par, validated_par[par], template_parameters[par]))
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -58,8 +58,31 @@ class Yank(object):
         ----------
         store_directory : str
            The storage directory in which output NetCDF files are read or written.
-        mpicomm : MPI communicator, optional, default=None
+        mpicomm : MPI communicator, optional
            If an MPI communicator is passed, an MPI simulation will be attempted.
+        restraint_type : str, optional
+           Restraint type to add between protein and ligand. Supported types are
+           'flat-bottom' and 'harmonic'. The second one is available only in
+           implicit solvent (default: 'flat-bottom').
+        randomize_ligand : bool, optional
+           Randomize ligand position when True. Not available in explicit solvent
+           (default: False).
+        randomize_ligand_close_cutoff : simtk.unit.Quantity (units: length), optional
+           Cutoff for ligand position randomization (default: 1.5*unit.angstrom).
+        randomize_ligand_sigma_multiplier : float, optional
+           Multiplier for ligand position randomization displacement (default: 2.0).
+        mc_displacement_sigma : simtk.unit.Quantity (units: length), optional
+           Maximum displacement for Monte Carlo moves that augment Langevin dynamics
+           (default: 10.0*unit.angstrom).
+
+        Other Parameters
+        ----------------
+        **kwargs
+           More options to pass to the ReplicaExchange class on initialization.
+
+        See Also
+        --------
+        ReplicaExchange.default_parameters : extra parameters accepted.
 
         """
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -18,7 +18,6 @@ Interface for automated free energy calculations.
 
 import os
 import os.path
-import sys
 import copy
 import glob
 import logging
@@ -29,10 +28,7 @@ import numpy as np
 import simtk.unit as unit
 import simtk.openmm as openmm
 
-from . import sampling, repex, alchemy
-
 from alchemy import AbsoluteAlchemicalFactory
-from repex import ThermodynamicState
 from sampling import ModifiedHamiltonianExchange # TODO: Modify to 'from yank.sampling import ModifiedHamiltonianExchange'?
 from restraints import HarmonicReceptorLigandRestraint, FlatBottomReceptorLigandRestraint
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -365,7 +365,7 @@ class Yank(object):
         simulation = ModifiedHamiltonianExchange(store_filename, mpicomm=self._mpicomm)
         simulation.create(thermodynamic_state, alchemical_states, positions,
                           displacement_sigma=self._mc_displacement_sigma, mc_atoms=mc_atoms,
-                          options=self._repex_options, metadata=metadata)
+                          options=self._repex_parameters, metadata=metadata)
 
         # Initialize simulation.
         # TODO: Use the right scheme for initializing the simulation without running.


### PR DESCRIPTION
Summary:
* Now ``Yank`` and ``ReplicaExchange`` both have a class variable ``default_parameters`` that specifies their options with their respective default value. These parameters are stored as object attributes on initialization.
* Options for both ``Yank`` and ``ReplicaExchange`` are passed on ``__init__`` with ``**kwargs``.
* It is not possible to pass repex options through ``Yank.create()`` and ``Yank.run()`` anymore (BREAKS THE API).
* A generic utility function ``validate_parameters()`` can be used to infer the expected parameter types from the default values specified by the classes, and validate/convert them appropriately, for example
```python
>>> parameters = {  # these could be obtained from YAML options
>>>        'show_energies': True,
>>>        'number_of_iterations': 1.1,
>>>        'timestep': '2.0*femtosecond'
>>>    }
>>> parameters = utils.validate_parameters(parameters, ReplicaExchange.default_parameters,
>>>                           check_unknown=True, process_units_str=True, float_to_int=True)
>>> parameters
... {'show_energies': True, 'number_of_iterations': 1, 'timestep': Quantity(value=2.0, unit=femtosecond)}
```

Local tests almost pass, but the error doesn't seem related to this pull request.