### PR TITLE
Fix extract trajectory and adds image molecules

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -561,7 +561,7 @@ def analyze(source_directory):
 
 def extract_trajectory(output_path, nc_path, state_index=None, replica_index=None,
                        start_frame=0, end_frame=-1, skip_frame=1, keep_solvent=True,
-                       discard_equilibration=False):
+                       discard_equilibration=False, image_molecules=False):
     """Extract phase trajectory from the NetCDF4 file.
 
     Parameters
@@ -604,6 +604,15 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
     try:
         nc_file = netcdf.Dataset(nc_path, 'r')
 
+        # Extract topology and system serialization
+        serialized_system = nc_file.groups['metadata'].variables['reference_system'][0]
+        serialized_topology = nc_file.groups['metadata'].variables['topology'][0]
+
+        # Determine if system is periodic
+        from simtk import openmm
+        reference_system = openmm.XmlSerializer.deserialize(str(serialized_system))
+        is_periodic = reference_system.usesPeriodicBoundaryConditions()
+
         # Get dimensions
         n_iterations = nc_file.variables['positions'].shape[0]
         n_atoms = nc_file.variables['positions'].shape[2]
@@ -626,8 +635,10 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
                          "effectively uncorrelated samples)...").format(n_equil, n_eff))
             frame_indices = frame_indices[n_equil:-1]
 
-        # Extract state positions
+        # Extract state positions and box vectors
         positions = np.zeros((len(frame_indices), n_atoms, 3))
+        if is_periodic:
+            box_vectors = np.zeros((len(frame_indices), 3, 3))
         if state_index is not None:
             # Deconvolute state indices
             state_indices = np.zeros(len(frame_indices))
@@ -635,24 +646,28 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
                 replica_indices = nc_file.variables['states'][iteration, :]
                 state_indices[i] = np.where(replica_indices == state_index)[0][0]
 
-            # Extract positions
+            # Extract state positions and box vectors
             for i, iteration in enumerate(frame_indices):
                 replica_index = state_indices[i]
-                positions[i, :, :] = nc_file.variables['positions'][iteration, replica_index, :, :]
+                positions[i, :, :] = nc_file.variables['positions'][iteration, replica_index, :, :].astype(np.float32)
+                if is_periodic:
+                    box_vectors[i, :, :] = nc_file.variables['box_vectors'][iteration, replica_index, :, :].astype(np.float32)
 
-        # Extract replica positions
-        else:
+        else:  # Extract replica positions and box vectors
             for i, iteration in enumerate(frame_indices):
-                positions[i, :, :] = nc_file.variables['positions'][iteration, replica_index, :, :]
-
-        # Extract topology
-        serialized_topology = nc_file.groups['metadata'].variables['topology'][0]
+                positions[i, :, :] = nc_file.variables['positions'][iteration, replica_index, :, :].astype(np.float32)
+                if is_periodic:
+                    box_vectors[i, :, :] = nc_file.variables['box_vectors'][iteration, replica_index, :, :].astype(np.float32)
     finally:
         nc_file.close()
 
     # Create trajectory object
     topology = utils.deserialize_topology(serialized_topology)
     trajectory = mdtraj.Trajectory(positions, topology)
+
+    # Force periodic boundary conditions to molecules positions
+    if image_molecules:
+        trajectory.image_molecules(inplace=True)
 
     # Remove solvent
     if not keep_solvent:

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -673,6 +673,8 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
     logger.info('Creating trajectory object...')
     topology = utils.deserialize_topology(serialized_topology)
     trajectory = mdtraj.Trajectory(positions, topology)
+    if is_periodic:
+        trajectory.unitcell_vectors = box_vectors
 
     # Force periodic boundary conditions to molecules positions
     if image_molecules:

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -642,7 +642,8 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
 
         # Extract replica positions
         else:
-            positions = nc_file.variables['positions'][:, replica_index, :, :]
+            for i, iteration in enumerate(frame_indices):
+                positions[i, :, :] = nc_file.variables['positions'][iteration, replica_index, :, :]
 
         # Extract topology
         serialized_topology = nc_file.groups['metadata'].variables['topology'][0]

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -24,7 +24,7 @@ YANK analyze
 
 Usage:
   yank analyze (-s STORE | --store=STORE) [-v | --verbose]
-  yank analyze extract-trajectory --netcdf=FILEPATH (--state=STATE | --replica=REPLICA) --trajectory=FILEPATH [--start=START_FRAME] [--skip=SKIP_FRAME] [--end=END_FRAME] [--nosolvent] [--discardequil] [-v | --verbose]
+  yank analyze extract-trajectory --netcdf=FILEPATH (--state=STATE | --replica=REPLICA) --trajectory=FILEPATH [--start=START_FRAME] [--skip=SKIP_FRAME] [--end=END_FRAME] [--nosolvent] [--discardequil] [--imagemol] [-v | --verbose]
 
 Description:
   Analyze the data to compute Free Energies OR extract the trajectory from the NetCDF file into a common fortmat.
@@ -44,6 +44,7 @@ Extract Trajectory Options:
   --skip=SKIP_FRAME             Extract one frame every SKIP_FRAME
   --nosolvent                   Do not extract solvent
   --discardequil                Detect and discard equilibration frames
+  --imagemol                    Reprocess trajectory to enforce periodic boundary conditions to molecules positions
 
 General Options:
   -v, --verbose                 Print verbose output
@@ -88,6 +89,8 @@ def dispatch_extract_trajectory(args):
         kwargs['keep_solvent'] = False
     if args['--discardequil']:
         kwargs['discard_equilibration'] = True
+    if args['--imagemol']:
+        kwargs['image_molecules'] = True
 
     # Extract trajectory
     analyze.extract_trajectory(output_path, nc_path, **kwargs)


### PR DESCRIPTION
Ready for review.

- Fix a bug where `start`, `end` and `skip` frames where ignored when extracting a replica trajectory and not a state.
- Fix #564: automatically detects if the system is periodic, sets box vectors, and adds an `--imagemol` parameter to `yank analyze extract-trajectory` to apply periodic boundary conditions to molecules positions.