### PR TITLE
Fix restraints for periodic systems and expanded state. YAML syntax future-proof.

### DIFF
--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -396,7 +396,7 @@ def dispatch_binding(args):
     yank = Yank(store_dir, **options)
     if args['--restraints']:
         restraint_type = args['--restraints']
-    yank.create(thermodynamic_state, *alchemical_phases, restraint_type)
+    yank.create(thermodynamic_state, *alchemical_phases, restraint_type=restraint_type)
 
     # Dump analysis object
     analysis = [[alchemical_phases[0].name, 1], [alchemical_phases[1].name, -1]]

--- a/Yank/commands/prepare.py
+++ b/Yank/commands/prepare.py
@@ -71,7 +71,7 @@ Simulation options:
   --platform=PLATFORM           OpenMM Platform to use (Reference, CPU, OpenCL, CUDA)
   --precision=PRECISION         OpenMM Platform precision model to use (for CUDA or OpenCL only, one of {mixed, double, single})
   --pressure=PRESSURE           Pressure for simulation (in atm, or simtk.unit readable string) [default: 1*atmospheres]
-  --restraints=TYPE             Restraint type to add between protein and ligand in implicit solvent (harmonic, flat-bottom) [default: flat-bottom]
+  --restraints=TYPE             Restraint type to add between protein and ligand in implicit solvent (Harmonic, FlatBottom)
   --temperature=TEMPERATURE     Temperature for simulation (in K, or simtk.unit readable string) [default: 298*kelvin]
 
 
@@ -357,8 +357,6 @@ def dispatch_binding(args):
         options['number_of_equilibration_iterations'] = int(args['--equilibrate'])
     if args['--online-analysis']:
         options['online_analysis'] = True
-    if args['--restraints']:
-        options['restraint_type'] = args['--restraints']
     if args['--randomize-ligand']:
         options['randomize_ligand'] = True
     if args['--minimize']:
@@ -396,7 +394,9 @@ def dispatch_binding(args):
 
     # Create new simulation.
     yank = Yank(store_dir, **options)
-    yank.create(thermodynamic_state, *alchemical_phases)
+    if args['--restraints']:
+        restraint_type = args['--restraints']
+    yank.create(thermodynamic_state, *alchemical_phases, restraint_type)
 
     # Dump analysis object
     analysis = [[alchemical_phases[0].name, 1], [alchemical_phases[1].name, -1]]

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -281,7 +281,7 @@ def prepare_phase(positions_file_path, topology_file_path, ligand_dsl, system_op
             err_msg = 'Found periodic box in inpcrd file but nonbondedMethod is NoCutoff'
     else:
         if system_options['nonbondedMethod'] != openmm.app.NoCutoff:
-            err_msg = 'nonbondedMethod is NoCutoff but could not find periodic box in inpcrd.'
+            err_msg = 'nonbondedMethod has cutoff but could not find periodic box in inpcrd.'
     if len(err_msg) != 0:
         logger.error(err_msg)
         raise RuntimeError(err_msg)

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -274,14 +274,18 @@ def prepare_phase(positions_file_path, topology_file_path, ligand_dsl, system_op
     # Check for solvent configuration inconsistencies
     # TODO: Check to make sure both files agree on explicit/implicit.
     err_msg = ''
+    nonbonded_method = system_options['nonbondedMethod']
+    nonperiodic_nonbonded_methods = [openmm.app.NoCutoff, openmm.app.CutoffNonPeriodic]
     if is_periodic:
         if 'implicitSolvent' in system_options:
             err_msg = 'Found periodic box in inpcrd file and implicitSolvent specified.'
-        if system_options['nonbondedMethod'] == openmm.app.NoCutoff:
-            err_msg = 'Found periodic box in inpcrd file but nonbondedMethod is NoCutoff'
+        if nonbonded_method in nonperiodic_nonbonded_methods:
+            err_msg = ('Found periodic box in inpcrd file but '
+                       'nonbondedMethod is {}'.format(nonbonded_method))
     else:
-        if system_options['nonbondedMethod'] != openmm.app.NoCutoff:
-            err_msg = 'nonbondedMethod has cutoff but could not find periodic box in inpcrd.'
+        if nonbonded_method not in nonperiodic_nonbonded_methods:
+            err_msg = ('nonbondedMethod {} is periodic but could not '
+                       'find periodic box in inpcrd.'.format(nonbonded_method))
     if len(err_msg) != 0:
         logger.error(err_msg)
         raise RuntimeError(err_msg)

--- a/Yank/tests/test_cli.py
+++ b/Yank/tests/test_cli.py
@@ -109,6 +109,8 @@ def test_script_yaml():
         experiments:
             system: system
             protocol: absolute-binding
+            restraint:
+                type: FlatBottom
         """.format(lysozyme_path, pxylene_path)
 
         yaml_file_path = os.path.join(tmp_dir, 'yank.yaml')

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -111,7 +111,6 @@ options:
   output_dir: %(output_directory)s
   number_of_iterations: 2
   nsteps_per_iteration: 10
-  restraint_type: %(restraint_type)s
   temperature: 300*kelvin
   softcore_beta: 0.0
 
@@ -150,6 +149,8 @@ protocols:
 experiments:
   system: lys-pxyl
   protocol: absolute-binding
+  restraint:
+    type: %(restraint_type)s
 """
     # Test all possible restraint types.
     available_restraint_types = yank.restraints.available_restraint_types()

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -95,7 +95,8 @@ def get_template_script(output_dir='.'):
             antechamber: {{charge_method: bcc}}
         benzene-epik0:
             filepath: {benzene_path}
-            epik: 0
+            epik:
+                select: 0
             antechamber: {{charge_method: bcc}}
         benzene-epikcustom:
             filepath: {benzene_path}
@@ -322,18 +323,17 @@ def test_validation_correct_molecules():
         {'name': 'p-xylene', 'antechamber': {'charge_method': 'bcc'}},
         {'smiles': 'Cc1ccccc1', 'openeye': {'quacpac': 'am1-bcc'},
             'antechamber': {'charge_method': None}},
-        {'name': 'p-xylene', 'antechamber': {'charge_method': 'bcc'},  'epik': 0},
         {'name': 'p-xylene', 'antechamber': {'charge_method': 'bcc'},
             'epik': {'ph': 7.6, 'ph_tolerance': 0.7, 'tautomerize': False, 'select': 0}},
         {'smiles': 'Cc1ccccc1', 'openeye': {'quacpac': 'am1-bcc'},
-            'antechamber': {'charge_method': None}, 'epik': 1},
+            'antechamber': {'charge_method': None}, 'epik': {'select': 1}},
 
         {'filepath': paths['abl']},
         {'filepath': paths['abl'], 'leap': {'parameters': 'leaprc.ff99SBildn'}},
         {'filepath': paths['abl'], 'leap': {'parameters': 'leaprc.ff99SBildn'}, 'select': 1},
         {'filepath': paths['abl'], 'select': 'all'},
         {'filepath': paths['toluene'], 'leap': {'parameters': 'leaprc.gaff'}},
-        {'filepath': paths['benzene'], 'epik': 1}
+        {'filepath': paths['benzene'], 'epik': {'select': 1, 'tautomerize': False}}
     ]
     for molecule in molecules:
         yield YamlBuilder._validate_molecules, {'mol': molecule}
@@ -355,7 +355,8 @@ def test_validation_wrong_molecules():
         {'filepath': 'nonexistentfile.pdb', 'leap': {'parameters': 'leaprc.ff14SB'}},
         {'filepath': paths['toluene'], 'smiles': 'Cc1ccccc1'},
         {'filepath': paths['toluene'], 'strip_protons': True},
-        {'filepath': paths['abl'], 'leap': {'parameters': 'oldff/leaprc.ff14SB'}, 'epik': 0},
+        {'filepath': paths['abl'], 'leap': {'parameters': 'oldff/leaprc.ff14SB'}, 'epik': {'select': 0}},
+        {'name': 'toluene', 'epik': 0},
         {'name': 'toluene', 'epik': {'tautomerize': 6}},
         {'name': 'toluene', 'epik': {'extract_range': 1}},
         {'name': 'toluene', 'smiles': 'Cc1ccccc1'},
@@ -880,7 +881,7 @@ class TestMultiMoleculeFiles():
             lig:
                 name: !Combinatorial [iupac1, iupac2]
                 leap: {{parameters: leaprc.gaff}}
-                epik: !Combinatorial [0, 2]
+                epik: !Combinatorial [{select: 0}, {select: 2}]
             multi:
                 filepath: {}
                 leap: {{parameters: oldff/leaprc.ff14SB}}
@@ -930,19 +931,19 @@ class TestMultiMoleculeFiles():
             lig_0_iupac1:
                 name: iupac1
                 leap: {{parameters: leaprc.gaff}}
-                epik: 0
+                epik: {select: 0}
             lig_2_iupac1:
                 name: iupac1
                 leap: {{parameters: leaprc.gaff}}
-                epik: 2
+                epik: {select: 2}
             lig_0_iupac2:
                 name: iupac2
                 leap: {{parameters: leaprc.gaff}}
-                epik: 0
+                epik: {select: 0}
             lig_2_iupac2:
                 name: iupac2
                 leap: {{parameters: leaprc.gaff}}
-                epik: 2
+                epik: {select: 2}
             multi_0:
                 filepath: {}
                 leap: {{parameters: oldff/leaprc.ff14SB}}

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -880,7 +880,8 @@ class TestMultiMoleculeFiles():
             lig:
                 name: !Combinatorial [iupac1, iupac2]
                 leap: {{parameters: leaprc.gaff}}
-                epik: !Combinatorial [{select: 0}, {select: 2}]
+                epik:
+                    select: !Combinatorial [0, 2]
             multi:
                 filepath: {}
                 leap: {{parameters: oldff/leaprc.ff14SB}}
@@ -930,19 +931,19 @@ class TestMultiMoleculeFiles():
             lig_0_iupac1:
                 name: iupac1
                 leap: {{parameters: leaprc.gaff}}
-                epik: {select: 0}
+                epik: {{select: 0}}
             lig_2_iupac1:
                 name: iupac1
                 leap: {{parameters: leaprc.gaff}}
-                epik: {select: 2}
+                epik: {{select: 2}}
             lig_0_iupac2:
                 name: iupac2
                 leap: {{parameters: leaprc.gaff}}
-                epik: {select: 0}
+                epik: {{select: 0}}
             lig_2_iupac2:
                 name: iupac2
                 leap: {{parameters: leaprc.gaff}}
-                epik: {select: 2}
+                epik: {{select: 2}}
             multi_0:
                 filepath: {}
                 leap: {{parameters: oldff/leaprc.ff14SB}}

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -262,7 +262,6 @@ def test_yaml_parsing():
         pressure: null
         constraints: AllBonds
         hydrogen_mass: 2*amus
-        restraint_type: Harmonic
         randomize_ligand: yes
         randomize_ligand_sigma_multiplier: 2.0
         randomize_ligand_close_cutoff: 1.5 * angstrom
@@ -287,8 +286,8 @@ def test_yaml_parsing():
     """
 
     yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
-    assert len(yaml_builder.options) == 35
-    assert len(yaml_builder.yank_options) == 23
+    assert len(yaml_builder.options) == 34
+    assert len(yaml_builder.yank_options) == 22
 
     # Check correct types
     assert yaml_builder.options['pressure'] is None
@@ -1763,6 +1762,8 @@ def test_run_experiment():
                 setup_dir: ''
                 experiments_dir: ''
             protocol: absolute-binding
+            restraint:
+                type: FlatBottom
         """.format(examples_paths()['lysozyme'], examples_paths()['p-xylene'],
                    indent(standard_protocol), tmp_dir)
 

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1610,6 +1610,7 @@ def test_yaml_creation():
         # left untouched
         expected_yaml_content = textwrap.dedent("""
         ---
+        version: '{}'
         options:
             experiments_dir: .
             output_dir: .
@@ -1622,7 +1623,7 @@ def test_yaml_creation():
         systems:{}
         protocols:{}
         experiments:{}
-        """.format(molecules, os.path.relpath(ligand_path, tmp_dir),
+        """.format(HIGHEST_VERSION, molecules, os.path.relpath(ligand_path, tmp_dir),
                    solvent, system, protocol, experiment))
         expected_yaml_content = expected_yaml_content[1:]  # remove first '\n'
 

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -50,7 +50,7 @@ def test_parameters():
     """Test Yank parameters initialization."""
 
     # Check that both Yank and Repex parameters are accepted
-    Yank(store_directory='test', restraint_type='harmonic', nsteps_per_iteration=1)
+    Yank(store_directory='test', randomize_ligand=True, nsteps_per_iteration=1)
 
 @tools.raises(TypeError)
 def test_unknown_parameters():
@@ -148,7 +148,6 @@ def notest_LennardJonesPair(box_width_nsigma=6.0):
 
     # Initialize YANK object.
     options = dict()
-    options['restraint_type'] = None
     options['number_of_iterations'] = 10
     options['platform'] = openmm.Platform.getPlatformByName("Reference") # use Reference platform for speed
     options['mc_rotation'] = False

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -854,15 +854,10 @@ class SetupDatabase:
                 epik_mol2_file = epik_base_path + 'mol2'
                 epik_sdf_file = epik_base_path + 'sdf'
 
-                # The 'epik' keyword can contain both a dictionary with the
-                # arguments to pass to run_epik(), or just the index
-                epik_args = mol_descr['epik']
-                if not isinstance(epik_args, dict):
-                    epik_args = {'extract_range': epik_args, 'tautomerize': False}
-
                 # Run epik and convert from maestro to both mol2 and sdf
                 # to not lose neither the penalties nor the residue name
-                omt.schrodinger.run_epik(mol_descr['filepath'], epik_mae_file, **epik_args)
+                epik_kwargs = mol_descr['epik']
+                omt.schrodinger.run_epik(mol_descr['filepath'], epik_mae_file, **epik_kwargs)
                 omt.schrodinger.run_structconvert(epik_mae_file, epik_sdf_file)
                 omt.schrodinger.run_structconvert(epik_mae_file, epik_mol2_file)
 
@@ -1530,9 +1525,9 @@ class YamlBuilder:
         validated_molecules = molecules_description.copy()
 
         # Define molecules Schema
-        epik_schema = Or(int, utils.generate_signature_schema(omt.schrodinger.run_epik,
-                                                              update_keys={'select': int},
-                                                              exclude_keys=['extract_range']))
+        epik_schema = utils.generate_signature_schema(omt.schrodinger.run_epik,
+                                                      update_keys={'select': int},
+                                                      exclude_keys=['extract_range'])
 
         parameters_schema = {  # simple strings are converted to list of strings
             'parameters': And(Use(lambda p: [p] if isinstance(p, str) else p), [str])}

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1812,9 +1812,13 @@ class YamlBuilder:
             self._experiments = {}
             return
 
+        # Restraint schema
+        restraint_schema = {'type': str}
+
         # Define experiment Schema
         experiment_schema = Schema({'system': is_known_system, 'protocol': is_known_protocol,
-                                    Optional('options'): Use(YamlBuilder._validate_options)})
+                                    Optional('options'): Use(YamlBuilder._validate_options),
+                                    Optional('restraint'): restraint_schema})
 
         # Schema validation
         for experiment_id, experiment_descr in self._expand_experiments():
@@ -2383,8 +2387,14 @@ class YamlBuilder:
                 thermodynamic_state = ThermodynamicState(temperature=exp_opts['temperature'],
                                                          pressure=exp_opts['pressure'])
 
+                # Determine restraint
+                try:
+                    restraint_type = experiment['restraint']['type']
+                except (KeyError, TypeError):  # restraint unspecified or None
+                    restraint_type = None
+
                 # Create new simulation
-                yank.create(thermodynamic_state, *phases)
+                yank.create(thermodynamic_state, *phases, restraint_type=restraint_type)
 
             # Run the simulation
             if self._mpicomm:  # wait for the simulation to be prepared

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -424,7 +424,7 @@ class Yank(object):
 
         # Construct thermodynamic states
         reference_state = copy.deepcopy(thermodynamic_state)
-        reference_state.system = reference_system
+        reference_state.system = copy.deepcopy(reference_system)
         reference_LJ_state = copy.deepcopy(thermodynamic_state)
         reference_LJ_expanded_state = copy.deepcopy(thermodynamic_state)
         reference_LJ_state.system = reference_system_LJ

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -234,7 +234,7 @@ class Yank(object):
 
         return
 
-    def create(self, thermodynamic_state, *alchemical_phases, restraint_type=None):
+    def create(self, thermodynamic_state, *alchemical_phases, **kwargs):
         """
         Set up a new set of alchemical free energy calculations for the specified phases.
 
@@ -250,6 +250,11 @@ class Yank(object):
            available only in implicit solvent (default: None).
 
         """
+        # Get kwargs
+        restraint_type = kwargs.pop('restraint_type')
+        if len(kwargs) != 0:
+            raise TypeError('got unexpected keyword arguments {}'.format(kwargs))
+
         # Make a deep copy of thermodynamic state.
         thermodynamic_state = copy.deepcopy(thermodynamic_state)
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -251,7 +251,7 @@ class Yank(object):
 
         """
         # Get kwargs
-        restraint_type = kwargs.pop('restraint_type')
+        restraint_type = kwargs.pop('restraint_type', None)
         if len(kwargs) != 0:
             raise TypeError('got unexpected keyword arguments {}'.format(kwargs))
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -28,7 +28,7 @@ import simtk.openmm as openmm
 
 from alchemy import AbsoluteAlchemicalFactory
 from .sampling import ModifiedHamiltonianExchange
-from .restraints import create_restraints
+from .restraints import create_restraints, V0
 
 from . import utils
 
@@ -124,7 +124,6 @@ class Yank(object):
     """
 
     default_parameters = {
-        'restraint_type': 'FlatBottom',
         'randomize_ligand': False,
         'randomize_ligand_sigma_multiplier': 2.0,
         'randomize_ligand_close_cutoff': 1.5 * unit.angstrom,
@@ -144,10 +143,6 @@ class Yank(object):
         platform : simtk.openmm.Platform, optional
             Platform to use for execution. If None, the fastest available platform
             is used (default: None).
-        restraint_type : str, optional
-           Restraint type to add between protein and ligand.
-           Supported types are 'FlatBottom' and 'Harmonic'
-           The second one is available only in implicit solvent (default: 'FlatBottom').
         randomize_ligand : bool, optional
            Randomize ligand position when True. Not available in explicit solvent
            (default: False).
@@ -239,7 +234,7 @@ class Yank(object):
 
         return
 
-    def create(self, thermodynamic_state, *alchemical_phases):
+    def create(self, thermodynamic_state, *alchemical_phases, restraint_type=None):
         """
         Set up a new set of alchemical free energy calculations for the specified phases.
 
@@ -249,6 +244,10 @@ class Yank(object):
             Thermodynamic state from which reference temperature and pressure are to be taken.
         *alchemical_phases :
             Variable list of AlchemicalPhase objects to create.
+        restraint_type : str, optional
+           Restraint type to add between protein and ligand. Supported
+           types are 'FlatBottom' and 'Harmonic'. The second one is
+           available only in implicit solvent (default: None).
 
         """
         # Make a deep copy of thermodynamic state.
@@ -274,14 +273,14 @@ class Yank(object):
 
         # Create new repex simulations.
         for phase in alchemical_phases:
-            self._create_phase(thermodynamic_state, phase)
+            self._create_phase(thermodynamic_state, phase, restraint_type)
 
         # Record that we are now initialized.
         self._initialized = True
 
         return
 
-    def _create_phase(self, thermodynamic_state, alchemical_phase):
+    def _create_phase(self, thermodynamic_state, alchemical_phase, restraint_type):
         """
         Create a repex object for a specified phase.
 
@@ -291,6 +290,10 @@ class Yank(object):
             Thermodynamic state from which reference temperature and pressure are to be taken.
         alchemical_phase : AlchemicalPhase
            The alchemical phase to be created.
+        restraint_type : str or None
+           Restraint type to add between protein and ligand. Supported
+           types are 'FlatBottom' and 'Harmonic'. The second one is
+           available only in implicit solvent.
 
         """
         # We add default repex options only on creation, on resume repex will pick them from the store file
@@ -327,8 +330,9 @@ class Yank(object):
 
         # TODO: Use more general approach to determine whether system is periodic.
         is_periodic = reference_system.usesPeriodicBoundaryConditions()
-        is_complex_explicit = len(atom_indices['receptor']) > 0 and is_periodic
-        is_complex_implicit = len(atom_indices['receptor']) > 0 and not is_periodic
+        is_complex = len(atom_indices['receptor']) > 0
+        is_complex_explicit = is_complex and is_periodic
+        is_complex_implicit = is_complex and not is_periodic
 
         # Make sure pressure is None if not periodic.
         if not is_periodic:
@@ -429,22 +433,27 @@ class Yank(object):
         # Compute standard state corrections for complex phase.
         metadata['standard_state_correction'] = 0.0
         # TODO: Do we need to include a standard state correction for other phases in periodic boxes?
-        if is_complex_implicit:
-            # Impose restraints for complex system in implicit solvent to keep ligand from drifting too far away from receptor.
+        if is_complex and restraint_type is not None:
             logger.debug("Creating receptor-ligand restraints...")
             reference_positions = positions[0]
-            restraints = create_restraints(self._restraint_type,
-                alchemical_phase.reference_topology, thermodynamic_state, reference_system, reference_positions, atom_indices['receptor'], atom_indices['ligand'])
-            force = restraints.get_restraint_force() # Get Force object incorporating restraints
+            restraints = create_restraints(restraint_type, alchemical_phase.reference_topology,
+                                           thermodynamic_state, reference_system, reference_positions,
+                                           atom_indices['receptor'], atom_indices['ligand'])
+            force = restraints.get_restraint_force()  # Get Force object incorporating restraints.
             reference_system.addForce(force)
-            metadata['standard_state_correction'] = restraints.get_standard_state_correction() # standard state correction in kT
+            metadata['standard_state_correction'] = restraints.get_standard_state_correction()  # in kT
         elif is_complex_explicit:
-            # For periodic systems, we do not use a restraint, but must add a standard state correction for the box volume.
+            # For periodic systems, we must still add a standard state
+            # correction for the box volume.
             # TODO: What if the box volume fluctuates during the simulation?
             box_vectors = reference_system.getDefaultPeriodicBoxVectors()
             box_volume = thermodynamic_state._volume(box_vectors)
-            STANDARD_STATE_VOLUME = 1660.53928 * unit.angstrom**3
-            metadata['standard_state_correction'] = - np.log(STANDARD_STATE_VOLUME / box_volume)
+            metadata['standard_state_correction'] = - np.log(V0 / box_volume)
+        elif is_complex_implicit:
+            # For implicit solvent/vacuum complex systems, we require a restraint
+            # to keep the ligand from drifting too far away from receptor.
+            raise ValueError('A receptor-ligand system in implicit solvent or '
+                             'vacuum requires a restraint.')
 
         # Create alchemically-modified states using alchemical factory.
         logger.debug("Creating alchemically-modified states...")

--- a/docs/examples/benzene-toluene-implicit.rst
+++ b/docs/examples/benzene-toluene-implicit.rst
@@ -15,7 +15,7 @@ The `OBC2` implicit solvent model is used, and the temperature is set to 300 Kel
 
 .. code-block:: none
 
-   $ yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
+   $ yank prepare binding amber --setupdir=setup --ligand="resname BEN" --store=output --iterations=1000 --restraints=Harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
 
 Run the simulation in serial mode with verbose output:
 

--- a/docs/examples/p-xylene-implicit.rst
+++ b/docs/examples/p-xylene-implicit.rst
@@ -15,7 +15,7 @@ The `OBC2` implicit solvent model is used, and the temperature is set to 300 Kel
 
 .. code-block:: none
 
-   $ yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1000 --restraints=harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
+   $ yank prepare binding amber --setupdir=setup --ligand="resname MOL" --store=output --iterations=1000 --restraints=Harmonic --gbsa=OBC2 --temperature=300*kelvin --verbose
 
 Run the simulation in serial mode with verbose output:
 

--- a/docs/yamlpages/cookbook.rst
+++ b/docs/yamlpages/cookbook.rst
@@ -49,7 +49,6 @@ In this example:
     output_dir: output
     experiments_dir: experiments
     randomize_ligand: yes
-    restraint_type: flat-bottom
     minimize: yes
     number_of_iterations: 2000
     temperature: 300*kelvin
@@ -92,6 +91,8 @@ In this example:
   experiments:
     system: T4-xylene-complex
     protocol: absolute-binding
+    restraint:
+      type: FlatBottom
                 
 After this is all setup, simply run: ``yank script --yaml={ThisScriptName.yaml}`` and YANK will take care of the rest for you.
 
@@ -124,7 +125,6 @@ In this Example:
      verbose: yes
      output_dir: .
      number_of_iterations: 2000
-     restraint_type: harmonic
      temperature: 300*kelvin
      pressure: 1*atmosphere
 
@@ -168,6 +168,8 @@ In this Example:
   experiments:
     system: t4-xylene-explicit
     protocol: absolute-binding
+    restraint:
+      type: Harmonic
 
 Now run: 
 

--- a/docs/yamlpages/experiments.rst
+++ b/docs/yamlpages/experiments.rst
@@ -19,13 +19,17 @@ Experiments Syntax
    experiments:
      system: {UserDefinedSystem}
      protocol: {UserDefinedProtocol}
+     restraint:
+       type: FlatBottom
      options:
        {Any Valid Option}
        {Any Valid Option}
        ...
 
-This is the structure of an ``experimenet``. 
+This is the structure of an ``experiment``.
 It takes a ``{UserDefinedSystem}`` (see :doc:`systems <systems>`) and a ``{UserDefinedProtocol}`` (see :doc:`protocols <protocols>`)  to create the experiment.
+
+The ``restraint`` is an optional keyword that applies a restraint to the ligand to keep it close to the receptor. Valid types are: FlatBottom/Harmonic/Boresch/null.
 
 The ``options`` directive lets you overwrite :doc:`any global setting <options>` specified in the header ``options`` for this specific experiment.
 

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -164,3 +164,5 @@ Detailed Options List
     * :ref:`restraint <yaml_experiments_syntax>`
 
   * :ref:`Running Multiple Experiments <yaml_experiments_syntax>`
+
+* :doc:`version <version>`

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -44,7 +44,6 @@ Detailed Options List
     * :ref:`pressure <yaml_options_pressure>`
     * :ref:`hydrogen_mass <yaml_options_hydrogen_mass>`
     * :ref:`constraints <yaml_options_constraints>`
-    * :ref:`restraint_type <yaml_options_restraint_type>`
 
   * :ref:`Simulation Parameters: <yaml_options_simulation_parameters>`
 
@@ -162,5 +161,6 @@ Detailed Options List
     * :ref:`system <yaml_experiments_syntax>`
     * :ref:`protocol <yaml_experiments_syntax>`
     * :ref:`options <yaml_experiments_syntax>`
+    * :ref:`restraint <yaml_experiments_syntax>`
 
   * :ref:`Running Multiple Experiments <yaml_experiments_syntax>`

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -235,20 +235,6 @@ Constrain bond lengths and angles. See OpenMM ``createSystem()`` documentation f
 
 Valid options: [Hbonds]/AllBonds/HAngles
 
-
-.. _yaml_options_restraint_type:
-
-restraint_type
---------------
-.. code-block:: yaml
-
-   options:
-     restraint_type: FlatBottom
-
-Apply a restraint to the ligand to keep it close to the receptor. This only works in Implicit Solvent. ``null`` option means no restraint.
-
-Valid options: [FlatBottom]/Harmonic/null
-
 |
 
 .. _yaml_options_simulation_parameters:

--- a/docs/yamlpages/version.rst
+++ b/docs/yamlpages/version.rst
@@ -1,0 +1,16 @@
+.. _yaml_version_head:
+
+Version Header for YAML Files
+*****************************
+
+The ``version`` header is an **optional** section where we define the language specification version of our YAML files.
+
+The header provides a means to ensure that your YAML file will be supported by the version of YANK you are running on.
+
+The only valid version right now is "1.0" but as YANK develops, more options will become available.
+
+.. code-block:: yaml
+
+    version: 1.0
+
+Valid Options: [1.0]

--- a/docs/yank-yaml-cookbook/all-options.yaml
+++ b/docs/yank-yaml-cookbook/all-options.yaml
@@ -38,9 +38,6 @@ options:
   hydrogen_mass: 1.0 * amu                      # Hydrogen mass for HMR simulations.
   constraints: HBonds                           # Constrain bond lengths and angles. Possible values are null,
                                                 # HBonds, AllBonds, and HAngles (see Openmm createSystem()).
-  restraint_type: FlatBottom                    # Apply a restrain to the ligand to keep it close to the
-                                                # receptor. Possible values are null, Harmonic, and FlatBottom.
-                                                # This works only implicit solvent.
 
   # SIMULATION PARAMETERS
   # ---------------------

--- a/docs/yank-yaml-cookbook/combinatorial-experiment.yaml
+++ b/docs/yank-yaml-cookbook/combinatorial-experiment.yaml
@@ -215,8 +215,11 @@ protocols:
 experiments:
   system: kinase-inhibitor
   protocol: absolute-binding
-  options:                                                  # All options that can be specified in the "options"
-    restraint_type: !Combinatorial [Harmonic, FlatBottom]   # section can be included here.
+  restraint:                                                 # Optionally, apply a restrain to the ligand to keep
+    type: !Combinatorial [Harmonic, FlatBottom]              # it close to the receptor. Possible types are null,
+                                                             # Harmonic, FlatBottom, and Boresch.
+  options:                                                   # All options that can be specified in the "options"
+    temperature: !Combinatorial [298.0*kelvin, 307.0*kelvin] # section can be included here.
 
 
 # It is also possible to specify a sequence of experiments with the syntax

--- a/docs/yank-yaml-cookbook/combinatorial-experiment.yaml
+++ b/docs/yank-yaml-cookbook/combinatorial-experiment.yaml
@@ -89,20 +89,12 @@ molecules:
                                                     # Notice that charge_method is set to null to keep the
                                                     # partial charges determined by openeye.
                                                     #
-    epik: 0                                         # Run Schrodinger's tool Epik with default parameters and
-                                                    # select the most likely protonation state for the molecule
-                                                    # (in solution). More control over epik parameters is possible
-                                                    #
-                                                    # molecules:
-                                                    #   imatinib:
-                                                    #     filepath: imatinib.mol2
-                                                    #     antechamber:
-                                                    #       charge_method: bcc
-                                                    #     epik:
-                                                    #       select: 0
-                                                    #       ph: 7.6
-                                                    #       ph_tolerance: 0.7
-                                                    #       tautomerize: no
+    epik:                                           # Run Schrodinger's tool Epik with default parameters and
+      select: 0                                     # select the most likely protonation state for the molecule
+      tautomerize: no                               # (in solution). More control over epik parameters is
+      ph: 7.6                                       # possible (see YAML documentation).
+      ph_tolerance: 0.7
+
   bosutinib:
     filepath: molecule_dir/bosutinib.mol2
     leap:                                           # It is possible to optionally include molecule-specific


### PR DESCRIPTION
Fix restraints:
- Fix #245: Add restraint also if the system is periodic.
- Fix #523: Do not reweight to the expanded state systems in implicit solvent/vacuum.
- Fix a bug where the restraint was added also to the expanded state.

Future-proof YAML syntax:
- `restraint` specification has been moved from the `options` to the `experiment` section, and has a nested `type` (example: `restraint: {type: Harmonic}`)
- dropped support for specifying epik selection with `epik: 0` in favor of `epik: {select: 0}`
- Fix #538: add YAML `version` for backward compatibility