### PR TITLE
Update installation docs to describe miniconda install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ Documentation and examples can be found at [getyank.org](http://getyank.org)
 Maintainers
 -----------
 
-* John D. Chodera (MSKCC)
-* Patrick B. Grinaway (MSKCC)
-* Arien Sebastian Rustenburg (MSKCC)
+* John D. Chodera `<john.chodera@choderalab.org>` (MSKCC)
+* Andrea Rizzi `<andrea.rizzi@choderalab.org>` (WCMC)
 
 Contributors
 ------------
@@ -26,11 +25,12 @@ Contributors
 * Peter M. Eastman (Stanford)
 * Mark Friedrichs (Stanford)
 * Imran Haque (Stanford)
+* Patrick B. Grinaway (MSKCC)
 * Christoph Klein (University of Virginia)
 * Rosa Luirink (VU Amsterdam)
 * Levi Naden (University of Virginia)
 * Daniel L. Parton (MSKCC)
 * Randy Radmer (Stanford)
-* Andrea Rizzi (WCMC)
+* Arien Sebastian Rustenburg (MSKCC)
 * Michael Shirts (University of Virginia)
 * Kai Wang (University of Virginia)

--- a/docs/acknowledgments.rst
+++ b/docs/acknowledgments.rst
@@ -10,9 +10,8 @@ This is just a partial list of those who have made substantial contributions.
 Maintainers
 -----------
 
-* John D. Chodera (MSKCC)
-* Patrick B. Grinaway (MSKCC)
-* Arien Sebastian Rustenburg (MSKCC)
+* John D. Chodera `<john.chodera@choderalab.org>` (MSKCC)
+* Andrea Rizzi `<andrea.rizzi@choderalab.org>` (WCMC)
 
 Contributors
 ------------
@@ -21,13 +20,13 @@ Contributors
 * Peter M. Eastman (Stanford)
 * Mark Friedrichs (Stanford)
 * Imran Haque (Stanford)
+* Patrick B. Grinaway (MSKCC)
 * Christoph Klein (University of Virginia)
 * Rosa Luirink (VU Amsterdam)
 * Robert McGibbon (Stanford)
 * Levi Naden (University of Virginia)
 * Daniel L. Parton (MSKCC)
 * Randy Radmer (Stanford)
-* Andrea Rizzi (WCMC)
+* Arien Sebastian Rustenburg (MSKCC)
 * Michael Shirts (University of Virginia)
 * Kai Wang (University of Virginia)
-

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -192,9 +192,6 @@ You can find some benchmarks for OpenMM on several classes of recent GPUs at `op
 
 Ross Walker and the Amber GPU developers maintain a set of `excellent pages with good inexpensive GPU hardware recommendations <http://ambermd.org/gpus/recommended_hardware.htm>`_ that will also work well with OpenMM and YANK.
 
-Amazon EC2 now provides `Linux GPU instances <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using_cluster_computing.html>`_ with high-performance GPUs and inexpensive on-demand and `spot pricing <http://aws.amazon.com/ec2/purchasing-options/spot-instances/>`_ (g2.2xlarge).
-We will soon provide ready-to-use images to let you quickly get started on EC2.
-
 Installing from source
 ======================
 
@@ -233,3 +230,12 @@ Test your YANK installation to make sure everything is behaving properly on your
    $ yank selftest
 
 This will not only check that installation paths are correct, but also run a battery of tests that ensure any automatically detected GPU hardware is behaving as expected.
+
+Running on the cloud
+--------------------
+
+Amazon EC2 now provides `Linux GPU instances <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using_cluster_computing.html>`_ with high-performance GPUs and inexpensive on-demand and `spot pricing <http://aws.amazon.com/ec2/purchasing-options/spot-instances/>`_ (g2.2xlarge).
+We will soon provide ready-to-use images to let you quickly get started on EC2.
+
+We are also exploring building `Docker containers <https://hub.docker.com/>`_ for rapid, reproducible, portable deployment of YANK to new compute environments.
+Stay tuned!

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Installing via `conda`
 
 The simplest way to install YANK is via the `conda <http://www.continuum.io/blog/conda>`_  package manager.
 Packages are provided on the `omnia Anaconda Cloud channel <http://anaconda.org/omnia>`_ for Linux, OS X, and Win platforms.
-The `yank Anaconda Cloud page <https://anaconda.org/omnia/yank>`_ has useful instructions and download statistics.
+The `yank Anaconda Cloud page <https://anaconda.org/omnia/yank>`_ has useful instructions and `download statistics <https://anaconda.org/omnia/yank/files>`_`.
 
 If you are using the `anaconda <https://www.continuum.io/downloads/>`_ scientific Python distribution, you already have the ``conda`` package manager installed.
 If not, the quickest way to get started is to install the `miniconda <http://conda.pydata.org/miniconda.html>`_ distribution, a lightweight minimal installation of Anaconda Python.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,10 +7,10 @@ Installing via `conda`
 ======================
 
 The simplest way to install YANK is via the `conda <http://www.continuum.io/blog/conda>`_  package manager.
-Packages are provided on the `omnia binstar channel <http://binstar.org/omnia>`_ for Linux, OS X, and Win platforms.
-The `yank binstar page <https://binstar.org/omnia/yank>`_ has useful instructions and download statistics.
+Packages are provided on the `omnia Anaconda Cloud channel <http://anaconda.org/omnia>`_ for Linux, OS X, and Win platforms.
+The `yank Anaconda Cloud page <https://anaconda.org/omnia/yank>`_ has useful instructions and download statistics.
 
-If you are using the `anaconda <https://store.continuum.io/cshop/anaconda/>`_ scientific Python distribution, you already have the ``conda`` package manager installed.
+If you are using the `anaconda <https://www.continuum.io/downloads/>`_ scientific Python distribution, you already have the ``conda`` package manager installed.
 If not, the quickest way to get started is to install the `miniconda <http://conda.pydata.org/miniconda.html>`_ distribution, a lightweight minimal installation of Anaconda Python.
 
 On `linux`, you can install the Python 2.7 version into `$HOME/miniconda2` with (on `bash` systems):

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Installing via `conda`
 
 The simplest way to install YANK is via the `conda <http://www.continuum.io/blog/conda>`_  package manager.
 Packages are provided on the `omnia Anaconda Cloud channel <http://anaconda.org/omnia>`_ for Linux, OS X, and Win platforms.
-The `yank Anaconda Cloud page <https://anaconda.org/omnia/yank>`_ has useful instructions and `download statistics <https://anaconda.org/omnia/yank/files>`_`.
+The `yank Anaconda Cloud page <https://anaconda.org/omnia/yank>`_ has useful instructions and `download statistics <https://anaconda.org/omnia/yank/files>`_.
 
 If you are using the `anaconda <https://www.continuum.io/downloads/>`_ scientific Python distribution, you already have the ``conda`` package manager installed.
 If not, the quickest way to get started is to install the `miniconda <http://conda.pydata.org/miniconda.html>`_ distribution, a lightweight minimal installation of Anaconda Python.
@@ -94,11 +94,13 @@ Optional Tools
 
 The `OpenEye toolkit and Python wrappers <http://www.eyesopen.com/toolkits>`_ can be installed to enable free energy calculations to be set up directly from `multiple supported small molecule formats <https://docs.eyesopen.com/toolkits/python/oechemtk/molreadwrite.html#file-formats>`_, including
 
-* Tripos mol2
 * SDF
 * SMILES
 * IUPAC names
+* Tripos mol2
 * PDB
+
+Note that PDB and mol2 are supported through the pure AmberTools pipeline as well, though this does not provide access to the OpenEye AM1-BCC charging pipeline.
 
 Use of the OpenEye toolkit requires an `academic or commercial license <http://www.eyesopen.com/licensing-philosophy>`_.
 
@@ -171,6 +173,7 @@ Optional
 .. note:: The ``mpi4py`` installation must be compiled against the system-installed MPI implementation used to launch jobs. Using the ``conda`` version of ``mpi4py`` together with the ``conda``-provided ``mpirun`` is the simplest way to avoid any issues.
 
 * The `OpenEye toolkit and Python wrappers <http://www.eyesopen.com/toolkits>`_ can be used to enable free energy calculations to be set up directly from multiple supported OpenEye formats, including Tripos mol2, PDB, SMILES, and IUPAC names (requires academic or commercial license).
+Note that PDB and mol2 are supported through the pure AmberTools pipeline as well, though this does not provide access to the OpenEye AM1-BCC charging pipeline.
 
 * `scipy.weave <http://docs.scipy.org/doc/scipy-0.14.0/reference/tutorial/weave.html>`_ is an optional dependency for the replica-exchange code, though this functionality will be migrated to `cython <http://cython.org>`_ in future revisions.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -119,8 +119,7 @@ Software
 --------
 
 YANK runs on Python 2.7.
-The developers generally use Python 2.7 on both Mac and Linux platforms.
-Automated tests on Linux are performed on every GitHub commit using `Travis CI <http://travis-ci.org>`_, and release tests are performed on Mac and Linux platforms using `Jenkins <http://jenkins.choderalab.org>`_..
+Support for Python 3.x is planned for a future release.
 
 Dependencies
 ++++++++++++
@@ -143,14 +142,23 @@ Required
 * HDF5 (required by NetCDF4):
   http://www.hdfgroup.org/HDF5/
 
-* netcdf4-python (a Python interface for netcdf4):
+* ``netcdf4-python`` (a Python interface for netcdf4):
   http://code.google.com/p/netcdf4-python/
 
-* numpy and scipy:
+* ``numpy`` and ``scipy``:
   http://www.scipy.org/
 
-* `alchemy`
+* ``docopt``:
+  http://docopt.org/
+
+* ``alchemy``
   https://github.com/choderalab/alchemy
+
+* ``pymbar``
+  https://github.com/choderalab/pymbar
+
+* ``schema``
+  https://pypi.python.org/pypi/schema
 
 * `AmberTools <http://ambermd.org/#AmberTools>`_ is needed for setting up protein-ligand systems using LEaP.
   https://github.com/choderalab/ambertools
@@ -158,11 +166,11 @@ Required
 Optional
 ^^^^^^^^
 
-* `mpi4py <http://mpi4py.scipy.org/>`_ is needed if  MPI support is desired.
+* `mpi4py <http://mpi4py.scipy.org/>`_ is needed if `MPI support <https://de.wikipedia.org/wiki/Message_Passing_Interface>`_ is desired.
 
-.. note:: The ``mpi4py`` installation must be compiled against the system-installed MPI implementation used to launch jobs.
+.. note:: The ``mpi4py`` installation must be compiled against the system-installed MPI implementation used to launch jobs. Using the ``conda`` version of ``mpi4py`` together with the ``conda``-provided ``mpirun`` is the simplest way to avoid any issues.
 
-* The `OpenEye toolkit and Python wrappers <http://www.eyesopen.com/toolkits>`_ can be used to enable free energy calculations to be set up directly from any supported OpenEye format, including mol2, PDB, ChemDraw, and many more (requires academic or commercial license).
+* The `OpenEye toolkit and Python wrappers <http://www.eyesopen.com/toolkits>`_ can be used to enable free energy calculations to be set up directly from multiple supported OpenEye formats, including Tripos mol2, PDB, SMILES, and IUPAC names (requires academic or commercial license).
 
 * `scipy.weave <http://docs.scipy.org/doc/scipy-0.14.0/reference/tutorial/weave.html>`_ is an optional dependency for the replica-exchange code, though this functionality will be migrated to `cython <http://cython.org>`_ in future revisions.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,7 +13,7 @@ The `yank Anaconda Cloud page <https://anaconda.org/omnia/yank>`_ has useful ins
 If you are using the `anaconda <https://www.continuum.io/downloads/>`_ scientific Python distribution, you already have the ``conda`` package manager installed.
 If not, the quickest way to get started is to install the `miniconda <http://conda.pydata.org/miniconda.html>`_ distribution, a lightweight minimal installation of Anaconda Python.
 
-On `linux`, you can install the Python 2.7 version into `$HOME/miniconda2` with (on `bash` systems):
+On ``linux``, you can install the Python 2.7 version into ``$HOME/miniconda2`` with (on ``bash`` systems):
 
 .. code-block:: bash
 
@@ -21,7 +21,7 @@ On `linux`, you can install the Python 2.7 version into `$HOME/miniconda2` with 
    $ bash ./Miniconda2-latest-Linux-x86_64.sh -b -p $HOME/miniconda2
    $ export PATH="$HOME/miniconda2/bin:$PATH"
 
-On `osx`, you want to use the `osx` binary
+On ``osx``, you want to use the ```osx`` binary
 
 .. code-block:: bash
 
@@ -29,7 +29,7 @@ On `osx`, you want to use the `osx` binary
    $ bash ./Miniconda2-latest-Linux-x86_64.sh -b -p $HOME/miniconda2
    $ export PATH="$HOME/miniconda2/bin:$PATH"
 
-You may want to add the new `$PATH` extension to your `~/.bashrc` file to ensure Anaconda Python is used by default.
+You may want to add the new ```$PATH`` extension to your ``~/.bashrc`` file to ensure Anaconda Python is used by default.
 Note that YANK will be installed into this local Python installation, so that you will not need to worry about disrupting existing Python installations.
 
 |
@@ -93,6 +93,7 @@ Optional Tools
 --------------
 
 The `OpenEye toolkit and Python wrappers <http://www.eyesopen.com/toolkits>`_ can be installed to enable free energy calculations to be set up directly from `multiple supported small molecule formats <https://docs.eyesopen.com/toolkits/python/oechemtk/molreadwrite.html#file-formats>`_, including
+
 * Tripos mol2
 * SDF
 * SMILES

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -87,6 +87,30 @@ Test your YANK installation to make sure everything is behaving properly on your
 
 This will not only check that installation paths are correct, but also run a battery of tests that ensure any automatically detected GPU hardware is behaving as expected.
 
+|
+
+Optional Tools
+--------------
+
+The `OpenEye toolkit and Python wrappers <http://www.eyesopen.com/toolkits>`_ can be installed to enable free energy calculations to be set up directly from `multiple supported small molecule formats <https://docs.eyesopen.com/toolkits/python/oechemtk/molreadwrite.html#file-formats>`_, including
+* Tripos mol2
+* SDF
+* SMILES
+* IUPAC names
+* PDB
+
+Use of the OpenEye toolkit requires an `academic or commercial license <http://www.eyesopen.com/licensing-philosophy>`_.
+
+To install these tools into your conda environment, use `pip`:
+
+.. code-block:: bash
+
+   $ pip install -i https://pypi.anaconda.org/OpenEye/simple OpenEye-toolkits
+
+Note that you will need to configure your ``$OE_LICENSE`` environment variable to point to a valid license file.
+
+|
+
 Supported platforms and environments
 ====================================
 
@@ -124,10 +148,14 @@ Required
 * numpy and scipy:
   http://www.scipy.org/
 
+* `alchemy`
+  https://github.com/choderalab/alchemy
+
+* `AmberTools <http://ambermd.org/#AmberTools>`_ is needed for setting up protein-ligand systems using LEaP.
+  https://github.com/choderalab/ambertools
+
 Optional
 ^^^^^^^^
-
-* `AmberTools <http://ambermd.org/#AmberTools>`_ is helpful for setting up protein-ligand systems using LEaP.
 
 * `mpi4py <http://mpi4py.scipy.org/>`_ is needed if  MPI support is desired.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,7 @@ If you are using the `anaconda <https://www.continuum.io/downloads/>`_ scientifi
 If not, the quickest way to get started is to install the `miniconda <http://conda.pydata.org/miniconda.html>`_ distribution, a lightweight minimal installation of Anaconda Python.
 
 On `linux`, you can install the Python 2.7 version into `$HOME/miniconda2` with (on `bash` systems):
+
 .. code-block:: bash
 
    $ wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
@@ -21,6 +22,7 @@ On `linux`, you can install the Python 2.7 version into `$HOME/miniconda2` with 
    $ export PATH="$HOME/miniconda2/bin:$PATH"
 
 On `osx`, you want to use the `osx` binary
+
 .. code-block:: bash
 
    $ wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -188,10 +188,12 @@ Recommended hardware
 ++++++++++++++++++++
 
 We have found the best price/performance results are currently obtained with NVIDIA GTX-class consumer-grade cards, such as the GTX-680, GTX-780, and GTX-Titan cards.
+You can find some benchmarks for OpenMM on several classes of recent GPUs at `openmm.org <http://openmm.org/about.html#benchmarks>`_.
 
 Ross Walker and the Amber GPU developers maintain a set of `excellent pages with good inexpensive GPU hardware recommendations <http://ambermd.org/gpus/recommended_hardware.htm>`_.
 
-Amazon EC2 now provides `Linux GPU instances <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using_cluster_computing.html>`_ with high-performance GPUs and inexpensive on-demand and `spot pricing <http://aws.amazon.com/ec2/purchasing-options/spot-instances/>`_ (g2.2xlarge).  We will soon provide ready-to-use images to let you quickly get started on EC2.
+Amazon EC2 now provides `Linux GPU instances <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using_cluster_computing.html>`_ with high-performance GPUs and inexpensive on-demand and `spot pricing <http://aws.amazon.com/ec2/purchasing-options/spot-instances/>`_ (g2.2xlarge).
+We will soon provide ready-to-use images to let you quickly get started on EC2.
 
 Installing from source
 ======================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -190,7 +190,7 @@ Recommended hardware
 We have found the best price/performance results are currently obtained with NVIDIA GTX-class consumer-grade cards, such as the GTX-680, GTX-780, and GTX-Titan cards.
 You can find some benchmarks for OpenMM on several classes of recent GPUs at `openmm.org <http://openmm.org/about.html#benchmarks>`_.
 
-Ross Walker and the Amber GPU developers maintain a set of `excellent pages with good inexpensive GPU hardware recommendations <http://ambermd.org/gpus/recommended_hardware.htm>`_.
+Ross Walker and the Amber GPU developers maintain a set of `excellent pages with good inexpensive GPU hardware recommendations <http://ambermd.org/gpus/recommended_hardware.htm>`_ that will also work well with OpenMM and YANK.
 
 Amazon EC2 now provides `Linux GPU instances <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using_cluster_computing.html>`_ with high-performance GPUs and inexpensive on-demand and `spot pricing <http://aws.amazon.com/ec2/purchasing-options/spot-instances/>`_ (g2.2xlarge).
 We will soon provide ready-to-use images to let you quickly get started on EC2.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,13 +11,24 @@ Packages are provided on the `omnia binstar channel <http://binstar.org/omnia>`_
 The `yank binstar page <https://binstar.org/omnia/yank>`_ has useful instructions and download statistics.
 
 If you are using the `anaconda <https://store.continuum.io/cshop/anaconda/>`_ scientific Python distribution, you already have the ``conda`` package manager installed.
-If not, but you have the ``pip`` package manager installed (to access packages from `PyPI <http://pypi.org>`_), you can easily get ``conda`` up and running with
+If not, the quickest way to get started is to install the `miniconda <http://conda.pydata.org/miniconda.html>`_ distribution, a lightweight minimal installation of Anaconda Python.
 
-.. code-block:: none
+On `linux`, you can install the Python 2.7 version into `$HOME/miniconda2` with (on `bash` systems):
+.. code-block:: bash
 
-   $ pip install conda
-   $ conda init
-   $ conda update conda --yes
+   $ wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
+   $ bash ./Miniconda2-latest-Linux-x86_64.sh -b -p $HOME/miniconda2
+   $ export PATH="$HOME/miniconda2/bin:$PATH"
+
+On `osx`, you want to use the `osx` binary
+.. code-block:: bash
+
+   $ wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh
+   $ bash ./Miniconda2-latest-Linux-x86_64.sh -b -p $HOME/miniconda2
+   $ export PATH="$HOME/miniconda2/bin:$PATH"
+
+You may want to add the new `$PATH` extension to your `~/.bashrc` file to ensure Anaconda Python is used by default.
+Note that YANK will be installed into this local Python installation, so that you will not need to worry about disrupting existing Python installations.
 
 |
 
@@ -28,7 +39,7 @@ You can install the latest stable release build of YANK via the ``conda`` packag
 
 .. code-block:: none
 
-   $ conda config --add channels http://conda.binstar.org/omnia
+   $ conda config --add channels omnia
    $ conda install yank
 
 This version is recommended for all users not actively developing new algorithms for alchemical free energy calculations.
@@ -42,9 +53,9 @@ Development build
 
 The bleeding-edge, absolute latest, very likely unstable development build of YANK is pushed to `binstar <https://binstar.org/omnia/yank>`_ with each GitHub commit, and can be obtained by
 
-.. code-block:: none
+.. code-block:: bash
 
-   $ conda config --add channels http://conda.binstar.org/omnia
+   $ conda config --add channels omnia
    $ conda install yank-dev
 
 .. warning:: Development builds may be unstable and are generally subjected to less testing than releases.  Use at your own risk!
@@ -55,7 +66,7 @@ Upgrading your installation
 
 To update an earlier ``conda`` installation of YANK to the latest release version, you can use ``conda update``:
 
-.. code-block:: none
+.. code-block:: bash
 
    $ conda update yank
 
@@ -68,7 +79,7 @@ Testing your installation
 
 Test your YANK installation to make sure everything is behaving properly on your machine:
 
-.. code-block:: none
+.. code-block:: bash
 
    $ yank selftest
 
@@ -156,7 +167,7 @@ Installation via `conda` is preferred for all other users.
 
 Clone the source code repository from `GitHub <http://github.com/choderalab/yank>`_.
 
-.. code-block:: none
+.. code-block:: bash
 
    $ git clone git://github.com/choderalab/yank.git
    $ cd yank/
@@ -164,7 +175,7 @@ Clone the source code repository from `GitHub <http://github.com/choderalab/yank
 
 If you wish to install into a different path (often preferred for development), use
 
-.. code-block:: none
+.. code-block:: bash
 
    $ python setup.py install
 
@@ -176,9 +187,8 @@ Testing your installation
 
 Test your YANK installation to make sure everything is behaving properly on your machine:
 
-.. code-block:: none
+.. code-block:: bash
 
    $ yank selftest
 
 This will not only check that installation paths are correct, but also run a battery of tests that ensure any automatically detected GPU hardware is behaving as expected.
-

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -23,11 +23,10 @@ Run an alchemical free energy calculation (in serial mode) using the parameters 
 
    $ yank script --yaml=yank.yaml
 
-Alternatively, the simulation can be `run in MPI mode <running-yank>`_ if you have multiple GPUs available.
+Alternatively, the simulation can be `run in MPI mode <running>`_ if you have multiple GPUs available.
 
 Analyze the simulation data:
 
 .. code-block:: bash
 
    $ yank analyze --store=experiments
-   

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,36 +5,29 @@ Quickstart (for the impatient)
 
 First, install the `anaconda <https://store.continuum.io/cshop/anaconda/>`_ scientific Python distribution.
 
-Install the release version of YANK from the `omnia binstar channel <https://binstar.org/omnia/yank>`_:
+Install the release version of YANK from the `omnia Anaconda Cloud channel <https://anaconda.org/omnia/yank>`_ (check out our detailed `installation <installation>`_ section):
 
-.. code-block:: none
+.. code-block:: bash
 
-   $ conda install -c https://conda.binstar.org/omnia yank
+   $ conda install -c omnia yank
 
 Go to the ``examples/p-xylene-implicit`` directory to find an example of computing the binding affinity of p-xylene to T4 lysozyme L99A:
 
-.. code-block:: none
+.. code-block:: bash
 
    $ cd ~/anaconda/share/yank/examples/p-xylene-implicit
 
-Use the `yank prepare` command to set up an alchemical free energy calculation using the ``OBC2`` implicit solvent model, specifying the residue named ``BEN`` as the ligand, selecting the temperature of 300 Kelvin, and using the diretory ``output/`` to write out data:
+Run an alchemical free energy calculation (in serial mode) using the parameters specified in the ``yank.yaml`` file:
 
-.. code-block:: none
+.. code-block:: bash
 
-   $ yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=1000 \
-     --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
+   $ yank script --yaml=yank.yaml
 
-Run the simulation in serial mode with:
+Alternatively, the simulation can be `run in MPI mode <running-yank>`_ if you have multiple GPUs available.
 
-.. code-block:: none
+Analyze the simulation data:
 
-   $ yank run --store=output --verbose
+.. code-block:: bash
 
-Alternatively, run the simulation in MPI mode:
-
-.. code-block:: none
-
-   $ yank run --store=output --mpi --verbose
-
-Note that, in MPI mode, the default device id for each GPU is used.
-See the section `Running YANK <running-yank>`_ for more information on using MPI mode, including strategies for dealing with machines containing multiple GPUs.
+   $ yank analyze --store=experiments
+   


### PR DESCRIPTION
This PR updates the installation docs to describe installation via `miniconda`.