### PR TITLE
Adds filename check as tleap does not allow numeric only variables

### DIFF
--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -712,6 +712,10 @@ class SetupDatabase:
 
         return molecule
 
+    def _check_mol_filename(self, fname):
+        name = os.path.basename(fname)
+        return name.isdigit()
+
     def _setup_molecules(self, *args):
         """Set up the files needed to generate the system for all the molecules.
 
@@ -736,6 +740,8 @@ class SetupDatabase:
         """
 
         for mol_id in args:
+            if self._check_mol_filename(mol_id):
+                raise Exception('tleap does not accept purely numerical filenames.')
             net_charge = None  # used by antechamber
             mol_descr = self.molecules[mol_id]
 


### PR DESCRIPTION
This is a tleap error that we noticed because we occasionally automatically generated mol2 filenames that were numeric only, ie '4354.mol2'. The filename is then written in the *.leap.in file which when fed into tleap generates a syntax error.

Welcome to LEaP!
(no leaprc in search path)
52432 = loadMol2 ./setup/molecules/52432/52432.gaff.mol2  
ERROR: syntax error

This pull request adds a prototype for a simple check that then raises an exception
