### PR TITLE
Add more debugging information about NaNs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ script:
   # Install various tools for testing
   - conda install --yes --quiet pip nose nose-timer
   # Install OpenEye toolkit
-  - ls -ltr $OE_LICENSE
   - pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Check Python version
   - python --version


### PR DESCRIPTION
This adds some more checks for NaN energies and positions, at the expense of a little speed.

Later, we can make these checks optional or remove some of them.