### PR TITLE
Epik ph option and bug fixes

### DIFF
--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -110,7 +110,10 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
                 mc_atoms = None
 
         # Store trial displacement magnitude and atoms to rotate in MC move.
-        self.displacement_sigma = 1.0 * unit.nanometer
+        if displacement_sigma is None:
+            self.displacement_sigma = 1.0 * unit.nanometer
+        else:
+            self.displacement_sigma = displacement_sigma
         if mc_atoms is not None:
             self.mc_atoms = np.array(mc_atoms)
             self.mc_displacement = True

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -630,17 +630,26 @@ def test_epik_enumeration():
                 filepath: {}
                 epik: 0
                 parameters: antechamber
-        """.format(tmp_dir, examples_paths()['benzene'])
+            benzene-custom:
+                filepath: {}
+                epik:
+                    extract_range: 0
+                    ph: 7.0
+                    tautomerize: yes
+                parameters: antechamber
+        """.format(tmp_dir, examples_paths()['benzene'], examples_paths()['benzene'])
 
+        mol_ids = ['benzene', 'benzene-custom']
         yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
-        yaml_builder._db._setup_molecules('benzene')
+        yaml_builder._db._setup_molecules(*mol_ids)
 
-        output_basename = os.path.join(tmp_dir, SetupDatabase.MOLECULES_DIR, 'benzene',
-                                       'benzene-epik.')
-        assert os.path.exists(output_basename + 'mol2')
-        assert os.path.getsize(output_basename + 'mol2') > 0
-        assert os.path.exists(output_basename + 'sdf')
-        assert os.path.getsize(output_basename + 'sdf') > 0
+        for mol_id in mol_ids:
+            output_basename = os.path.join(tmp_dir, SetupDatabase.MOLECULES_DIR,
+                                           mol_id, mol_id + '-epik.')
+            assert os.path.exists(output_basename + 'mol2')
+            assert os.path.getsize(output_basename + 'mol2') > 0
+            assert os.path.exists(output_basename + 'sdf')
+            assert os.path.getsize(output_basename + 'sdf') > 0
 
 
 def test_strip_protons():

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -553,6 +553,10 @@ def test_setup_name_smiles_openeye_charges():
             else:  # With antechamber, sqm should alter the charges a little
                 assert not input_charges.equals(output_charges)
 
+        # Check that molecules are resumed correctly
+        yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
+        yaml_builder._db._setup_molecules('toluene', 'p-xylene')
+
 
 @unittest.skipIf(not utils.is_openeye_installed(), 'This test requires OpenEye installed.')
 def test_clashing_atoms():

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -861,7 +861,7 @@ class SetupDatabase:
 
                 # Run epik and convert from maestro to both mol2 and sdf
                 # to not lose neither the penalties nor the residue name
-                omt.schrodinger.run_epik(mol_descr['filepath'], epik_mae_file, tautomerize=True,
+                omt.schrodinger.run_epik(mol_descr['filepath'], epik_mae_file, tautomerize=False,
                                          extract_range=epik_idx)
                 omt.schrodinger.run_structconvert(epik_mae_file, epik_sdf_file)
                 omt.schrodinger.run_structconvert(epik_mae_file, epik_mol2_file)

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -521,9 +521,12 @@ class SetupDatabase:
             all_file_exist &= os.path.isfile(file_path) and os.path.getsize(file_path) > 0
             if all_file_exist:  # Make sure internal description is correct
                 molecule_descr[descr_key] = file_path
-                extension = os.path.splitext(molecule_descr['filepath'])[1]
-                if extension == '.mol2':
-                    molecule_descr['net_charge'] = utils.get_mol2_net_charge(molecule_descr['filepath'])
+
+        # Compute and update small molecule net charge
+        if all_file_exist:
+            extension = os.path.splitext(molecule_descr['filepath'])[1]
+            if extension == '.mol2':
+                molecule_descr['net_charge'] = utils.get_mol2_net_charge(molecule_descr['filepath'])
 
         return all_file_exist, all_file_exist
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -853,16 +853,20 @@ class SetupDatabase:
 
             # Enumerate protonation states with epik
             if 'epik' in mol_descr:
-                epik_idx = mol_descr['epik']
                 epik_base_path = os.path.join(mol_dir, mol_id + '-epik.')
                 epik_mae_file = epik_base_path + 'mae'
                 epik_mol2_file = epik_base_path + 'mol2'
                 epik_sdf_file = epik_base_path + 'sdf'
 
+                # The 'epik' keyword can contain both a dictionary with the
+                # arguments to pass to run_epik(), or just the index
+                epik_args = mol_descr['epik']
+                if not isinstance(epik_args, dict):
+                    epik_args = {'extract_range': epik_args, 'tautomerize': False}
+
                 # Run epik and convert from maestro to both mol2 and sdf
                 # to not lose neither the penalties nor the residue name
-                omt.schrodinger.run_epik(mol_descr['filepath'], epik_mae_file, tautomerize=False,
-                                         extract_range=epik_idx)
+                omt.schrodinger.run_epik(mol_descr['filepath'], epik_mae_file, **epik_args)
                 omt.schrodinger.run_structconvert(epik_mae_file, epik_sdf_file)
                 omt.schrodinger.run_structconvert(epik_mae_file, epik_mol2_file)
 
@@ -1339,7 +1343,7 @@ class YamlBuilder:
         file_formats = set(['mol2', 'sdf', 'pdb', 'smiles', 'csv'])
         sources = set(['filepath', 'name', 'smiles'])
         template_mol = {'filepath': 'str', 'name': 'str', 'smiles': 'str',
-                        'parameters': 'str', 'epik': 0, 'select': 0,
+                        'parameters': 'str', 'epik': None, 'select': 0,
                         'strip_protons': False}
 
         self._db.molecules = yaml_content.get('molecules', {})


### PR DESCRIPTION
* Fixes #359 .
* Fix a bug on resume with molecules generated by name or SMILES (thanks @MehtapIsik for discovering it!).
* Fix a bug that prevented a repex option to be used.

This should be ready to be merged if tests pass.