### PR TITLE
Fix test and work around for OpenMM precision bug

### DIFF
--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1833,7 +1833,7 @@ def test_run_experiment():
         # Same thing with a system
         err_msg = ''
         system_dir = os.path.dirname(
-            yaml_builder._db.get_system('system_vacuum')[0].position_path)
+            yaml_builder._db.get_system('system_GBSAOBC2')[0].position_path)
         try:
             yaml_builder.build_experiments()
         except YamlParseError as e:


### PR DESCRIPTION
Fix a slow test that wasn't caught by Travis, and implement a workaround function to set precision for OpenCL and CUDA until openmm#1665 gets fixed and released.

Ready to be reviewed/merged.