### PR TITLE
[WIP] Make selftest a more helpful

### DIFF
--- a/Yank/commands/selftest.py
+++ b/Yank/commands/selftest.py
@@ -69,11 +69,12 @@ def dispatch(args):
         print{  "************************************************")
     # OpenEye checks
     try:
-        print("OpenEye install Found! Checking install...")
+        import openeye
         import openeye.examples.openeye_tests as OETests
+        print("OpenEye version $s Found! Checking install..." % openeye.__version__)
         OETests.run_test_suite()
     except:
-        print("OpenEye install not found")
+        print("Valid OpenEye install not found")
         print("Not required, but please check install if you expected it")
     # Run nosetests
     # Note: These will not run during standard nosetests because they must be explicitly called

--- a/Yank/commands/selftest.py
+++ b/Yank/commands/selftest.py
@@ -60,13 +60,13 @@ def dispatch(args):
     # Errors
     platform_errors = mm.Platform.getPlatformLoadErrors()
     if len(platform_errors) > 0: # This check only required to make header
-        print{  "************************************************")
+        print(  "************************************************")
         print("\nWarning! There were OpenMM Platform Load Errors!")
-        print{  "************************************************")
+        print(  "************************************************")
         for e in platform_errors:
             print(e)
-        print{  "************************************************")
-        print{  "************************************************")
+        print(  "************************************************")
+        print(  "************************************************")
     # OpenEye checks
     try:
         import openeye
@@ -83,9 +83,9 @@ def dispatch(args):
         # Clear some lines
         print("\n\n\n")
         # Alert User
-        print{"******************************************")
+        print("******************************************")
         print("Nosetests invoked! This will take a while!")
-        print{"******************************************")
+        print("******************************************")
         import nose
         try: #Check for timer install
             result = nose.run(argv=['yank', '--nocapture', '--verbosity=%d'%verbosity, '--with-timer', '-a', '!slow'] )

--- a/Yank/commands/selftest.py
+++ b/Yank/commands/selftest.py
@@ -92,7 +92,7 @@ def dispatch(args):
             result = nose.run(argv=['yank', '--nocapture', '--verbosity=%d'%verbosity, '-a', '!slow'] )
 
     if args['--doctests'] or args['-d']:
-        print "Running doctests for all modules..."
+        print("Running doctests for all modules...")
 
         # Run tests on main module.
         import yank
@@ -112,8 +112,8 @@ def dispatch(args):
 
         # Report results.
         if failure_count == 0:
-            print "All doctests pass."
+            print("All doctests pass.")
         else:
-            print "WARNING: There were %d doctest failures." % failure_count
+            print("WARNING: There were %d doctest failures." % failure_count)
 
     return True


### PR DESCRIPTION
This PR tries to make the `yank selftest` command more helpful to the user. It runs a few general checks and alerts the users when things are not expected. Changes are based on suggestion in #80.

Options available for running all nosetests and/or doctests. These should not cause an infinite loop since they must be explicitly called when the command is issued and the tests themselves do not do so.

I have not had a chance to test this (yet) but wanted to upload to get feedback on if we want selftest to do more or less while we're making changes to it anyways