### PR TITLE
Fix storage of scalar options in NetCDF and --randomize-ligand option

### DIFF
--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -466,6 +466,7 @@ def dispatch_binding(args):
         options.update(YamlBuilder(args['--yaml']).options)
 
     # Create new simulation.
+    print options # DEBUG
     yank = Yank(store_dir, **options)
     yank.create(phases, systems, positions, atom_indices, thermodynamic_state)
 

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -466,7 +466,6 @@ def dispatch_binding(args):
         options.update(YamlBuilder(args['--yaml']).options)
 
     # Create new simulation.
-    print options # DEBUG
     yank = Yank(store_dir, **options)
     yank.create(phases, systems, positions, atom_indices, thermodynamic_state)
 

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -1953,7 +1953,7 @@ class ReplicaExchange(object):
             if type(option_value) == unit.Quantity:
                 option_unit = option_value.unit
                 option_value = option_value / option_unit
-            # Store the Python type.            
+            # Store the Python type.
             option_type = type(option_value)
             option_type_name = typename(option_type)
             # Handle booleans
@@ -1994,7 +1994,7 @@ class ReplicaExchange(object):
     def _restore_dict_from_netcdf(self, ncgrp):
         """
         Restore dict from NetCDF.
-        
+
         Parameters
         ----------
         ncgrp : netcdf.Dataset group
@@ -2020,10 +2020,14 @@ class ReplicaExchange(object):
             elif option_ncvar.shape == ():
                 option_value = option_ncvar.getValue()
                 # Cast to python types.
-                if type(option_value) in [np.int32, np.int64]:
+                if type_name == 'bool':
+                    option_value = bool(option_value)
+                elif type_name == 'int':
                     option_value = int(option_value)
-                if type(option_value) in [np.float32, np.float64]:
+                elif type_name == 'float':
                     option_value = float(option_value)
+                elif type_name == 'str':
+                    option_value = str(option_value)
                 logger.debug("Restoring option: %s -> %s (type: %s)" % (option_name, str(option_value), type(option_value)))
             elif (option_ncvar.shape[0] >= 0):
                 option_value = np.array(option_ncvar[:], eval(type_name))
@@ -2087,14 +2091,14 @@ class ReplicaExchange(object):
 
         # Find the group.
         ncgrp_options = ncfile.groups['options']
-        
+
         # Restore options as dict.
         options = self._restore_dict_from_netcdf(ncgrp_options)
 
         # Set these as attributes.
         for option_name in options.keys():
             setattr(self, option_name, options[option_name])
-        
+
         # Signal success.
         return True
 
@@ -2717,4 +2721,3 @@ class HamiltonianExchange(ReplicaExchange):
 if __name__ == "__main__":
     import doctest
     doctest.testmod()
-

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -113,8 +113,8 @@ class Yank(object):
         self.default_protocols['complex-explicit'] = AbsoluteAlchemicalFactory.defaultComplexProtocolExplicit()
 
         # Store Yank parameters
-        for opt, default in self.default_parameters.items():
-            setattr(self, '_' + opt, kwargs.pop(opt, default))
+        for option_name, default_value in self.default_parameters.items():
+            setattr(self, '_' + option_name, kwargs.pop(option_name, default_value))
 
         # Check for unknown parameters
         if not set(kwargs) <= set(ModifiedHamiltonianExchange.default_parameters):
@@ -365,7 +365,7 @@ class Yank(object):
         if self._randomize_ligand and (phase == 'complex-implicit'):
             logger.debug("Randomizing ligand positions and excluding overlapping configurations...")
             randomized_positions = list()
-            nstates = len(systems)
+            nstates = len(alchemical_states)
             for state_index in range(nstates):
                 positions_index = np.random.randint(0, len(positions))
                 current_positions = positions[positions_index]
@@ -541,4 +541,3 @@ class Yank(object):
             results['binding']['dDelta_f'] = np.sqrt(results['solvent']['dDelta_f']**2 + results['complex']['dDelta_f']**2)
 
         return results
-

--- a/examples/p-xylene-implicit/run.sh
+++ b/examples/p-xylene-implicit/run.sh
@@ -19,7 +19,7 @@ yank cleanup --store=output
 
 # Set up calculation.
 echo "Setting up binding free energy calculation..."
-yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose
+yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=$NITERATIONS --restraints=harmonic --gbsa=OBC2 --temperature="300*kelvin" --verbose --randomize-ligand
 
 # Run the simulation with verbose output:
 echo "Running simulation..."


### PR DESCRIPTION
This fixes the storage of scalar options dictionaries in the NetCDF storage, which were not properly being converted back to scalar types.

Also fixes `--randomize-ligand`.
