### PR TITLE
Set recommended GB radii and expand options for solvent

### DIFF
--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -123,6 +123,43 @@ def find_components(topology, ligand_dsl, ligand_net_charge=0,
     return atom_indices
 
 
+# See Amber manual Table 4.1 http://ambermd.org/doc12/Amber15.pdf
+_OPENMM_TO_TLEAP_PBRADII = {'HCT': 'mbondi', 'OBC1': 'mbondi2', 'OBC2': 'mbondi2',
+                            'GBn': 'bondi', 'GBn2': 'mbondi3'}
+
+def get_leap_recommended_pbradii(implicit_solvent):
+    """Return the recommended PBradii setting for LeAP.
+
+    Parameters
+    ----------
+    implicit_solvent : str
+        The implicit solvent model.
+
+    Returns
+    -------
+    pbradii : str or object
+        The LeAP recommended PBradii for the model.
+
+    Raises
+    ------
+    ValueError
+        If the implicit solvent model is not supported by OpenMM.
+
+    Examples
+    --------
+    >>> get_leap_recommended_pbradii('OBC2')
+    'mbondi2'
+    >>> from simtk.openmm.app import HCT
+    >>> get_leap_recommended_pbradii(HCT)
+    'mbondi'
+
+    """
+    try:
+        return _OPENMM_TO_TLEAP_PBRADII[str(implicit_solvent)]
+    except KeyError:
+        raise ValueError('Implicit solvent {} is not supported.'.format(implicit_solvent))
+
+
 def prepare_amber(system_dir, ligand_dsl, system_parameters, ligand_net_charge=0, verbose=False):
     """Create a system from prmtop and inpcrd files.
 
@@ -226,3 +263,8 @@ def prepare_amber(system_dir, ligand_dsl, system_parameters, ligand_net_charge=0
     phases = systems.keys()
 
     return [phases, systems, positions, atom_indices]
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -293,17 +293,6 @@ def test_no_nonbonded_method():
     """
     YamlBuilder(textwrap.dedent(yaml_content))
 
-@raises(YamlParseError)
-def test_implicit_solvent_consistence():
-    """An exception is raised with NoCutoff and nonbonded_cutoff."""
-    yaml_content = """
-    ---
-    solvents:
-        solvtest:
-            nonbonded_method: NoCutoff
-            nonbonded_cutoff: 3*nanometers
-    """
-    YamlBuilder(textwrap.dedent(yaml_content))
 
 @raises(YamlParseError)
 def test_explicit_solvent_consistence():

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -19,13 +19,14 @@ import sys
 import glob
 import copy
 import yaml
+import inspect
 import logging
 logger = logging.getLogger(__name__)
 
 import numpy as np
 import openmoltools as omt
 from simtk import unit, openmm
-from simtk.openmm.app import PDBFile
+from simtk.openmm.app import PDBFile, AmberPrmtopFile
 from alchemy import AlchemicalState, AbsoluteAlchemicalFactory
 
 import utils
@@ -1840,17 +1841,17 @@ class YamlBuilder:
                 ligand_dsl = 'resname ' + ligand_dsl
                 logger.debug('DSL string for the ligand: "{}"'.format(ligand_dsl))
 
-                # System configuration
-                create_system_filter = set(('nonbonded_method', 'nonbonded_cutoff', 'implicit_solvent',
-                                            'constraints', 'hydrogen_mass'))
+                # System configuration.
+                # OpenMM adopts camel case convention so we need to change the options format.
                 solvent = self._db.solvents[components['solvent']]
-                system_pars = {opt: solvent[opt] for opt in create_system_filter if opt in solvent}
-                system_pars.update({opt: exp_opts[opt] for opt in create_system_filter
-                                    if opt in exp_opts})
-
-                # Convert underscore_parameters to camelCase for OpenMM API
-                system_pars = {utils.underscore_to_camelcase(opt): value
-                               for opt, value in system_pars.items()}
+                options_camelcase = {utils.underscore_to_camelcase(key): value
+                                     for key, value in solvent.items()}
+                options_camelcase.update({utils.underscore_to_camelcase(key): value
+                                          for key, value in exp_opts.items()})
+                # We use inspection to filter the options to pass to createSystem()
+                create_system_args = set(inspect.getargspec(AmberPrmtopFile.createSystem).args)
+                system_pars = {arg: options_camelcase[arg] for arg in create_system_args
+                               if arg in options_camelcase}
 
                 # Prepare system
                 phases, systems, positions, atom_indices = pipeline.prepare_amber(system_dir, ligand_dsl,

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -660,8 +660,10 @@ class SetupDatabase:
         # Configure solvent
         if solvent['nonbonded_method'] == openmm.app.NoCutoff:
             if 'implicit_solvent' in solvent:  # GBSA implicit solvent
+                implicit_solvent = solvent['implicit_solvent']
                 tleap.new_section('Set GB radii to recommended values for OBC')
-                tleap.add_commands('set default PBRadii mbondi2')
+                tleap.add_commands('set default PBRadii {}'.format(
+                    pipeline.get_leap_recommended_pbradii(implicit_solvent)))
         else:  # explicit solvent
             tleap.new_section('Solvate systems')
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1427,11 +1427,7 @@ class YamlBuilder:
 
             # Test solvent consistency
             nonbonded_method = solvent['nonbonded_method']
-            if nonbonded_method == openmm.app.NoCutoff:
-                if 'nonbonded_cutoff' in solvent:
-                    err_msg = ('solvent {} specify both nonbonded_method: NoCutoff and '
-                               'and nonbonded_cutoff').format(solvent_id)
-            else:
+            if nonbonded_method != openmm.app.NoCutoff:
                 if 'implicit_solvent' in solvent:
                     err_msg = ('solvent {} specify both nonbonded_method: {} '
                                'and implicit_solvent').format(solvent_id, nonbonded_method)


### PR DESCRIPTION
In this PR:
* Set GB radii to recommended settings by Amber for the implicit solvent model
* Fix #216 (allow set nonbonded cutoff with implicit solvent)
* Expand YAML solvent options to everything that can be passed to `createSystem()` by using introspection.