### PR TITLE
Fixes to periodic restraints and expanded states

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -367,7 +367,10 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         force = openmm.CustomBondForce(self._energy_function)
         force.addGlobalParameter('lambda_restraints', 1.0)
         is_periodic = self._system.usesPeriodicBoundaryConditions()
-        force.setUsesPeriodicBoundaryConditions(is_periodic)
+        try:  # This was added in OpenMM 7.1
+            force.setUsesPeriodicBoundaryConditions(is_periodic)
+        except AttributeError:
+            pass
         for parameter in self._bond_parameter_names:
             force.addPerBondParameter(parameter)
         try:
@@ -412,7 +415,10 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         system.addParticle(1.0 * unit.amu)
         force = self._create_restraint_force(0, 1)
         # Disable the PBC if on for this approximation of the analytical solution
-        force.setUsesPeriodicBoundaryConditions(False)
+        try:  # This was added in OpenMM 7.1
+            force.setUsesPeriodicBoundaryConditions(False)
+        except AttributeError:
+            pass
         system.addForce(force)
 
         # Create a Reference context to evaluate energies on the CPU.
@@ -939,7 +945,10 @@ class Boresch(OrientationDependentRestraint):
         force.addGlobalParameter('lambda_restraints', 1.0)
         force.addBond(self._restraint_atoms, [])
         is_periodic = self._system.usesPeriodicBoundaryConditions()
-        force.setUsesPeriodicBoundaryConditions(is_periodic)
+        try:  # This was added in OpenMM 7.1
+            force.setUsesPeriodicBoundaryConditions(is_periodic)
+        except AttributeError:
+            pass
         return force
 
     def get_standard_state_correction(self):

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -354,7 +354,7 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
             noninteracting_expanded_state.system.__setstate__(str(ncgrp_stateinfo.variables['noninteracting_expanded_system'][0]))
 
             self.fully_interacting_expanded_state = fully_interacting_expanded_state
-            self.noninteracting_expanded_state = fully_interacting_expanded_state
+            self.noninteracting_expanded_state = noninteracting_expanded_state
 
         final_time = time.time()
         elapsed_time = final_time - initial_time

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -465,12 +465,13 @@ class Yank(object):
             noninteracting_expanded_state = None
         else:
             # Create the system for noninteracting
-            noninteracting_expanded_system = copy.deepcopy(alchemical_system)
+            expanded_factory = AbsoluteAlchemicalFactory(fully_interacting_expanded_state.system,
+                                                         ligand_atoms=alchemical_indices,
+                                                         **self._alchemy_parameters)
+            noninteracting_expanded_system = expanded_factory.alchemically_modified_system
             # Set all USED alchemical interactions to the decoupled state
             alchemical_state = alchemical_states[-1]
             AbsoluteAlchemicalFactory.perturbSystem(noninteracting_expanded_system, alchemical_state)
-            # Expand Cutoff
-            expand_cutoff(noninteracting_expanded_system)
 
             # Construct thermodynamic states
             noninteracting_expanded_state = copy.deepcopy(thermodynamic_state)

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - scipy
     - setuptools
     - netcdf4
-    - openmm >=7.1.0
+    - openmm >=7.0.1
     - mdtraj >=1.7.2
     - openmmtools
     - pymbar
@@ -37,7 +37,7 @@ requirements:
     - scipy
     - cython
     - netcdf4
-    - openmm >=7.1.0
+    - openmm >=7.0.1
     - mdtraj >=1.7.2
     - openmmtools
     - pymbar


### PR DESCRIPTION
Ready for review/merge if tests pass.

* Optional periodic restraints for backward compatibility with OpenMM 7.0.1.
* Fix copy paste error, and `alpha_ewald`/`r_cutoff` parameters in noninteracting expanded state.