### PR TITLE
Alchemically modify ligand-neutralizing counterions

### DIFF
--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -116,7 +116,7 @@ def setup_binding_amber(args):
         system_parameters['nonbondedCutoff'] = process_unit_bearing_arg(args, '--cutoff', unit.nanometers)
 
     # Prepare phases of calculation.
-    return pipeline.prepare_amber(setup_directory, args['--ligand'], system_parameters, verbose)
+    return pipeline.prepare_amber(setup_directory, args['--ligand'], system_parameters, verbose=verbose)
 
 def setup_binding_gromacs(args):
     """

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -20,8 +20,6 @@ logger = logging.getLogger(__name__)
 import mdtraj
 from simtk import openmm
 
-from repex import ThermodynamicState
-
 #=============================================================================================
 # UTILITY FUNCTIONS
 #=============================================================================================

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -48,27 +48,36 @@ _SOLVENT_RESNAMES = frozenset(['118', '119', '1AL', '1CU', '2FK', '2HP', '2OF', 
         'TRA', 'UNX', 'V', 'V2+', 'VN3', 'VO4', 'W', 'WO5', 'Y1', 'YB', 'YB2',
         'YH', 'YT3', 'ZN', 'ZN2', 'ZN3', 'ZNA', 'ZNO', 'ZO3'])
 
-def find_components(topology, ligand_dsl, solvent_resnames=_SOLVENT_RESNAMES):
-    """
-    Return list of receptor and ligand atoms.
+
+def find_components(topology, ligand_dsl, ligand_net_charge=0,
+                    solvent_resnames=_SOLVENT_RESNAMES):
+    """Determine the atom indices of the system components.
+
     Ligand atoms are specified through MDTraj domain-specific language (DSL),
-    while receptor atoms are everything else excluding water.
+    while receptor atoms are everything else excluding solvent.
+
+    If ligand_net_charge is non-zero, the function also isolates the indices
+    of ligand-neutralizing counterions in the 'ligand_counterions' component.
 
     Parameters
     ----------
     topology : mdtraj.Topology, simtk.openmm.app.Topology
-       The topology object specifying the system. If simtk.openmm.app.Topology
-       is passed instead this will be converted.
+        The topology object specifying the system. If simtk.openmm.app.Topology
+        is passed instead this will be converted.
     ligand_dsl : str
-       DSL specification of the ligand atoms.
-    solvent_resnames : list of str, optional, default=['WAT', 'TIP', 'HOH']
-       List of solvent residue names to exclude from receptor definition.
+        DSL specification of the ligand atoms.
+    ligand_net_charge : int, optional
+        The net charge of the ligand (default is 0).
+    solvent_resnames : list of str, optional
+        List of solvent residue names to exclude from receptor definition (default
+        is _SOLVENT_RESNAME).
 
     Returns
     -------
     atom_indices : dict of list of int
-       atom_indices[component] is a list of atom indices belonging to that component, where
-       component is one of 'receptor', 'ligand', 'solvent', 'complex'
+        atom_indices[component] is a list of atom indices belonging to that
+        component, where component is one of 'receptor', 'ligand', 'solvent',
+        'complex', and 'ligand_counterions'.
 
     """
     atom_indices = {}
@@ -94,9 +103,27 @@ def find_components(topology, ligand_dsl, solvent_resnames=_SOLVENT_RESNAMES):
                                 if atom.index not in not_receptor_set]
     atom_indices['complex'] = atom_indices['receptor'] + atom_indices['ligand']
 
+    # Isolate ligand-neutralizing counterions
+    if ligand_net_charge != 0:
+        if ligand_net_charge > 0:
+            counterions_set = {name for name in solvent_resnames if '-' in name}
+        elif ligand_net_charge < 0:
+            counterions_set = {name for name in solvent_resnames if '+' in name}
+
+        ligand_counterions = [atom.index for atom in mdtraj_top.atoms
+                              if atom.residue.name in counterions_set]
+        atom_indices['ligand_counterions'] = ligand_counterions[:abs(ligand_net_charge)]
+
+        # Eliminate ligand counterions indices from solvent component
+        atom_indices['solvent'] = [i for i in atom_indices['solvent']
+                                   if i not in atom_indices['ligand_counterions']]
+    else:
+        atom_indices['ligand_counterions'] = []
+
     return atom_indices
 
-def prepare_amber(system_dir, ligand_dsl, system_parameters, verbose=False):
+
+def prepare_amber(system_dir, ligand_dsl, system_parameters, ligand_net_charge=0, verbose=False):
     """Create a system from prmtop and inpcrd files.
 
     Parameters
@@ -107,19 +134,24 @@ def prepare_amber(system_dir, ligand_dsl, system_parameters, verbose=False):
         MDTraj DSL string that specify the ligand atoms.
     system_parameters : dict
         A kwargs dictionary to pass to openmm.app.AmberPrmtopFile.createSystem().
+    ligand_net_charge : int, optional
+       The net charge of the ligand. If non-zero, the function will look in the
+       system for ligand-neutralizing counterions that will be included in atom_indices
+       (default is 0).
     verbose : bool
         Whether or not to log informations (default is False).
 
     Returns
     -------
     phases : list of str
-       Phases (thermodynamic legs) of the calculation.
+        Phases (thermodynamic legs) of the calculation.
     systems : dict
-       systems[phase] is the OpenMM System reference object for phase 'phase'.
+        systems[phase] is the OpenMM System reference object for phase 'phase'.
     positions : dict
-       positions[phase] is a numpy array of positions for initializing replicas.
+        positions[phase] is a numpy array of positions for initializing replicas.
     atom_indices : dict
-       atom_indices[phase][component] is list of atom indices for component 'component' in phase 'phase'.
+        atom_indices[phase][component] is list of atom indices for component 'component'
+        in phase 'phase' as returned by find_components().
 
     """
     systems = {}  # systems[phase] is the System object associated with phase 'phase'
@@ -189,7 +221,7 @@ def prepare_amber(system_dir, ligand_dsl, system_parameters, verbose=False):
             raise RuntimeError(err_msg)
 
         # Find ligand atoms and receptor atoms
-        atom_indices[phase] = find_components(prmtop.topology, ligand_dsl)
+        atom_indices[phase] = find_components(prmtop.topology, ligand_dsl, ligand_net_charge)
 
     phases = systems.keys()
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1153,8 +1153,8 @@ class TLeap:
         components = ' '.join(args)
         self.add_commands('{} = combine {{{{ {} }}}}'.format(group, components))
 
-    def neutralize(self, unit, ion):
-        self.add_commands('addIons2 {} {} 0'.format(unit, ion))
+    def add_ions(self, unit, ion, num_ions=0):
+        self.add_commands('addIons2 {} {} {}'.format(unit, ion, num_ions))
 
     def solvate(self, group, water_model, clearance):
         self.add_commands('solvateBox {} {} {} iso'.format(group, water_model,

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -13,8 +13,8 @@ import collections
 
 from pkg_resources import resource_filename
 
+import mdtraj
 from simtk import unit
-from mdtraj.utils import enter_temp_directory
 
 #========================================================================================
 # Logging functions
@@ -802,6 +802,29 @@ def validate_parameters(parameters, template_parameters, check_unknown=False,
 # Stuff to move to openmoltools when they'll be stable
 #=============================================================================================
 
+
+def get_mol2_net_charge(mol2_file_path):
+    """Compute the sum of the partial charges for a molecule in a mol2 file.
+
+    Note that the mol2 file must indicated the charge of each atom consistently.
+    The function works only for single-structure mol2 files.
+
+    Parameters
+    ----------
+    mol2_file_path : str
+        Path to the mol2 file containing the molecule(s).
+
+    Returns
+    -------
+    net_charge : int
+        The molecule net charge calculated as the sum of its partial charges
+
+    """
+    atoms_frame, _ = mdtraj.formats.mol2.mol2_to_dataframes(mol2_file_path)
+    net_charge = atoms_frame['charge'].sum()
+    return int(round(net_charge))
+
+
 def is_openeye_installed():
     try:
         from openeye import oechem
@@ -1188,7 +1211,7 @@ class TLeap:
                        for local, path in self._file_paths.items()}
         script = self._script.format(**local_files) + 'quit\n'
 
-        with enter_temp_directory():
+        with mdtraj.utils.enter_temp_directory():
             # Copy input files
             for local_file, file_path in input_files.items():
                 shutil.copy(file_path, local_file)

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1801,7 +1801,8 @@ class YamlBuilder:
                 system_dir = self._db.get_system(components, exp_opts['pack'])
 
                 # Get ligand resname for alchemical atom selection
-                ligand_dsl = utils.get_mol2_resname(self._db.molecules[components['ligand']]['filepath'])
+                ligand_descr = self._db.molecules[components['ligand']]
+                ligand_dsl = utils.get_mol2_resname(ligand_descr['filepath'])
                 if ligand_dsl is None:
                     ligand_dsl = 'MOL'
                 ligand_dsl = 'resname ' + ligand_dsl
@@ -1819,7 +1820,8 @@ class YamlBuilder:
                                for opt, value in system_pars.items()}
 
                 # Prepare system
-                phases, systems, positions, atom_indices = pipeline.prepare_amber(system_dir, ligand_dsl, system_pars)
+                phases, systems, positions, atom_indices = pipeline.prepare_amber(system_dir, ligand_dsl,
+                                                                 system_pars, ligand_descr['net_charge'])
 
                 # Create thermodynamic state
                 thermodynamic_state = ThermodynamicState(temperature=exp_opts['temperature'],

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -205,7 +205,8 @@ class Yank(object):
            A dict of positions corresponding to each phase, e.g. positions['solvent'] is a single set of positions or list of positions to seed replicas.
            Shape must be natoms x 3, with natoms matching number of particles in corresponding system.
         atom_indices : dict of dict list of int, optional, default=None
-           atom_indices[phase][component] is a list of atom indices, for each component in ['ligand', 'receptor', 'complex', 'solvent']
+           atom_indices[phase][component] is a list of atom indices, for each component in ['ligand', 'receptor',
+           'complex', 'solvent', 'ligand_counterions']
         thermodynamic_state : ThermodynamicState (System need not be defined), optional, default=None
            Thermodynamic state at which calculations are to be carried out
         protocols : dict of list of AlchemicalState, optional, default=None
@@ -269,7 +270,8 @@ class Yank(object):
         positions : list of simtk.unit.Qunatity objects containing (natoms x 3) positions (as np or lists)
            The list of positions to be used to seed replicas in a round-robin way.
         atom_indices : dict
-           atom_indices[phase][component] is the set of atom indices associated with component, where component is ['ligand', 'receptor']
+           atom_indices[phase][component] is the set of atom indices associated with component, where component
+           is ['ligand', 'receptor', 'complex', 'solvent', 'ligand_counterions']
         thermodynamic_state : ThermodynamicState
            Thermodynamic state from which reference temperature and pressure are to be taken.
         protocols : dict of list of AlchemicalState, optional, default=None
@@ -346,8 +348,11 @@ class Yank(object):
 
         # Create alchemically-modified states using alchemical factory.
         logger.debug("Creating alchemically-modified states...")
-        #factory = AbsoluteAlchemicalFactory(reference_system, ligand_atoms=atom_indices['ligand'], test_positions=positions[0], platform=repex_options['platform']) # DEBUG code for testing
-        factory = AbsoluteAlchemicalFactory(reference_system, ligand_atoms=atom_indices['ligand'],
+        try:
+            alchemical_indices = atom_indices['ligand_counterions'] + atom_indices['ligand']
+        except KeyError:
+            alchemical_indices = atom_indices['ligand']
+        factory = AbsoluteAlchemicalFactory(reference_system, ligand_atoms=alchemical_indices,
                                             **self._alchemy_parameters)
         alchemical_states = protocols[phase]
         alchemical_system = factory.alchemically_modified_system


### PR DESCRIPTION
This PR addresses #345 . Sketch of the implementation:

1. Determine ligand net charge by summing all partial charges in input ``mol2`` file.
2. First add ligand-neutralizing counterions, then add counterions to neutralize the whole solvation box.
3. Add an optional key to [``atom_indices``](https://github.com/choderalab/yank/blob/master/Yank/yank.py#L207-L208): ``atom_indices['ligand_counterions']`` that contains the indices of the ligand-neutralizing counterions.
4. Initialize alchemical factory as ``AbsoluteAlchemicalFactory(ligand_atoms=atom_indices['ligand'] + atom_indices['ligand_counterions'])``