### PR TITLE
Fix potential bug in computing alchemical reduced potentials

### DIFF
--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -306,6 +306,13 @@ class ThermodynamicState(object):
         # Set positions.
         context.setPositions(positions)
 
+        # Set alchemical state
+        # TODO: Deal with this better
+        if hasattr(self, 'alchemical_state'):
+            from alchemy import AbsoluteAlchemicalFactory
+            AbsoluteAlchemicalFactory.perturbContext(context, self.alchemical_state)
+            # TODO: Restore old context parameters
+
         # Retrieve potential energy.
         potential_energy = context.getState(getEnergy=True).getPotentialEnergy()
 

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -168,6 +168,13 @@ class ThermodynamicState(object):
 
         return
 
+    @property
+    def kT(self):
+        """
+        Return the thermal energy (kT) of this state.
+        """
+        return (kB * self.temperature)
+
     def reduced_potential(self, positions, box_vectors=None, platform=None, context=None):
         """
         Compute the reduced potential for the given positions in this thermodynamic state.
@@ -408,6 +415,10 @@ class ThermodynamicState(object):
         Examples
         --------
         Compute the volume of a Lennard-Jones fluid at 100 K and 1 atm.
+
+        TODO
+        ----
+        * Replace with OpenMM State.getPeriodicBoxVolume()
 
         >>> from openmmtools import testsystems
         >>> testsystem = testsystems.LennardJonesFluid()


### PR DESCRIPTION
I found that `ThermodynamicState.reduced_potential()` wasn't actually setting the alchemical state prior to computing the reduced potential. I have a hack in right now to see if this makes a difference, but we also need to make sure the old state is restored at the end of this calculation in order to avoid unexpected changes to the cached `Context`.