### PR TITLE
Use expanded cutoff for fully interacting and noninteracting states

### DIFF
--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -95,7 +95,7 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
         self._noninteracting_expanded_context = None
         self.noninteracting_expanded_state = None
 
-    def create(self, base_state, alchemical_states, positions, displacement_sigma=None, mc_atoms=None, options=None, metadata=None, fully_interacting_expanded__state=None, noninteracting_expanded_state=None):
+    def create(self, base_state, alchemical_states, positions, displacement_sigma=None, mc_atoms=None, options=None, metadata=None, fully_interacting_expanded_state=None, noninteracting_expanded_state=None):
         """
         Initialize a modified Hamiltonian exchange simulation object.
 

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -949,12 +949,14 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
                     self.u_k_non[replica_index] = self.noninteracting_expanded_state.reduced_potential(self.replica_positions[replica_index], box_vectors=self.replica_box_vectors[replica_index], context=noninteracting_expanded_context)
 
                 # Send final energies to all nodes.
-                energies_gather = self.mpicomm.allgather(self.u_k[self.mpicomm.rank:self.nstates:self.mpicomm.size])
+                energies_gather_full = self.mpicomm.allgather(self.u_k_full[self.mpicomm.rank:self.nstates:self.mpicomm.size])
+                energies_gather_non = self.mpicomm.allgather(self.u_k_non[self.mpicomm.rank:self.nstates:self.mpicomm.size])
                 for replica_index in range(self.nstates):
                     source = replica_index % self.mpicomm.size # node with data
                     index = replica_index // self.mpicomm.size # index within batch
-                    self.u_k_full[replica_index] = energies_gather[source][index]
-                    self.u_k_non[replica_index] = energies_gather[source][index]
+                    self.u_k_full[replica_index] = energies_gather_full[source][index]
+                    self.u_k_non[replica_index] = energies_gather_non[source][index]
+
             else:
                 # Serial version.
                 for replica_index in range(self.nstates):

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -265,12 +265,12 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
             setattr(ncvar_temperatures, 'long_name', "temperatures[state] is the temperature of thermodynamic state 'state'")
             ncvar_temperatures[0] = self.fully_interacting_expanded_state.temperature / temperature_unit
             # Pressures
-            if self.reference_state.pressure is not None:
+            if self..fully_interacting_expanded_state.pressure is not None:
                 ncvar_pressures = ncgrp_stateinfo.createVariable('pressures', 'f', ('scalar',))
                 setattr(ncvar_pressures, 'units', 'atm')
                 setattr(ncvar_pressures, 'long_name', "pressures[state] is the external pressure of thermodynamic state 'state'")
                 for state_index in range(self.nstates):
-                    ncvar_pressures[0] = self.reference_state.pressure / pressure_unit
+                    ncvar_pressures[0] = self..fully_interacting_expanded_state.pressure / pressure_unit
             # System
             logger.debug("Serializing systems...")
             ncvar_serialized_fully_interacting_expanded_system = ncgrp_stateinfo.createVariable('fully_interacting_expanded_system', str, ('scalar',), zlib=True)

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -875,8 +875,9 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
     def _resume_from_netcdf(self, ncfile):
         super(ModifiedHamiltonianExchange, self)._resume_from_netcdf(ncfile)
         # Restore fully interacting energies
-        if 'fully_interacting_energies' in ncfile.variables:
-            self.u_k = ncfile.variables['fully_interacting_energies'][self.iteration, :].copy()
+        if 'fully_interacting_expanded_cutoff_energies' in ncfile.variables:
+            self.u_k_full = ncfile.variables['fully_interacting_expanded_cutoff_energies'][self.iteration, :].copy()
+            self.u_k_non = ncfile.variables['noninteracting_expanded_cutoff_energies'][self.iteration, :].copy()
 
     def _compute_energies(self):
         """

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -265,12 +265,12 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
             setattr(ncvar_temperatures, 'long_name', "temperatures[state] is the temperature of thermodynamic state 'state'")
             ncvar_temperatures[0] = self.fully_interacting_expanded_state.temperature / temperature_unit
             # Pressures
-            if self..fully_interacting_expanded_state.pressure is not None:
+            if self.fully_interacting_expanded_state.pressure is not None:
                 ncvar_pressures = ncgrp_stateinfo.createVariable('pressures', 'f', ('scalar',))
                 setattr(ncvar_pressures, 'units', 'atm')
                 setattr(ncvar_pressures, 'long_name', "pressures[state] is the external pressure of thermodynamic state 'state'")
                 for state_index in range(self.nstates):
-                    ncvar_pressures[0] = self..fully_interacting_expanded_state.pressure / pressure_unit
+                    ncvar_pressures[0] = self.fully_interacting_expanded_state.pressure / pressure_unit
             # System
             logger.debug("Serializing systems...")
             ncvar_serialized_fully_interacting_expanded_system = ncgrp_stateinfo.createVariable('fully_interacting_expanded_system', str, ('scalar',), zlib=True)

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -263,7 +263,7 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
             ncvar_temperatures = ncgrp_stateinfo.createVariable('temperatures', 'f', ('scalar',))
             setattr(ncvar_temperatures, 'units', 'K')
             setattr(ncvar_temperatures, 'long_name', "temperatures[state] is the temperature of thermodynamic state 'state'")
-            ncvar_temperatures[0] = self.reference_state.temperature / temperature_unit
+            ncvar_temperatures[0] = self.fully_interacting_expanded_state.temperature / temperature_unit
             # Pressures
             if self.reference_state.pressure is not None:
                 ncvar_pressures = ncgrp_stateinfo.createVariable('pressures', 'f', ('scalar',))

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -36,26 +36,23 @@ def test_resuming():
 
     positions = toluene_test.positions
 
-    # We pass as reference_LJ_state and reference_LJ_state the normal
+    # We pass as fully_interacting_expanded_state and noninteracting_expanded_state the normal
     # reference state as we just want to check that they are correctly
     # set on resume
-    reference_state = ThermodynamicState(temperature=300.0*unit.kelvin)
-    reference_state.system = toluene_test.system
-    reference_LJ_state = copy.deepcopy(base_state)
-    reference_LJ_expanded_state = copy.deepcopy(base_state)
+    fully_interacting_expanded_state = ThermodynamicState(temperature=300.0*unit.kelvin)
+    fully_interacting_expanded_state.system = toluene_test.system
+    noninteracting_expanded_state = copy.deepcopy(base_state)
 
     with enter_temp_directory():
         store_file_name = 'simulation.nc'
         simulation = ModifiedHamiltonianExchange(store_file_name)
         simulation.create(base_state, alchemical_states, positions, mc_atoms=ligand_atoms,
-                          reference_state=reference_state,
-                          reference_LJ_state=reference_LJ_state,
-                          reference_LJ_expanded_state=reference_LJ_expanded_state)
+                          fully_interacting_expanded_state=fully_interacting_expanded_state,
+                          noninteracting_expanded_state = noninteracting_expanded_state)
 
         # Clean up simulation and resume
         del simulation
         simulation = ModifiedHamiltonianExchange(store_file_name)
         simulation.resume()
-        assert simulation.reference_state is not None
-        assert simulation.reference_LJ_state is not None
-        assert simulation.reference_LJ_expanded_state is not None
+        assert simulation.fully_interacting_expanded_state is not None
+        assert simulation.noninteracting_expanded_state is not None

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -372,44 +372,18 @@ class Yank(object):
         # which the fully-interacting energy is to be computed. An enlarged cutoff
         # is used to account for the anisotropic dispersion correction. This must
         # be done BEFORE adding the restraint to reference_system.
-        if not is_periodic:
-            reference_state = None
-            reference_LJ_state = None
-            reference_LJ_expanded_state = None
-        else:
-            # Create system with only LJ forces.
-            reference_system_LJ = copy.deepcopy(reference_system)
-            forces_to_remove = []
-            for forceIndex in range(reference_system_LJ.getNumForces()):
-                force = reference_system_LJ.getForce(forceIndex)
-                if isinstance(force, openmm.NonbondedForce):
-                    # Turn off electrostatics.
-                    for particle in range(force.getNumParticles()):
-                        q, sigma, epsilon = force.getParticleParameters(particle)
-                        force.setParticleParameters(particle, 0, sigma, epsilon)
-                    for exception in range(force.getNumExceptions()):
-                        particle1, particle2, chargeprod, epsilon, sigma = force.getExceptionParameters(exception)
-                        force.setExceptionParameters(exception, particle1, particle2, 0, sigma, epsilon)
-                else:
-                    # Queue force to remove if not a NB fore.
-                    forces_to_remove.append(forceIndex)
-            # Remove all but NonbondedForce. If done in previous loop, number of
-            # forces change so indices change.
-            for forceIndex in forces_to_remove[::-1]:
-                reference_system_LJ.removeForce(forceIndex)
+        # We dont care about restraint in decoupled state (although we will set to 0) since we will
+        # account for that by hand.
 
-            # Create system with only LJ forces with an expanded cutoff.
-            reference_system_LJ_expanded = copy.deepcopy(reference_system_LJ)
-
+        # Helper function for expanded cutoff
+        def expand_cutoff(passed_system, max_allowed_cutoff = 16 * unit.angstroms):
             # Determine minimum box side dimension
-            box_vectors = reference_system_LJ_expanded.getDefaultPeriodicBoxVectors()
+            box_vectors = passed_system.getDefaultPeriodicBoxVectors()
             min_box_dimension = min([max(vector) for vector in box_vectors])
-
             # Expand cutoff to minimize artifact and verify that box is big enough.
             # If we use a barostat we leave more room for volume fluctuations or
             # we risk fatal errors. If we don't use a barostat, OpenMM will raise
             # the appropriate exception on context creation.
-            max_allowed_cutoff = 16 * unit.angstroms
             max_switching_distance = max_allowed_cutoff - (1 * unit.angstrom)
             # TODO: Make max_allowed_cutoff an option
             if thermodynamic_state.pressure and min_box_dimension < 2.25 * max_allowed_cutoff:
@@ -419,9 +393,9 @@ class Yank(object):
             logger.debug('Setting cutoff for fully interacting system to maximum '
                          'allowed {}'.format(str(max_allowed_cutoff)))
 
-            # Expanded cutoff LJ system if needed
+            # Expanded cutoff system if needed
             # We don't want to reduce the cutoff if its already large
-            for force in reference_system_LJ_expanded.getForces():
+            for force in passed_system.getForces():
                 try:
                     if force.getCutoffDistance() < max_allowed_cutoff:
                         force.setCutoffDistance(max_allowed_cutoff)
@@ -436,13 +410,19 @@ class Yank(object):
                 except Exception:
                     pass
 
+        # Set the fully-interacting expanded cutoff state here
+        if not is_periodic:
+            fully_interacting_expanded_state = None
+        else:
+            # Create the fully interacting system
+            fully_interacting_expanded_system = copy.deepcopy(reference_system)
+
+            # Expand Cutoff
+            expand_cutoff(fully_interacting_expanded_system)
+
             # Construct thermodynamic states
-            reference_state = copy.deepcopy(thermodynamic_state)
-            reference_state.system = copy.deepcopy(reference_system)
-            reference_LJ_state = copy.deepcopy(thermodynamic_state)
-            reference_LJ_expanded_state = copy.deepcopy(thermodynamic_state)
-            reference_LJ_state.system = reference_system_LJ
-            reference_LJ_expanded_state.system = reference_system_LJ_expanded
+            fully_interacting_expanded_state = copy.deepcopy(thermodynamic_state)
+            fully_interacting_expanded_state.system = fully_interacting_expanded_system
 
         # Compute standard state corrections for complex phase.
         metadata['standard_state_correction'] = 0.0
@@ -479,6 +459,33 @@ class Yank(object):
                                             **self._alchemy_parameters)
         alchemical_system = factory.alchemically_modified_system
         thermodynamic_state.system = alchemical_system
+
+        # Create the expanded cutoff decoupled state
+        if fully_interacting_expanded_state is None:
+            noninteracting_expanded_state = None
+        else:
+            # Create the system for noninteracting
+            noninteracting_expanded_system = copy.deepcopy(alchemical_system)
+            # Set all USED alchemical interactions to 0
+            # Determine which parameters were used
+            alchemical_parameters = alchemical_states[0].keys()
+            # Set the default parameter values
+            # We dont know which force has which variable, so try all
+            for force in noninteracting_expanded_system.getForces():
+                try:
+                    number_global = force.getNumGlobalParameters()
+                    for parameter_index in range(number_global):
+                        global_name = force.getGlobalParameterName(parameter_index)
+                        if global_name in alchemical_parameters:
+                            force.setGlobalParameterDefaultValue(parameter_index, 0)
+                except:
+                    pass
+            # Expand Cutoff
+            expand_cutoff(noninteracting_expanded_system)
+
+            # Construct thermodynamic states
+            noninteracting_expanded_state = copy.deepcopy(thermodynamic_state)
+            noninteracting_expanded_state.system = noninteracting_expanded_system
 
         # Check systems for finite energies.
         # TODO: Refactor this into another function.
@@ -529,9 +536,8 @@ class Yank(object):
         simulation.create(thermodynamic_state, alchemical_states, positions,
                           displacement_sigma=self._mc_displacement_sigma, mc_atoms=mc_atoms,
                           options=repex_parameters, metadata=metadata,
-                          reference_state = reference_state,
-                          reference_LJ_state = reference_LJ_state,
-                          reference_LJ_expanded_state = reference_LJ_expanded_state)
+                          fully_interacting_expanded_state = fully_interacting_expanded_state,
+                          noninteracting_expanded_state = noninteracting_expanded_state)
 
         # Initialize simulation.
         # TODO: Use the right scheme for initializing the simulation without running.

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -466,20 +466,9 @@ class Yank(object):
         else:
             # Create the system for noninteracting
             noninteracting_expanded_system = copy.deepcopy(alchemical_system)
-            # Set all USED alchemical interactions to 0
-            # Determine which parameters were used
-            alchemical_parameters = alchemical_states[0].keys()
-            # Set the default parameter values
-            # We dont know which force has which variable, so try all
-            for force in noninteracting_expanded_system.getForces():
-                try:
-                    number_global = force.getNumGlobalParameters()
-                    for parameter_index in range(number_global):
-                        global_name = force.getGlobalParameterName(parameter_index)
-                        if global_name in alchemical_parameters:
-                            force.setGlobalParameterDefaultValue(parameter_index, 0)
-                except:
-                    pass
+            # Set all USED alchemical interactions to the decoupled state
+            alchemical_state = alchemical_states[-1]
+            AbsoluteAlchemicalFactory.perturbSystem(noninteracting_expanded_system, alchemical_state)
             # Expand Cutoff
             expand_cutoff(noninteracting_expanded_system)
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.12.2"
+VERSION = "0.12.3"
 ISRELEASED = False
 __version__ = VERSION
 ########################


### PR DESCRIPTION
Removes old way of computed expanded cutoff in favor of computing free energy relative to expanded cutoffs at both the fully interacting and non-interacting systems.

Phew!