### PR TITLE
Switch to using periodic boundary restraints

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - scipy
     - setuptools
     - netcdf4
-    - openmm >=7.0.1
+    - openmm >=7.1.0
     - mdtraj >=1.7.2
     - openmmtools
     - pymbar
@@ -37,7 +37,7 @@ requirements:
     - scipy
     - cython
     - netcdf4
-    - openmm >=7.0.1
+    - openmm >=7.1.0
     - mdtraj >=1.7.2
     - openmmtools
     - pymbar

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.12.1"
+VERSION = "0.12.2"
 ISRELEASED = False
 __version__ = VERSION
 ########################


### PR DESCRIPTION
Restraints should now use periodic images for computing distances. 
Did some PEP8 cleanup while I was in there

Now requires OpenMM 7.1.0 minimum