### PR TITLE
Keep original ligand conformation during OE charging

### DIFF
--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -739,7 +739,7 @@ class SetupDatabase:
                 molecule = omt.openeye.iupac_to_oemol(mol_descr['name'])
             elif 'smiles' in mol_descr:
                 molecule = omt.openeye.smiles_to_oemol(mol_descr['smiles'])
-            molecule = omt.openeye.get_charges(molecule, keep_confs=1)
+            molecule = omt.openeye.get_charges(molecule, keep_confs=None)
         except ImportError as e:
             error_msg = ('requested molecule generation from name or smiles but '
                          'could not find OpenEye toolkit: ' + str(e))


### PR DESCRIPTION
Fix #402 

If the ligand conformation is already specified, we should force it to avoid moving ligands that should start in the binding pocket.

Waiting for tests to pass.