### PR TITLE
Fix epik penalties parsing, and resume. More MPI debug messages

### DIFF
--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1050,7 +1050,7 @@ def run_epik(input_file_path, output_file_path, max_structures=32, ph=7.0,
     if output_mae and extract_range is None:
         epik_output = output_file_path
     else:
-        epik_output = os.path.splitext(output_file_path)[0] + '.mae'
+        epik_output = os.path.splitext(output_file_path)[0] + '-temp.mae'
 
     # Run epik, we need list in case there's a space in the paths
     # We run with output_dir as working directory to save there the log file

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -105,8 +105,10 @@ def config_root_logger(verbose, log_file_path=None, mpicomm=None):
     else:
         rank = 0
 
-    if rank != 0:
-        log_file_path = None
+    # Create different log files for each MPI process
+    if rank != 0 and log_file_path is not None:
+        basepath, ext = os.path.splitext(log_file_path)
+        log_file_path = '{}_{}{}'.format(basepath, rank, ext)
 
     # Add handler for stdout and stderr messages
     terminal_handler = logging.StreamHandler()

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+import csv
 import copy
 import shutil
 import inspect
@@ -936,11 +937,13 @@ def run_proplister(input_file_path):
     cmd = [proplister_path, '-a', '-c', input_file_path]
     output = subprocess.check_output(cmd)
 
-    # The output is a cvs file with comma separators. The first line are the
-    # property names and then each row are the values for each molecule
-    output = output.split('\n')
-    names = output[0].split(',')
-    values = output[1].split(',')
+    # The output is a cvs file. The first line are the property names and then each row
+    # contains the values for each molecule. We use the csv module to avoid splitting
+    # strings that contain commas (e.g. "2,2-dimethylpropane"). We assume we want only
+    # the tags of the first molecule in the file
+    csv_reader = csv.reader(output.split('\n'))
+    names = csv_reader.next()
+    values = csv_reader.next()
 
     properties = dict(zip(names, values))
     return properties

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -745,7 +745,7 @@ class SetupDatabase:
         """
 
         for mol_id in args:
-            net_formal_charge = None  # used by antechamber
+            net_charge = None  # used by antechamber
             mol_descr = self.molecules[mol_id]
 
             # Have we already processed this molecule? Do we have to do it at all?
@@ -837,9 +837,8 @@ class SetupDatabase:
                                extract_range=epik_idx)
                 utils.run_structconvert(epik_sdf_file, epik_mol2_file)
 
-                # Save new net charge, i_epik_Tot_Q property is a float string
-                net_formal_charge = utils.run_proplister(epik_sdf_file)['i_epik_Tot_Q']
-                net_formal_charge = int(round(float(net_formal_charge)))
+                # Save new net charge from the i_epik_Tot_Q property
+                net_charge = int(utils.run_proplister(epik_sdf_file)['i_epik_Tot_Q'])
 
                 # Keep filepath consistent
                 mol_descr['filepath'] = epik_mol2_file
@@ -866,7 +865,7 @@ class SetupDatabase:
                 input_mol_path = os.path.abspath(mol_descr['filepath'])
                 with utils.temporary_cd(mol_dir):
                     openmoltools.amber.run_antechamber(mol_id, input_mol_path,
-                                                       net_charge=net_formal_charge)
+                                                       net_charge=net_charge)
 
                 # Save new parameters paths
                 mol_descr['filepath'] = os.path.join(mol_dir, mol_id + '.gaff.mol2')

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1742,10 +1742,12 @@ class YamlBuilder:
 
         # Create directory and configure logger for this experiment
         results_dir = self._get_experiment_dir(exp_opts, experiment_dir)
+        resume = os.path.isdir(results_dir)
         if self._mpicomm is None or self._mpicomm.rank == 0:
-            if not os.path.isdir(results_dir):
+            if not resume:
                 os.makedirs(results_dir)
-            resume = self._check_resume_experiment(results_dir)
+            else:
+                resume = self._check_resume_experiment(results_dir)
         if self._mpicomm:  # process 0 send result to other processes
             resume = self._mpicomm.bcast(resume, root=0)
         utils.config_root_logger(exp_opts['verbose'], os.path.join(results_dir, exp_name + '.log'),

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -836,8 +836,9 @@ class SetupDatabase:
                                extract_range=epik_idx)
                 utils.run_structconvert(epik_sdf_file, epik_mol2_file)
 
-                # Save new net charge
-                net_formal_charge = int(utils.run_proplister(epik_sdf_file)['i_epik_Tot_Q'])
+                # Save new net charge, i_epik_Tot_Q property is a float string
+                net_formal_charge = utils.run_proplister(epik_sdf_file)['i_epik_Tot_Q']
+                net_formal_charge = int(round(float(net_formal_charge)))
 
                 # Keep filepath consistent
                 mol_descr['filepath'] = epik_mol2_file

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -831,11 +831,17 @@ class SetupDatabase:
             # Enumerate protonation states with epik
             if 'epik' in mol_descr:
                 epik_idx = mol_descr['epik']
-                epik_mol2_file = os.path.join(mol_dir, mol_id + '-epik.mol2')
-                epik_sdf_file = os.path.join(mol_dir, mol_id + '-epik.sdf')
-                utils.run_epik(mol_descr['filepath'], epik_sdf_file, tautomerize=True,
+                epik_base_path = os.path.join(mol_dir, mol_id + '-epik.')
+                epik_mae_file = epik_base_path + 'mae'
+                epik_mol2_file = epik_base_path + 'mol2'
+                epik_sdf_file = epik_base_path + 'sdf'
+
+                # Run epik and convert from maestro to both mol2 and sdf
+                # to not lose neither the penalties nor the residue name
+                utils.run_epik(mol_descr['filepath'], epik_mae_file, tautomerize=True,
                                extract_range=epik_idx)
-                utils.run_structconvert(epik_sdf_file, epik_mol2_file)
+                utils.run_structconvert(epik_mae_file, epik_sdf_file)
+                utils.run_structconvert(epik_mae_file, epik_mol2_file)
 
                 # Save new net charge from the i_epik_Tot_Q property
                 net_charge = int(utils.run_proplister(epik_sdf_file)['i_epik_Tot_Q'])


### PR DESCRIPTION
Various minor fixes:
* Fix epik penalties parsing.
* Fix ``resume_simulation`` when nc files don't exist.
* Non-root nodes do not print debug messages on ``stdout``, but now each non-root node create a separate log file so that we can still keep track of what happens in non-root processes.

The PR should be ready to be merged unless somebody has objections.