### PR TITLE
Fix automatic addition of barostat for non-periodic systems

### DIFF
--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -2117,8 +2117,12 @@ class ReplicaExchange(object):
 
             # Log value (truncate if too long but save length)
             if hasattr(option_value, '__len__'):
+                try:
+                    option_value_len = len(option_value)
+                except TypeError:  # this is a zero-dimensional array
+                    option_value_len = np.atleast_1d(option_value)
                 logger.debug("Restoring option: {} -> {} (type: {}, length {})".format(
-                    option_name, str(option_value)[:500], type(option_value), len(option_value)))
+                    option_name, str(option_value)[:500], type(option_value), option_value_len))
             else:
                 logger.debug("Retoring option: {} -> {} (type: {})".format(
                     option_name, option_value, type(option_value)))

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -1432,8 +1432,9 @@ class ReplicaExchange(object):
                     logger.debug("minimizing replica %d / %d" % (replica_index, self.nstates))
                     self._minimize_replica(replica_index)
 
-        # Equilibrate
+        # Equilibrate: temporarily set timestep to equilibration timestep
         production_timestep = self.timestep
+        self.timestep = self.equilibration_timestep
         for iteration in range(self.number_of_equilibration_iterations):
             logger.debug("equilibration iteration %d / %d" % (iteration, self.number_of_equilibration_iterations))
             self._propagate_replicas()

--- a/Yank/tests/test_prepare.py
+++ b/Yank/tests/test_prepare.py
@@ -15,9 +15,7 @@ Test 'yank prepare'.
 
 import tempfile
 
-from openmmtools import testsystems
-
-from nose.plugins.skip import Skip, SkipTest
+from nose.plugins.attrib import attr
 
 from docopt import docopt
 from yank.cli import usage
@@ -38,6 +36,8 @@ def test_prepare_amber_implicit(verbose=False):
     from yank.commands import prepare
     prepare.dispatch(args)
 
+
+@attr('slow')  # Skip on Travis-CI
 def test_prepare_amber_explicit(verbose=False):
     store_directory = tempfile.mkdtemp()
     examples_path = utils.get_data_filename("../examples/benzene-toluene-explicit/setup/")  # Could only figure out how to install things like yank.egg/examples/, rather than yank.egg/yank/examples/
@@ -49,6 +49,8 @@ def test_prepare_amber_explicit(verbose=False):
     from yank.commands import prepare
     prepare.dispatch(args)
 
+
+@attr('slow')  # Skip on Travis-CI
 def test_prepare_gromacs_explicit(verbose=False):
     store_directory = tempfile.mkdtemp()
     examples_path = utils.get_data_filename("../examples/p-xylene-gromacs-example/setup/")

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1578,6 +1578,7 @@ def test_get_alchemical_path():
     assert len(complex_path) == 7
 
 
+@attr('slow')  # Skip on Travis-CI
 def test_run_experiment_from_amber_files():
     """Test experiment run from prmtop/inpcrd files."""
     complex_path = examples_paths()['bentol-complex']
@@ -1751,21 +1752,21 @@ def test_run_solvation_experiment():
     """Test solvation free energy experiment run."""
     with omt.utils.temporary_directory() as tmp_dir:
         yaml_script = get_template_script(tmp_dir)
+        yaml_script['solvents']['PME']['clearance'] = '14*angstroms'
         yaml_script['systems'] = {
             'system1':
                 {'solute': 'toluene', 'solvent1': 'PME', 'solvent2': 'vacuum',
                  'leap': {'parameters': ['leaprc.gaff', 'leaprc.ff14SB']}}}
-
         protocol = yaml_script['protocols']['absolute-binding']['solvent']
         yaml_script['protocols'] = {
             'hydration-protocol': {
-                'solvent1' : protocol,
-                'solvent2' : protocol
+                'solvent1': protocol,
+                'solvent2': protocol
             }
         }
         yaml_script['experiments'] = {
-            'system' : 'system1',
-            'protocol' : 'hydration-protocol'
+            'system': 'system1',
+            'protocol': 'hydration-protocol'
             }
 
         yaml_builder = YamlBuilder(yaml_script)
@@ -1787,7 +1788,6 @@ def test_run_solvation_experiment():
 
         # Check that solvated phase has a barostat.
         from netCDF4 import Dataset
-        from simtk import openmm
         ncfile = Dataset(os.path.join(output_dir, 'solvent1.nc'), 'r')
         ncgrp_stateinfo = ncfile.groups['thermodynamic_states']
         system = openmm.System()

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -102,9 +102,16 @@ def test_phase_creation():
         try:
             nc_file = netcdf.Dataset(nc_path, mode='r')
             metadata_group = nc_file.groups['metadata']
+            serialized_system = metadata_group.variables['reference_system'][0]
             serialized_topology = metadata_group.variables['topology'][0]
         finally:
             nc_file.close()
+
+        # Yank doesn't add a barostat to implicit systems
+        serialized_system = str(serialized_system)  # convert unicode
+        deserialized_system = openmm.XmlSerializer.deserialize(serialized_system)
+        for force in deserialized_system.getForces():
+            assert 'Barostat' not in force.__class__.__name__
 
         # Topology has been stored correctly
         deserialized_topology = utils.deserialize_topology(serialized_topology)

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -331,28 +331,6 @@ class Yank(object):
         atom_indices = alchemical_phase.atom_indices
         alchemical_states = alchemical_phase.protocol
 
-        # If temperature and pressure are specified, make sure MonteCarloBarostat is attached.
-        if thermodynamic_state.temperature and thermodynamic_state.pressure:
-            forces = { reference_system.getForce(index).__class__.__name__ : reference_system.getForce(index) for index in range(reference_system.getNumForces()) }
-
-            if 'MonteCarloAnisotropicBarostat' in forces:
-                raise Exception('MonteCarloAnisotropicBarostat is unsupported.')
-
-            if 'MonteCarloBarostat' in forces:
-                logger.debug('MonteCarloBarostat found: Setting default temperature and pressure.')
-                barostat = forces['MonteCarloBarostat']
-                # Set temperature and pressure.
-                try:
-                    barostat.setDefaultTemperature(thermodynamic_state.temperature)
-                except AttributeError:  # versions previous to OpenMM7.1
-                    barostat.setTemperature(thermodynamic_state.temperature)
-                barostat.setDefaultPressure(state.pressure)
-            else:
-                # Create barostat and add it to the system if it doesn't have one already.
-                logger.debug('MonteCarloBarostat not found: Creating one.')
-                barostat = openmm.MonteCarloBarostat(thermodynamic_state.pressure, thermodynamic_state.temperature)
-                reference_system.addForce(barostat)
-
         # Check the dimensions of positions.
         for index in range(len(positions)):
             n_atoms, _ = (positions[index] / positions[index].unit).shape
@@ -377,7 +355,29 @@ class Yank(object):
         is_complex_implicit = len(atom_indices['receptor']) > 0 and not is_periodic
 
         # Make sure pressure is None if not periodic.
-        if not is_periodic: thermodynamic_state.pressure = None
+        if not is_periodic:
+            thermodynamic_state.pressure = None
+        # If temperature and pressure are specified, make sure MonteCarloBarostat is attached.
+        elif thermodynamic_state.temperature and thermodynamic_state.pressure:
+            forces = { reference_system.getForce(index).__class__.__name__ : reference_system.getForce(index) for index in range(reference_system.getNumForces()) }
+
+            if 'MonteCarloAnisotropicBarostat' in forces:
+                raise Exception('MonteCarloAnisotropicBarostat is unsupported.')
+
+            if 'MonteCarloBarostat' in forces:
+                logger.debug('MonteCarloBarostat found: Setting default temperature and pressure.')
+                barostat = forces['MonteCarloBarostat']
+                # Set temperature and pressure.
+                try:
+                    barostat.setDefaultTemperature(thermodynamic_state.temperature)
+                except AttributeError:  # versions previous to OpenMM7.1
+                    barostat.setTemperature(thermodynamic_state.temperature)
+                barostat.setDefaultPressure(thermodynamic_state.pressure)
+            else:
+                # Create barostat and add it to the system if it doesn't have one already.
+                logger.debug('MonteCarloBarostat not found: Creating one.')
+                barostat = openmm.MonteCarloBarostat(thermodynamic_state.pressure, thermodynamic_state.temperature)
+                reference_system.addForce(barostat)
 
         # Create a copy of the system for which the fully-interacting energy is to be computed.
         # For explicit solvent calculations, an enlarged cutoff is used to account for the anisotropic dispersion correction.

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -279,28 +279,6 @@ class Yank(object):
 
         return
 
-    def _is_periodic(self, system):
-        """
-        Report whether a given system is periodic or not.
-
-        Parameters
-        ----------
-        system : simtk.openmm.System
-           The system object to examine for periodic forces.
-
-        Returns
-        -------
-        is_periodic : bool
-           True is returned if a NonbondedForce object is present with getNonBondedMethod() reporting one of [CutoffPeriodic, Ewald, PME]
-
-        """
-
-        is_periodic = False
-        forces = { system.getForce(index).__class__.__name__ : system.getForce(index) for index in range(system.getNumForces()) }
-        if forces['NonbondedForce'].getNonbondedMethod() in [openmm.NonbondedForce.CutoffPeriodic, openmm.NonbondedForce.Ewald, openmm.NonbondedForce.PME]:
-            is_periodic = True
-        return is_periodic
-
     def _create_phase(self, thermodynamic_state, alchemical_phase):
         """
         Create a repex object for a specified phase.
@@ -346,7 +324,7 @@ class Yank(object):
         metadata = dict()
 
         # TODO: Use more general approach to determine whether system is periodic.
-        is_periodic = self._is_periodic(reference_system)
+        is_periodic = reference_system.usesPeriodicBoundaryConditions()
         is_complex_explicit = len(atom_indices['receptor']) > 0 and is_periodic
         is_complex_implicit = len(atom_indices['receptor']) > 0 and not is_periodic
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -365,7 +365,7 @@ class Yank(object):
             # TODO: Should we warn if cutoff can't be extended enough?
             # TODO: Should we extend to some minimum cutoff rather than the maximum allowed?
             box_vectors = fully_interacting_system.getDefaultPeriodicBoxVectors()
-            max_allowed_cutoff = 0.489 * max([max(vector) for vector in box_vectors])  # TODO: Correct this for non-rectangular boxes
+            max_allowed_cutoff = 0.499 * min([max(vector) for vector in box_vectors])  # TODO: Correct this for non-rectangular boxes
             logger.debug('Setting cutoff for fully interacting system to maximum allowed (%s)' % str(max_allowed_cutoff))
             for force_index in range(fully_interacting_system.getNumForces()):
                 force = fully_interacting_system.getForce(force_index)

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -345,10 +345,6 @@ class Yank(object):
         # Inizialize metadata storage.
         metadata = dict()
 
-        # Store a serialized copy of the reference system.
-        metadata['reference_system'] = openmm.XmlSerializer.serialize(reference_system)
-        metadata['topology'] = utils.serialize_topology(alchemical_phase.reference_topology)
-
         # TODO: Use more general approach to determine whether system is periodic.
         is_periodic = self._is_periodic(reference_system)
         is_complex_explicit = len(atom_indices['receptor']) > 0 and is_periodic
@@ -378,6 +374,10 @@ class Yank(object):
                 logger.debug('MonteCarloBarostat not found: Creating one.')
                 barostat = openmm.MonteCarloBarostat(thermodynamic_state.pressure, thermodynamic_state.temperature)
                 reference_system.addForce(barostat)
+
+        # Store a serialized copy of the reference system.
+        metadata['reference_system'] = openmm.XmlSerializer.serialize(reference_system)
+        metadata['topology'] = utils.serialize_topology(alchemical_phase.reference_topology)
 
         # Create a copy of the system for which the fully-interacting energy is to be computed.
         # For explicit solvent calculations, an enlarged cutoff is used to account for the anisotropic dispersion correction.

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -297,7 +297,7 @@ class Yank(object):
 
         is_periodic = False
         forces = { system.getForce(index).__class__.__name__ : system.getForce(index) for index in range(system.getNumForces()) }
-        if forces['NonbondedForce'].getNonbondedMethod in [openmm.NonbondedForce.CutoffPeriodic, openmm.NonbondedForce.Ewald, openmm.NonbondedForce.PME]:
+        if forces['NonbondedForce'].getNonbondedMethod() in [openmm.NonbondedForce.CutoffPeriodic, openmm.NonbondedForce.Ewald, openmm.NonbondedForce.PME]:
             is_periodic = True
         return is_periodic
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -365,7 +365,7 @@ class Yank(object):
             # TODO: Should we warn if cutoff can't be extended enough?
             # TODO: Should we extend to some minimum cutoff rather than the maximum allowed?
             box_vectors = fully_interacting_system.getDefaultPeriodicBoxVectors()
-            max_allowed_cutoff = 0.499 * max([ max(vector) for vector in box_vectors ]) # TODO: Correct this for non-rectangular boxes
+            max_allowed_cutoff = 0.489 * max([max(vector) for vector in box_vectors])  # TODO: Correct this for non-rectangular boxes
             logger.debug('Setting cutoff for fully interacting system to maximum allowed (%s)' % str(max_allowed_cutoff))
             for force_index in range(fully_interacting_system.getNumForces()):
                 force = fully_interacting_system.getForce(force_index)


### PR DESCRIPTION
I just prevented `Yank` to add a barostat if the system is not periodic.

**Question:** it looks like OpenMM sets the default box vectors of a newly created system to a cube of side 2.0nm. Are there cases in which we want a non-periodic box? Should we set the vectors to `None` for non-periodic systems?