### PR TITLE
Fix YAML syntax for null restraint

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -366,7 +366,8 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         """
         force = openmm.CustomBondForce(self._energy_function)
         force.addGlobalParameter('lambda_restraints', 1.0)
-        force.setUsesPeriodicBoundaryConditions(True)
+        is_periodic = self._system.usesPeriodicBoundaryConditions()
+        force.setUsesPeriodicBoundaryConditions(is_periodic)
         for parameter in self._bond_parameter_names:
             force.addPerBondParameter(parameter)
         try:
@@ -932,7 +933,8 @@ class Boresch(OrientationDependentRestraint):
         force = openmm.CustomCompoundBondForce(nparticles, energy_function)
         force.addGlobalParameter('lambda_restraints', 1.0)
         force.addBond(self._restraint_atoms, [])
-        force.setUsesPeriodicBoundaryConditions(True)
+        is_periodic = self._system.usesPeriodicBoundaryConditions()
+        force.setUsesPeriodicBoundaryConditions(is_periodic)
         return force
 
     def get_standard_state_correction(self):

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================================
 
 kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA  # Boltzmann constant
-V0 = 1660.0*unit.angstroms**3  # standard state volume
+V0 = 1660.53928 * unit.angstroms**3  # standard state volume
 
 # =============================================================================================
 # Dispatch appropriate restraint type from registered restraint classes

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -610,7 +610,9 @@ def test_validation_correct_experiments():
     basic_script = yank_load(basic_script)
 
     experiments = [
-        {'system': 'sys', 'protocol': 'absolute-binding'}
+        {'system': 'sys', 'protocol': 'absolute-binding'},
+        {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {'type': 'Harmonic'}},
+        {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {'type': None}}
     ]
     for experiment in experiments:
         modified_script = basic_script.copy()

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1830,7 +1830,7 @@ class YamlBuilder:
             return
 
         # Restraint schema
-        restraint_schema = {'type': str}
+        restraint_schema = {'type': Or(str, None)}
 
         # Define experiment Schema
         experiment_schema = Schema({'system': is_known_system, 'protocol': is_known_protocol,


### PR DESCRIPTION
This allows to specify in combinatorial experiments
```yaml
experiments:
  ...
  restraint:
    type: !Combinatorial [FlatBottom, Harmonic, null]
```
Ready for review.