### PR TITLE
Fix travis nosetests attribute syntax error to reactivate tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   # Test the local installation
   - source activate _test
   - conda install --yes --quiet pip nose nose-timer
-  - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-doctest --with-timer -a "\!slow" && cd ..
+  - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-doctest --with-timer -a '!slow' && cd ..
 
 env:
   matrix:

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -21,6 +21,7 @@ import tempfile
 import itertools
 
 from nose.tools import raises
+from nose.plugins.attrib import attr
 
 from yank.yamlbuild import *
 from mdtraj.formats.mol2 import mol2_to_dataframes
@@ -1335,6 +1336,8 @@ def test_yaml_creation():
             for line, expected in zip(f, expected_yaml_content.split('\n')):
                 assert line[:-1] == expected  # without final '\n'
 
+
+@attr('slow')  # Skip on Travis-CI
 def test_run_experiment():
     with utils.temporary_directory() as tmp_dir:
         yaml_content = """

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -750,6 +750,7 @@ class TestMultiMoleculeFiles():
     def teardown_class(cls):
         shutil.rmtree(cls.tmp_dir)
 
+    @unittest.skipIf(not utils.is_openeye_installed(), 'This test requires OpenEye installed.')
     def test_expand_molecules(self):
         """Check that combinatorial molecules are handled correctly."""
         yaml_content = """


### PR DESCRIPTION
Fix #387 

I think there was a subtle error in the syntax used to tell nosetests to skip `slow` tests. Let's see if this fixes it.