### PR TITLE
Fix standard state calculation approximation for PBC bonds

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -591,6 +591,7 @@ class Harmonic(RadiallySymmetricRestraint):
 
         # Compute std dev of distances from restrained atom.
         sigma = distances.std() * unit
+        logger.debug("Spring Constant Sigma, s = %.3f nm" % (sigma / unit.nanometer))
 
         # Compute corresponding spring constant.
         K = self.kT / sigma**2

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -451,6 +451,7 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         logger.debug("shell_volume = %f nm^3" % (shell_volume / unit.nanometers**3))
 
         # Compute standard-state volume for a single molecule in a box of size (1 L) / (avogadros number)
+        # Should also generate constant V0
         liter = 1000.0 * unit.centimeters**3  # one liter
         box_volume = liter / (unit.AVOGADRO_CONSTANT_NA*unit.mole) # standard state volume
         logger.debug("box_volume = %f nm^3" % (box_volume / unit.nanometers**3))

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -575,13 +575,13 @@ class Harmonic(RadiallySymmetricRestraint):
 
         """
 
-        unit = self._positions.unit
+        carried_unit = self._positions.unit
 
         # Get dimensionless receptor positions.
-        x = self._positions[self._receptor_atoms,:] / unit
+        x = self._positions[self._receptor_atoms,:] / carried_unit
 
         # Get dimensionless restrained atom coordinate.
-        xref = self._positions[self._restrained_receptor_atom, :] / unit  # (3,) array
+        xref = self._positions[self._restrained_receptor_atom, :] / carried_unit  # (3,) array
         xref = np.reshape(xref, (1,3)) # (1,3) array
 
         # Compute distances from restrained atom.
@@ -590,7 +590,7 @@ class Harmonic(RadiallySymmetricRestraint):
         distances = np.sqrt(((x - np.tile(xref, (natoms, 1)))**2).sum(1))
 
         # Compute std dev of distances from restrained atom.
-        sigma = distances.std() * unit
+        sigma = distances.std() * carried_unit
         logger.debug("Spring Constant Sigma, s = %.3f nm" % (sigma / unit.nanometers))
 
         # Compute corresponding spring constant.

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -591,7 +591,7 @@ class Harmonic(RadiallySymmetricRestraint):
 
         # Compute std dev of distances from restrained atom.
         sigma = distances.std() * unit
-        logger.debug("Spring Constant Sigma, s = %.3f nm" % (sigma / unit.nanometer))
+        logger.debug("Spring Constant Sigma, s = %.3f nm" % (sigma / unit.nanometers))
 
         # Compute corresponding spring constant.
         K = self.kT / sigma**2

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -340,7 +340,7 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
 
         # Compute distances from restrained atom.
         natoms = x.shape[0]
-        distances = np.sqrt(((x - np.tile(xref, (natoms, 1)))**2).sum(1)) # distances[i] is the distance from the centroid to particle i
+        distances = np.sqrt(((x - np.tile(xref, (natoms, 1)))**2).sum(1)) #  distances[i] is the distance from the centroid to particle i
 
         # Compute std dev of distances from restrained atom.
         radius_of_gyration = distances.std() * unit
@@ -411,6 +411,8 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         system.addParticle(1.0 * unit.amu)
         system.addParticle(1.0 * unit.amu)
         force = self._create_restraint_force(0, 1)
+        # Disable the PBC if on for this approximation of the analytical solution
+        force.setUsesPeriodicBoundaryConditions(False)
         system.addForce(force)
 
         # Create a Reference context to evaluate energies on the CPU.
@@ -578,7 +580,7 @@ class Harmonic(RadiallySymmetricRestraint):
         x = self._positions[self._receptor_atoms,:] / unit
 
         # Get dimensionless restrained atom coordinate.
-        xref = self._positions[self._restrained_receptor_atom,:] / unit # (3,) array
+        xref = self._positions[self._restrained_receptor_atom, :] / unit  # (3,) array
         xref = np.reshape(xref, (1,3)) # (1,3) array
 
         # Compute distances from restrained atom.
@@ -658,13 +660,14 @@ class FlatBottom(RadiallySymmetricRestraint):
 
         if (natoms > 3):
             # Check that restrained receptor atom is in expected range.
-            if (self._restrained_receptor_atom > natoms):
+            if self._restrained_receptor_atom > natoms:
                 raise ValueError('Receptor atom %d was selected for restraint, but system only has %d atoms.' % (self._restrained_receptor_atom, natoms))
 
             # Compute median absolute distance to central atom.
             # (Working in non-unit-bearing floats for speed.)
-            xref = np.reshape(x[self._restrained_receptor_atom,:], (1,3)) # (1,3) array
-            distances = np.sqrt(((x - np.tile(xref, (natoms, 1)))**2).sum(1)) # distances[i] is the distance from the centroid to particle i
+            xref = np.reshape(x[self._restrained_receptor_atom, :], (1,3))  # (1,3) array
+            # distances[i] is the distance from the centroid to particle i
+            distances = np.sqrt(((x - np.tile(xref, (natoms, 1)))**2).sum(1))
             median_absolute_distance = np.median(abs(distances))
 
             # Convert back to unit-bearing quantity.
@@ -683,7 +686,7 @@ class FlatBottom(RadiallySymmetricRestraint):
         logger.debug("restraint distance r0 = %.1f A" % (r0 / unit.angstroms))
 
         # Set spring constant/
-        #K = (2.0 * 0.0083144621 * 5.0 * 298.0 * 100) * unit.kilojoules_per_mole/unit.nanometers**2
+        # K = (2.0 * 0.0083144621 * 5.0 * 298.0 * 100) * unit.kilojoules_per_mole/unit.nanometers**2
         K = 0.6 * unit.kilocalories_per_mole / unit.angstroms**2
         logger.debug("K = %.1f kcal/mol/A^2" % (K / (unit.kilocalories_per_mole / unit.angstroms**2)))
 

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -16,7 +16,7 @@ Test restraints module.
 import tempfile
 import shutil
 import math
-import unittest
+import numpy as np
 
 from nose.plugins.attrib import attr
 
@@ -73,10 +73,14 @@ expected_restraints = {
 
 
 def test_harmonic_standard_state():
-    """Test that the expected harmonic standard state correction is close to our approximation"""
+    """
+    Test that the expected harmonic standard state correction is close to our approximation
+
+    Also ensures that PBC bonds are being computed and disabled correctly as expected
+    """
     LJ_fluid = testsystems.LennardJonesFluid()
-    receptor_atoms = [0]
-    ligand_atoms =  [1, 2, 3]
+    receptor_atoms = [0, 1, 2]
+    ligand_atoms = [3, 4, 5]
     thermodynamic_state = ThermodynamicState(temperature=300.0 * unit.kelvin)
     restraint = yank.restraints.create_restraints('Harmonic', LJ_fluid.topology, thermodynamic_state, LJ_fluid.system,
                                                   LJ_fluid.positions, receptor_atoms, ligand_atoms)
@@ -87,7 +91,7 @@ def test_harmonic_standard_state():
     analytical_shell_volume = (2 * math.pi / (spring_constant * restraint.beta))**(3.0/2)
     analytical_standard_state_G = - math.log(box_volume / analytical_shell_volume)
     restraint_standard_state_G = restraint.get_standard_state_correction()
-    unittest.assertAlmostEqual(analytical_standard_state_G, restraint_standard_state_G)
+    np.testing.assert_allclose(analytical_standard_state_G, restraint_standard_state_G)
 
 
 def test_available_restraint_classes():

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -21,7 +21,7 @@ import numpy as np
 from nose.plugins.attrib import attr
 
 import yank.restraints
-from openmmtools.testsystems import ThermodynamicState
+from yank.repex import ThermodynamicState
 
 from simtk import unit, openmm
 from openmmtools import testsystems


### PR DESCRIPTION
Simulation will still generate use the PBC bonds for restraint, however the standard state correction which is based on estimating an analytical solution now does not (to correctly compute integral out to r=inf while also using OpenMM Contexts to get energy)

Wrote a test to make sure that what OpenMM computes is close to analytical solution.

Some small PEP8's as I saw them.