### PR TITLE
Allow analyze to work on NetCDF files that do not contain 'metadata'

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -471,9 +471,11 @@ def analyze(source_directory):
             nstates = ncfile.variables['positions'].shape[1]
             logger.info("Read %(niterations)d iterations, %(nstates)d states" % vars())
 
-            # Read phase direction and standard state correction free energy.
-            # Yank sets correction to 0 if there are no restraints
-            DeltaF_restraints = ncfile.groups['metadata'].variables['standard_state_correction'][0]
+            DeltaF_restraints = 0.0
+            if 'metadata' in ncfile.groups:
+                # Read phase direction and standard state correction free energy.
+                # Yank sets correction to 0 if there are no restraints
+                DeltaF_restraints = ncfile.groups['metadata'].variables['standard_state_correction'][0]
 
             # Choose number of samples to discard to equilibration
             MIN_ITERATIONS = 10 # minimum number of iterations to use automatic detection


### PR DESCRIPTION
This minor change allows `yank analyze` to work on NetCDF files that do not contain `metadata`. The standard state correction is set to zero in this case.

This is useful for some analysis of simulation data generated by `repex` in tests of cutoff-dependence I am running right now.