### PR TITLE
Add platform options

### DIFF
--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -33,9 +33,6 @@ Description:
 Required Arguments:
   -y, --yaml=FILEPATH           Path to the YAML script specifying options and/or how to set up and run the experiment.
 
-General Options:
-  --platform=PLATFORM           OpenMM Platform to use (Reference, CPU, OpenCL, CUDA)
-
 """
 
 #=============================================================================================
@@ -54,12 +51,11 @@ def dispatch(args):
     """
     if args['--yaml']:
         yaml_path = args['--yaml']
-        platform_name = args['--platform']
 
         if not os.path.isfile(yaml_path):
             raise ValueError('Cannot find YAML script "{}"'.format(yaml_path))
 
-        yaml_builder = YamlBuilder(yaml_source=yaml_path, platform_name=platform_name)
+        yaml_builder = YamlBuilder(yaml_source=yaml_path)
         yaml_builder.build_experiments()
         return True
 

--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -25,13 +25,16 @@ usage = """
 YANK script
 
 Usage:
-  yank script (-y=FILEPATH | --yaml=FILEPATH)
+  yank script (-y=FILEPATH | --yaml=FILEPATH) [--platform=PLATFORM]
 
 Description:
   Set up and run free energy calculations from a YAML scrpit. All options can be specified in the YAML script. 
 
 Required Arguments:
   -y, --yaml=FILEPATH           Path to the YAML script specifying options and/or how to set up and run the experiment.
+
+General Options:
+  --platform=PLATFORM           OpenMM Platform to use (Reference, CPU, OpenCL, CUDA)
 
 """
 
@@ -51,11 +54,12 @@ def dispatch(args):
     """
     if args['--yaml']:
         yaml_path = args['--yaml']
+        platform_name = args['--platform']
 
         if not os.path.isfile(yaml_path):
             raise ValueError('Cannot find YAML script "{}"'.format(yaml_path))
 
-        yaml_builder = YamlBuilder(yaml_source=yaml_path)
+        yaml_builder = YamlBuilder(yaml_source=yaml_path, platform_name=platform_name)
         yaml_builder.build_experiments()
         return True
 

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -570,7 +570,7 @@ class ReplicaExchange(object):
     # Options to store.
     options_to_store = ['collision_rate', 'constraint_tolerance', 'timestep', 'nsteps_per_iteration', 'number_of_iterations', 'equilibration_timestep', 'number_of_equilibration_iterations', 'title', 'minimize', 'replica_mixing_scheme', 'online_analysis', 'show_mixing_statistics']
 
-    def __init__(self, store_filename, mpicomm=None, mm=None, **kwargs):
+    def __init__(self, store_filename, mpicomm=None, platform=None, mm=None, **kwargs):
         """
         Initialize replica-exchange simulation facility.
 
@@ -582,6 +582,8 @@ class ReplicaExchange(object):
            OpenMM API implementation to use
         mpicomm : mpi4py communicator, optional, default=None
            MPI communicator, if parallel execution is desired
+        platform : simtk.openmm.Platform, optional, default=None
+            Platform to use for execution. If None, the fastest available platform is used.
 
         Other Parameters
         ----------------
@@ -601,7 +603,7 @@ class ReplicaExchange(object):
 
         # Set default options.
         # These can be changed externally until object is initialized.
-        self.platform = None
+        self.platform = platform
         self.platform_name = None
         self.integrator = None # OpenMM integrator to use for propagating dynamics
 

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -846,6 +846,12 @@ class ReplicaExchange(object):
         if not self._initialized:
             self._initialize_resume()
 
+        # Log platform configuration
+        if self.platform is None:
+            logger.info('No user-specified platform found. Will run with OpenMM default.')
+        else:
+            logger.info('Running with platform {}'.format(self.platform.getName()))
+
         # Main loop
         run_start_time = time.time()
         run_start_iteration = self.iteration

--- a/Yank/tests/test_cli.py
+++ b/Yank/tests/test_cli.py
@@ -114,4 +114,4 @@ def test_script_yaml():
         yaml_file_path = os.path.join(tmp_dir, 'yank.yaml')
         with open(yaml_file_path, 'w') as f:
             f.write(textwrap.dedent(yaml_content))
-        run_cli('script --yaml={} --platform=Reference'.format(yaml_file_path))
+        run_cli('script --yaml={}'.format(yaml_file_path))

--- a/Yank/tests/test_cli.py
+++ b/Yank/tests/test_cli.py
@@ -114,4 +114,4 @@ def test_script_yaml():
         yaml_file_path = os.path.join(tmp_dir, 'yank.yaml')
         with open(yaml_file_path, 'w') as f:
             f.write(textwrap.dedent(yaml_content))
-        run_cli('script --yaml={}'.format(yaml_file_path))
+        run_cli('script --yaml={} --platform=Reference'.format(yaml_file_path))

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -166,7 +166,7 @@ def test_replica_exchange(mpicomm=None, verbose=True):
     # Create and configure simulation object.
     simulation = ReplicaExchange(store_filename, mpicomm=mpicomm)
     simulation.create(states, seed_positions)
-    simulation.platform_name = 'Reference'
+    simulation.platform = openmm.Platform.getPlatformByName('Reference')
     simulation.minimize = False
     simulation.number_of_iterations = 200
     simulation.nsteps_per_iteration = 500
@@ -333,7 +333,7 @@ def notest_hamiltonian_exchange(mpicomm=None, verbose=True):
     # Create and configure simulation object.
     simulation = HamiltonianExchange(store_filename, mpicomm=mpicomm)
     simulation.create(reference_state, systems, seed_positions)
-    simulation.platform_name = 'Reference'
+    simulation.platform = openmm.Platform.getPlatformByName('Reference')
     simulation.number_of_iterations = 200
     simulation.timestep = 2.0 * units.femtoseconds
     simulation.nsteps_per_iteration = 500

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1493,9 +1493,8 @@ def test_select_fastest_platform():
     else:
         fastest_platform = 'CPU'
 
-    yaml_builder = YamlBuilder(yaml_source='options: {}')
-    yaml_builder._configure_platform(platform_precision='single')
-    assert yaml_builder._platform.getName() == fastest_platform
+    platform = YamlBuilder._determine_fastest_platform()
+    assert platform.getName() == fastest_platform
 
 
 def test_platform_precision_configuration():

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -2078,12 +2078,10 @@ class YamlBuilder:
            The fastest available platform.
 
         """
-        system = openmm.System()
-        system.addParticle(1.0 * unit.amu)  # system needs at least 1 particle
-        integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
-        context = openmm.Context(system, integrator)
-        platform = context.getPlatform()
-        del context, integrator
+        platform_speeds = np.array([openmm.Platform.getPlatform(i).getSpeed()
+                                    for i in range(openmm.Platform.getNumPlatforms())])
+        fastest_platform_id = np.argmax(platform_speeds)
+        platform = openmm.Platform.getPlatform(fastest_platform_id)
         return platform
 
     def _configure_platform(self, platform_precision):

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -2096,6 +2096,13 @@ class YamlBuilder:
 
         platform_name = self._platform.getName()
 
+        # Use only a single CPU thread if we are using the CPU platform.
+        # TODO: Since there is an environment variable that can control this,
+        # TODO: we may want to avoid doing this.
+        if platform_name == 'CPU' and self._mpicomm is not None:
+            logger.debug("Setting 'CpuThreads' to 1 because MPI is active.")
+            self._platform.setPropertyDefaultValue('CpuThreads', '1')
+
         # If user doesn't specify precision, determine default value
         if platform_precision is None:
             # Reference and CPU have only 1 precision model. We'll check

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -2067,6 +2067,25 @@ class YamlBuilder:
 
         return is_supported
 
+    @staticmethod
+    def _determine_fastest_platform():
+        """
+        Return the fastest available platform.
+
+        Returns
+        -------
+        platform : simtk.openmm.Platform
+           The fastest available platform.
+
+        """
+        system = openmm.System()
+        system.addParticle(1.0 * unit.amu)  # system needs at least 1 particle
+        integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
+        context = openmm.Context(system, integrator)
+        platform = context.getPlatform()
+        del context, integrator
+        return platform
+
     def _configure_platform(self, platform_precision):
         """
         Configure the platform to be used for simulation for the given precision.
@@ -2087,12 +2106,7 @@ class YamlBuilder:
         """
         # Determine and cache the fastest platform available
         if self._platform is None:
-            system = openmm.System()
-            system.addParticle(1.0 * unit.amu)  # system needs at least 1 particle
-            integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
-            context = openmm.Context(system, integrator)
-            self._platform = context.getPlatform()
-            del context, integrator
+            self._platform = self._determine_fastest_platform()
 
         platform_name = self._platform.getName()
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -2072,7 +2072,7 @@ class YamlBuilder:
         """
         platform_speeds = np.array([openmm.Platform.getPlatform(i).getSpeed()
                                     for i in range(openmm.Platform.getNumPlatforms())])
-        fastest_platform_id = np.argmax(platform_speeds)
+        fastest_platform_id = int(np.argmax(platform_speeds))
         platform = openmm.Platform.getPlatform(fastest_platform_id)
         return platform
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -2107,10 +2107,10 @@ class YamlBuilder:
         """
         # Determine the platform to configure
         if platform_name == 'fastest':
-            platform = openmm.Platform.getPlatformByName(platform_name)
+            platform = self._determine_fastest_platform()
             platform_name = platform.getName()
         else:
-            platform = self._determine_fastest_platform()
+            platform = openmm.Platform.getPlatformByName(platform_name)
 
         # Use only a single CPU thread if we are using the CPU platform.
         # TODO: Since there is an environment variable that can control this,

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -32,6 +32,8 @@ Detailed Options List
     * :ref:`output_dir <yaml_options_output_dir>`
     * :ref:`setup_dir <yaml_options_setup_dir>`
     * :ref:`experiments_dir <yaml_options_experiments_dir>`
+    * :ref:`platform <yaml_options_platform>`
+    * :ref:`precision <yaml_options_precision>`
 
   * :ref:`System and Simulation Prep <yaml_options_sys_and_sim_prep>`
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -99,6 +99,33 @@ The folder where all generate simulation setup files are stored. A folder will b
 
 Valid Options (experiments): <Path String>
 
+
+.. _yaml_options_platform:
+
+platform
+--------
+.. code-block:: yaml
+
+   options:
+     platform: fastest
+
+The OpenMM platform used to run the calculations. The default value (``fastest``) automatically selects the fastest available platform. Some platforms (especially ``CUDA`` and ``OpenCL``) may not be available on all systems.
+
+Valid options: [fastest]/CUDA/OpenCL/CPU/Reference
+
+.. _yaml_options_precision:
+
+precision
+---------
+.. code-block:: yaml
+
+   options:
+     precision: auto
+
+Floating point precision to use during the simulation. It can be set for OpenCL and CUDA platforms only. The default value (``auto``) is equivalent to ``mixed`` when the device support this precision, and ``single`` otherwise.
+
+Valid options: [auto]/double/mixed/single
+
 |
 
 .. _yaml_options_sys_and_sim_prep:
@@ -169,7 +196,7 @@ Valid options (298 * kelvin): <Quantity Temperature> [1]_
 
 .. _yaml_options_pressure:
 
-presuure
+pressure
 --------
 .. code-block:: yaml
 

--- a/examples/yank-yaml-cookbook/all-options.yaml
+++ b/examples/yank-yaml-cookbook/all-options.yaml
@@ -17,6 +17,13 @@ options:
   setup_dir: setup                  # The main folder where the setup and simulation files
   experiments_dir: experiments      # are saved. Relative paths are interpreted as relative
                                     # w.r.t. output_dir path.
+  platform: fastest                 # The OpenMM platform to use between 'Reference', 'CPU',
+                                    # 'OpenCL', and 'CUDA'. The default value 'fastest' selects
+                                    # automatically the fastest available platform.
+  precision: auto                   # Precision mode. For OpenCL and CUDA platforms, this
+                                    # can be set to 'single', 'mixed' or 'double'. The default
+                                    # value 'auto' selects always 'mixed' when the device
+                                    # support this precision, otherwise 'single'.
 
   # SYSTEM AND SIMULATION PREPARATION
   # ---------------------------------


### PR DESCRIPTION
Fix #441 and #481 . Should be ready for review if tests pass.

- Introduce the ability to specify the platform for the calculation through the `yank script` command and `Yank` API.
- Add `precision` option in YAML.
- Set the platform default precision mode to `mixed` when possible. Note that some devices do not support double or mixed precision for the OpenCL platform. In that case the default value is `single`.

Currently I've implemented the system so that the driver class takes care of the platform configuration (i.e. correcting the default precision to `mixed`), and passes a `Platform` object to `Yank`. If nothing is passed, the OpenMM default is used.