### PR TITLE
Fixing the doc build pointer

### DIFF
--- a/devtools/travis-ci/push-docs-to-s3.py
+++ b/devtools/travis-ci/push-docs-to-s3.py
@@ -32,7 +32,7 @@ secret_key = {AWS_SECRET_ACCESS_KEY}
 
     # Sync index file.
     template = ('s3cmd --guess-mime-type --config {config} '
-                'sync devtools/ci/index.html s3://{bucket}/')
+                'sync devtools/travis-ci/index.html s3://{bucket}/')
     cmd = template.format(
             config=f.name,
             bucket=BUCKET_NAME)


### PR DESCRIPTION
This should now point to the correct version of the index.html. I hope

This may require more fixes to figure out how to get s3 to actually build the file. 

Do we know of a way to get travis to push to s3 to test without a merge? Better question: do we have a test page that isn't public, or at least not linked to on s3 based on PRs for us to test?