### PR TITLE
[WIP] Quick band-aid fix for MPI termination

### DIFF
--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -1087,7 +1087,7 @@ class ReplicaExchange(object):
         self._finalize()
 
         if self.mpicomm:
-            # Only the root node needs to clean up.
+            # Only the root node needs to close files.
             if self.mpicomm.rank != 0: return
 
         if hasattr(self, 'ncfile'):


### PR DESCRIPTION
This is a quick band-aid fix to ensure we don't leave straggler processes around after MPI processes receive a `SIGABRT`, `SIGINT`, or `SIGTERM` from Torque.

A much better approach would be to use [context managers](http://stackoverflow.com/questions/865115/how-do-i-correctly-clean-up-a-python-object) to ensure that all files are gracefully synced and closed and MPI is aborted as the program terminates, but this will require some refactoring/redesign. As a result, the current solution may result in some additional data corruption that is hopefully minimized by the fact that NetCDF syncs the files each iteration.