### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,36 @@
 [![Travis Build Status](https://travis-ci.org/choderalab/yank.png)](https://travis-ci.org/choderalab/yank)
-[![Jenkins Test Status](https://jenkins.choderalab.org/buildStatus/icon?job=test-yank-linux-xeon-gtxtitan-jak)](https://jenkins.choderalab.org/job/test-yank-linux-xeon-gtxtitan-jak/)
 [![Anaconda Cloud Badge](https://anaconda.org/omnia/yank/badges/version.svg)](https://anaconda.org/omnia/yank)
 [![Anaconda Cloud Downloads](https://anaconda.org/omnia/yank/badges/downloads.svg)](https://anaconda.org/omnia/yank)
 [![DOI](https://zenodo.org/badge/13779937.svg)](https://zenodo.org/badge/latestdoi/13779937)
 
-yank
+YANK
 ====
 
-YANK: GPU-accelerated calculation of ligand binding affinities in implicit and explicit solvent using alchemical free energy methodologies.
+An open, extensible Python framework for GPU-accelerated alchemical free energy calculations
 
 Documentation
 -------------
 
-Documentation and examples can be found at [getyank.org](http://getyank.org)
+Documentation, tutorials, and best practices can be found at [getyank.org](http://getyank.org).
+
+Getting Started
+---------------
+See the [Quickstart instructions](http://getyank.org/latest/quickstart.html).
 
 Examples
 --------
 
-Examples are made available through [their own repository](http://github.com/choderalab/yank-examples).
+Examples are available in the [`yank-examples` repository](http://github.com/choderalab/yank-examples):
+```bash
+git clone https://github.com/choderalab/yank-examples.git
+```
 
 Maintainers
 -----------
 
-* John D. Chodera `<john.chodera@choderalab.org>` (MSKCC)
-* Andrea Rizzi `<andrea.rizzi@choderalab.org>` (WCMC)
 * Levi N. Naden `<levi.naden@choderalab.org>` (MSKCC)
+* Andrea Rizzi `<andrea.rizzi@choderalab.org>` (WCMC)
+* John D. Chodera `<john.chodera@choderalab.org>` (MSKCC)
 
 Contributors
 ------------


### PR DESCRIPTION
This cleans up the README:
* Remove broken Jenkins badge
* Update current maintainer order
* Add instructions for getting examples
* Update tagline
* Add quickstart link