### PR TITLE
Ordered combinatorial tree

### DIFF
--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -12,7 +12,6 @@ Test various utility functions.
 import textwrap
 
 import openmoltools as omt
-import simtk.unit as unit
 from schema import Schema
 from openmmtools import testsystems
 
@@ -68,10 +67,8 @@ def test_find_combinatorial_leaves():
             'leaf': ['a', 'b', 'c'],
             'comb-leaf': CombinatorialLeaf(['d', 'e'])}}})
     leaf_paths, leaf_vals = simple_tree._find_combinatorial_leaves()
-    assert all(leaf_path in [('simple', 'vector'), ('simple', 'nested', 'comb-leaf')]
-                         for leaf_path in leaf_paths)
-    assert all(leaf_val in [[2, 3, 4], ['d', 'e']] 
-                        for leaf_val in leaf_vals)
+    assert leaf_paths == (('simple', 'nested', 'comb-leaf'), ('simple', 'vector'))
+    assert leaf_vals == (['d', 'e'], [2, 3, 4])
 
 
 def test_expand_tree():
@@ -119,6 +116,7 @@ def test_expand_tree():
                           'benzene-benzene', 'benzene-benzene-2', 'benzene-notapath'])
     expected_names = [expected_names_A, expected_names_B]
     assert set([name for name, _ in long_tree.named_combinations(separator='-', max_name_length=25)]) in expected_names
+
 
 def test_expand_id_nodes():
     """CombinatorialTree.expand_id_nodes()"""

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -67,6 +67,8 @@ def test_find_combinatorial_leaves():
             'leaf': ['a', 'b', 'c'],
             'comb-leaf': CombinatorialLeaf(['d', 'e'])}}})
     leaf_paths, leaf_vals = simple_tree._find_combinatorial_leaves()
+
+    # Paths must be in alphabetical order with their associated values
     assert leaf_paths == (('simple', 'nested', 'comb-leaf'), ('simple', 'vector'))
     assert leaf_vals == (['d', 'e'], [2, 3, 4])
 
@@ -79,30 +81,28 @@ def test_expand_tree():
                                                     'leaf': ['d', 'e'],
                                                     'combleaf': CombinatorialLeaf(['a', 'b', 'c'])}}})
     result = [{'simple': {'scalar': 1, 'vector': 2, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'a'}}},
-              {'simple': {'scalar': 1, 'vector': 2, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'b'}}},
-              {'simple': {'scalar': 1, 'vector': 2, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'c'}}},
               {'simple': {'scalar': 1, 'vector': 3, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'a'}}},
-              {'simple': {'scalar': 1, 'vector': 3, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'b'}}},
-              {'simple': {'scalar': 1, 'vector': 3, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'c'}}},
               {'simple': {'scalar': 1, 'vector': 4, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'a'}}},
+              {'simple': {'scalar': 1, 'vector': 2, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'b'}}},
+              {'simple': {'scalar': 1, 'vector': 3, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'b'}}},
               {'simple': {'scalar': 1, 'vector': 4, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'b'}}},
+              {'simple': {'scalar': 1, 'vector': 2, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'c'}}},
+              {'simple': {'scalar': 1, 'vector': 3, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'c'}}},
               {'simple': {'scalar': 1, 'vector': 4, 'nested': {'leaf': ['d', 'e'], 'combleaf': 'c'}}}]
-    assert all(exp in result for exp in simple_tree)
+    assert result == [exp for exp in simple_tree]
 
     # Test named_combinations generator using either order to account for generator randomness
-    expected_names_A = set(['2_a', '3_a', '4_a', '2_b', '3_b', '4_b', '2_c', '3_c', '4_c'])
-    expected_names_B = set(['a_2', 'a_3', 'a_4', 'b_2', 'b_3', 'b_4', 'c_2', 'c_3', 'c_4'])
-    expected_names = [expected_names_A, expected_names_B]
-    assert set([name for name, _ in simple_tree.named_combinations(separator='_', max_name_length=3)]) in expected_names
+    expected_names = {'a_2', 'a_3', 'a_4', 'b_2', 'b_3', 'b_4', 'c_2', 'c_3', 'c_4'}
+    assert expected_names == set([name for name, _ in simple_tree.named_combinations(separator='_',
+                                                                                     max_name_length=3)])
 
     # Test maximum length, similar names and special characters
     long_tree = CombinatorialTree({'key1': CombinatorialLeaf(['th#*&^isnameistoolong1',
                                                               'th#*&^isnameistoolong2']),
                                    'key2': CombinatorialLeaf(['test1', 'test2'])})
-    expected_names_A = set(['test-thisn', 'test-thisn-2', 'test-thisn-3', 'test-thisn-4'])
-    expected_names_B = set(['thisn-test', 'thisn-test-2', 'thisn-test-3', 'thisn-test-4'])
-    expected_names = [expected_names_A, expected_names_B]
-    assert set([name for name, _ in long_tree.named_combinations(separator='-', max_name_length=10)]) in expected_names
+    expected_names = {'thisn-test', 'thisn-test-2', 'thisn-test-3', 'thisn-test-4'}
+    assert expected_names == set([name for name, _ in long_tree.named_combinations(separator='-',
+                                                                                   max_name_length=10)])
 
     # Test file paths are handled correctly
     examples_dir = get_data_filename(os.path.join('..', 'examples'))
@@ -110,12 +110,10 @@ def test_expand_tree():
     benzene = os.path.join(examples_dir, 'benzene-toluene-explicit', 'setup', 'benzene.tripos.mol2')
     long_tree = CombinatorialTree({'key1': CombinatorialLeaf([abl, benzene]),
                                    'key2': CombinatorialLeaf([benzene, benzene, 'notapath'])})
-    expected_names_A = set(['benzene-2HYYpdbfixer', 'benzene-2HYYpdbfixer-2', 'notapath-2HYYpdbfixer',
-                          'benzene-benzene', 'benzene-benzene-2', 'notapath-benzene'])
-    expected_names_B = set(['2HYYpdbfixer-benzene', '2HYYpdbfixer-benzene-2', '2HYYpdbfixer-notapath',
-                          'benzene-benzene', 'benzene-benzene-2', 'benzene-notapath'])
-    expected_names = [expected_names_A, expected_names_B]
-    assert set([name for name, _ in long_tree.named_combinations(separator='-', max_name_length=25)]) in expected_names
+    expected_names = {'2HYYpdbfixer-benzene', '2HYYpdbfixer-benzene-2', '2HYYpdbfixer-notapath',
+                      'benzene-benzene', 'benzene-benzene-2', 'benzene-notapath'}
+    assert expected_names == set([name for name, _ in long_tree.named_combinations(separator='-',
+                                                                                   max_name_length=25)])
 
 
 def test_expand_id_nodes():
@@ -131,8 +129,9 @@ def test_expand_id_nodes():
     assert t['molecules'] == {'mol1_1': {'mol_value': 1}, 'mol1_2': {'mol_value': 2},
                               'mol2_3': {'mol_value': 3}, 'mol2_4': {'mol_value': 4}}
     assert t['systems'] == {'sys1': {'molecules': CombinatorialLeaf(['mol1_2', 'mol1_1'])},
-                        'sys2': {'molecules': CombinatorialLeaf(['mol1_2', 'mol1_1', 'mol2_3', 'mol2_4'])},
+                            'sys2': {'molecules': CombinatorialLeaf(['mol1_2', 'mol1_1', 'mol2_3', 'mol2_4'])},
                             'sys3': {'prmtopfile': 'mysystem.prmtop'}}
+
 
 def test_topology_serialization():
     """Correct serialization of Topology objects."""

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -546,9 +546,7 @@ def test_validation_correct_protocols():
             assert sorted_protocol.keys() == protocol.keys()
         else:
             assert isinstance(sorted_protocol, collections.OrderedDict)
-            for key in sorted_protocol.keys():
-                first_phase = key
-                break
+            first_phase = next(iter(sorted_protocol.keys()))  # py2/3 compatible
             assert 'complex' in first_phase or 'solvent1' in first_phase
 
 
@@ -866,7 +864,7 @@ class TestMultiMoleculeFiles():
 
     # TODO: Fix this test to not be literal check. Py3 causes the combined litteral names to not always be the same
     @unittest.skipIf(not utils.is_openeye_installed(), 'This test requires OpenEye installed.')
-    def notest_expand_molecules(self):
+    def test_expand_molecules(self):
         """Check that combinatorial molecules are handled correctly."""
         yaml_content = """
         ---
@@ -1369,8 +1367,7 @@ def test_charged_ligand():
         explicit-system:
             receptor: !Combinatorial {}
             ligand: imatinib
-        """.format(imatinib_path, [key for key in receptors.keys()]))
-        #""".format(imatinib_path, receptors.keys()))
+        """.format(imatinib_path, list(receptors.keys())))
         yaml_content = get_template_script(tmp_dir)
         yaml_content['molecules'].update(updates['molecules'])
         yaml_content['systems']['explicit-system'].update(updates['explicit-system'])

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -485,8 +485,7 @@ def test_validation_wrong_systems():
 
 def test_order_phases():
     """YankLoader preserves protocol phase order."""
-    ordered_phases = ['complex', 'solvent', 'athirdphase']
-    yaml_content = """
+    yaml_content_template = """
     ---
     absolute-binding:
         {}:
@@ -500,16 +499,19 @@ def test_order_phases():
         {}:
             alchemical_path:
                 lambda_electrostatics: [1.0, 0.8, 0.6, 0.3, 0.0]
-                lambda_sterics: [1.0, 0.8, 0.6, 0.3, 0.0]""".format(*ordered_phases)
+                lambda_sterics: [1.0, 0.8, 0.6, 0.3, 0.0]"""
 
-    # Be sure that normal parsing is not ordered or the test is useless
-    parsed = yaml.load(textwrap.dedent(yaml_content))
-    assert list(parsed['absolute-binding'].keys()) != ordered_phases
+    # Find order of phases for which normal parsing is not ordered or the test is useless
+    for ordered_phases in itertools.permutations(['athirdphase', 'complex', 'solvent']):
+        yaml_content = yaml_content_template.format(*ordered_phases)
+        parsed = yaml.load(textwrap.dedent(yaml_content))
+        if tuple(parsed['absolute-binding'].keys()) != ordered_phases:
+            break
 
     # Insert !Ordered tag
     yaml_content = yaml_content.replace('binding:', 'binding: !Ordered')
     parsed = yank_load(yaml_content)
-    assert list(parsed['absolute-binding'].keys()) == ordered_phases
+    assert tuple(parsed['absolute-binding'].keys()) == ordered_phases
 
 
 def test_validation_correct_protocols():

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -599,9 +599,9 @@ class CombinatorialTree(collections.MutableMapping):
         combinatorial_leaf_vals = [leaf_vals[i] for i in combinatorial_ids]
 
         # Sort leaves by alphabetical order of the path
-        combinatorial_leaf_paths, combinatorial_leaf_vals = zip(*sorted(zip(combinatorial_leaf_paths,
-                                                                            combinatorial_leaf_vals)))
-
+        if len(combinatorial_leaf_paths) > 0:
+            combinatorial_leaf_paths, combinatorial_leaf_vals = zip(*sorted(zip(combinatorial_leaf_paths,
+                                                                                combinatorial_leaf_vals)))
         return combinatorial_leaf_paths, combinatorial_leaf_vals
 
     def _combinations_generator(self, leaf_paths, leaf_vals):

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -544,14 +544,14 @@ class CombinatorialTree(collections.MutableMapping):
     def _find_leaves(self):
         """Traverse a dict tree and find the leaf nodes.
 
-        Returns:
-        --------
+        Returns
+        -------
         A tuple containing two lists. The first one is a list of paths to the leaf
         nodes in a tuple format (e.g. the path to node['a']['b'] is ('a', 'b')) while
         the second one is a list of all the values of those leaf nodes.
 
-        Examples:
-        ---------
+        Examples
+        --------
         >>> simple_tree = CombinatorialTree({'simple': {'scalar': 1,
         ...                                             'vector': [2, 3, 4],
         ...                                             'nested': {
@@ -582,17 +582,26 @@ class CombinatorialTree(collections.MutableMapping):
     def _find_combinatorial_leaves(self):
         """Traverse a dict tree and find CombinatorialLeaf nodes.
 
-        Returns:
-        --------
-        A tuple containing two lists. The first one is a list of paths to combinatorial
-        leaf nodes in a tuple format (e.g. the path to node['a']['b'] is ('a', 'b')) while
-        the second one is a list of the values of those nodes.
+        Returns
+        -------
+        combinatorial_leaf_paths, combinatorial_leaf_vals : tuple of tuples
+            combinatorial_leaf_paths is a tuple of paths to combinatorial leaf
+            nodes in tuple format (e.g. the path to node['a']['b'] is ('a', 'b'))
+            while combinatorial_leaf_vals is the tuple of the values of those nodes.
+            The list of paths is guaranteed to be sorted by alphabetical order.
 
         """
         leaf_paths, leaf_vals = self._find_leaves()
+
+        # Filter leaves that are not combinatorial
         combinatorial_ids = [i for i, val in enumerate(leaf_vals) if isinstance(val, CombinatorialLeaf)]
         combinatorial_leaf_paths = [leaf_paths[i] for i in combinatorial_ids]
         combinatorial_leaf_vals = [leaf_vals[i] for i in combinatorial_ids]
+
+        # Sort leaves by alphabetical order of the path
+        combinatorial_leaf_paths, combinatorial_leaf_vals = zip(*sorted(zip(combinatorial_leaf_paths,
+                                                                            combinatorial_leaf_vals)))
+
         return combinatorial_leaf_paths, combinatorial_leaf_vals
 
     def _combinations_generator(self, leaf_paths, leaf_vals):


### PR DESCRIPTION
Fix #490, #491, and #493.

Combinatorial leaves are iterated always in the same order (alphabetical order of the string tree path), so that the automatically generated name of the combination is the same. This fixes resuming simulations (since the name of the experiment folder could be different for different runs) and simplifies tests.