### PR TITLE
Revert to precise travis infrastructure to avoid glibc incompatibilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: c
 sudo: false
-
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+      - g++
+      - gfortran
+      - valgrind
+      - csh
+      - g++-multilib
+      - gcc-multilib
+      
 branches:
   only:
     - master


### PR DESCRIPTION
This attempts to address #346 