### PR TITLE
[WIP] Serialize initial conditions when NaNs appear

### DIFF
--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -373,6 +373,9 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
         logger.debug("Creating and caching Context and Integrator.")
         state = self.states[0]
         self._integrator = openmm.LangevinIntegrator(state.temperature, self.collision_rate, self.timestep)
+        #from openmmtools.integrators import GHMCIntegrator # DEBUG JDC
+        #self._integrator = GHMCIntegrator(state.temperature, self.collision_rate, self.timestep) # DEBUG JDC
+        #self._integrator.setConstraintTolerance(1.0e-6) # DEBUG JDC
         self._integrator.setRandomNumberSeed(int(np.random.randint(0, MAX_SEED)))
         self._context = self._create_context(state.system, self._integrator)
         final_time = time.time()
@@ -757,16 +760,27 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
                 # Run dynamics.
                 integrator.step(self.nsteps_per_iteration)
                 integrator_end_time = time.time()
+                # DEBUG GHMC
+                #naccept = integrator.getGlobalVariableByName('naccept')
+                #ntrials = integrator.getGlobalVariableByName('ntrials')
+                #logger.debug('replica %5d : GHMC accepted %d / %d (%.3f %%)' % (replica_index, naccept, ntrials, float(naccept) / float(ntrials) * 100.0))
+                #integrator.resetStatistics()
+                #potential_before = context.getState(getEnergy=True).getPotentialEnergy()
+                #context.setPositions( context.getState(getPositions=True, enforcePeriodicBox=state.system.usesPeriodicBoundaryConditions()).getPositions() )
+                #potential_after = context.getState(getEnergy=True).getPotentialEnergy()               
+                #delta_energy = (potential_after - potential_before)
+                #logger.debug('replica %d : change in energy from periodic box enforcement = %8.3f kT' % (replica_index, delta_energy/state.kT))
                 # Get final positions
                 getstate_start_time = time.time()
-                openmm_state = context.getState(getPositions=True, enforcePeriodicBox=state.system.usesPeriodicBoundaryConditions())
+                #openmm_state = context.getState(getPositions=True, enforcePeriodicBox=state.system.usesPeriodicBoundaryConditions())
+                openmm_state = context.getState(getPositions=True, enforcePeriodicBox=False) # DEBUG
                 getstate_end_time = time.time()
                 # Check if final positions are NaN.
-                positions = openmm_state.getPositions(asNumpy=True)
-                if np.any(np.isnan(positions / unit.angstroms)):
+                final_positions = openmm_state.getPositions(asNumpy=True)
+                if np.any(np.isnan(final_positions / unit.angstroms)):
                     raise Exception('Particle coordinate is nan')
                 # Get box vectors
-                box_vectors = openmm_state.getPeriodicBoxVectors(asNumpy=True)
+                final_box_vectors = openmm_state.getPeriodicBoxVectors(asNumpy=True)
                 # Check if final potential energy is NaN.
                 if np.isnan(context.getState(getEnergy=True).getPotentialEnergy() / state.kT):
                     raise Exception('Potential for replica %d is NaN after dynamics' % replica_index)
@@ -799,9 +813,9 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
                     raise e
 
         # Store box vectors.
-        self.replica_box_vectors[replica_index] = box_vectors
+        self.replica_box_vectors[replica_index] = final_box_vectors
         # Store final positions
-        self.replica_positions[replica_index] = positions
+        self.replica_positions[replica_index] = final_positions
 
         # Compute timing.
         end_time = time.time()

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -776,7 +776,10 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
                     # If it's a NaN, increment the NaN counter and try again
                     nan_counter += 1
                     if nan_counter >= MAX_NAN_RETRIES:
-                        raise Exception('Maximum number of NAN retries (%d) exceeded.' % MAX_NAN_RETRIES)
+                        msg = 'Maximum number of NAN retries (%d) exceeded.' % MAX_NAN_RETRIES
+                        if self.mpicomm:
+                            msg += ' (MPI process %d / %d)' % (self.mpicomm.rank, self.mpicomm.size)
+                        raise Exception(msg)
                     logger.info('NaN detected in replica %d. Retrying (%d / %d).' % (replica_index, nan_counter, MAX_NAN_RETRIES))
                 else:
                     # It's not an exception we recognize, so re-raise it

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -749,6 +749,7 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
                 setpositions_end_time = time.time()
                 # Assign Maxwell-Boltzmann velocities.
                 context.setVelocitiesToTemperature(state.temperature, int(np.random.randint(0, MAX_SEED)))
+                velocities = context.getState(getVelocities=True).getVelocities(asNumpy=True) # get velocities in case we have to record them on NaN
                 setvelocities_end_time = time.time()
                 # Check if initial potential energy is NaN.
                 if np.isnan(context.getState(getEnergy=True).getPotentialEnergy() / state.kT):
@@ -781,6 +782,18 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
                             msg += ' (MPI process %d / %d)' % (self.mpicomm.rank, self.mpicomm.size)
                         raise Exception(msg)
                     logger.info('NaN detected in replica %d. Retrying (%d / %d).' % (replica_index, nan_counter, MAX_NAN_RETRIES))
+                    # Serialize to XML
+                    from yank.utils import serialize_openmm_object_to_file
+                    context.setPeriodicBoxVectors(box_vectors[0,:], box_vectors[1,:], box_vectors[2,:])
+                    context.setPositions(positions)
+                    context.setVelocities(velocities)
+                    openmm_state = context.getState(getPositions=True, getVelocities=True, getEnergy=True, getForces=True, getParameters=True)
+                    prefix = 'iteration%d-replica%d-state%d-nan%d' % (self.iteration, replica_index, state_index, nan_counter)
+                    serialize_openmm_object_to_file(prefix + '.system.xml', context.getSystem())
+                    serialize_openmm_object_to_file(prefix + '.integrator.xml', context.getIntegrator())
+                    serialize_openmm_object_to_file(prefix + '.state.xml', openmm_state)
+                    logger.info('Serialized initial System, State, and Integrator to %s.*' % (prefix))
+                    del openmm_state
                 else:
                     # It's not an exception we recognize, so re-raise it
                     raise e

--- a/Yank/sampling.py
+++ b/Yank/sampling.py
@@ -373,9 +373,6 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
         logger.debug("Creating and caching Context and Integrator.")
         state = self.states[0]
         self._integrator = openmm.LangevinIntegrator(state.temperature, self.collision_rate, self.timestep)
-        #from openmmtools.integrators import GHMCIntegrator # DEBUG JDC
-        #self._integrator = GHMCIntegrator(state.temperature, self.collision_rate, self.timestep) # DEBUG JDC
-        #self._integrator.setConstraintTolerance(1.0e-6) # DEBUG JDC
         self._integrator.setRandomNumberSeed(int(np.random.randint(0, MAX_SEED)))
         self._context = self._create_context(state.system, self._integrator)
         final_time = time.time()
@@ -760,20 +757,9 @@ class ModifiedHamiltonianExchange(ReplicaExchange):
                 # Run dynamics.
                 integrator.step(self.nsteps_per_iteration)
                 integrator_end_time = time.time()
-                # DEBUG GHMC
-                #naccept = integrator.getGlobalVariableByName('naccept')
-                #ntrials = integrator.getGlobalVariableByName('ntrials')
-                #logger.debug('replica %5d : GHMC accepted %d / %d (%.3f %%)' % (replica_index, naccept, ntrials, float(naccept) / float(ntrials) * 100.0))
-                #integrator.resetStatistics()
-                #potential_before = context.getState(getEnergy=True).getPotentialEnergy()
-                #context.setPositions( context.getState(getPositions=True, enforcePeriodicBox=state.system.usesPeriodicBoundaryConditions()).getPositions() )
-                #potential_after = context.getState(getEnergy=True).getPotentialEnergy()               
-                #delta_energy = (potential_after - potential_before)
-                #logger.debug('replica %d : change in energy from periodic box enforcement = %8.3f kT' % (replica_index, delta_energy/state.kT))
                 # Get final positions
                 getstate_start_time = time.time()
-                #openmm_state = context.getState(getPositions=True, enforcePeriodicBox=state.system.usesPeriodicBoundaryConditions())
-                openmm_state = context.getState(getPositions=True, enforcePeriodicBox=False) # DEBUG
+                openmm_state = context.getState(getPositions=True, enforcePeriodicBox=state.system.usesPeriodicBoundaryConditions())
                 getstate_end_time = time.time()
                 # Check if final positions are NaN.
                 final_positions = openmm_state.getPositions(asNumpy=True)

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -632,6 +632,23 @@ class CombinatorialTree(collections.MutableMapping):
 # Miscellaneous functions
 #========================================================================================
 
+def serialize_openmm_object_to_file(filename, openmm_object):
+    """Serialize an OpenMM System, State, or Integrator to specified file.
+    
+    Parameters
+    ----------
+    filename : str
+        The file to write to
+    openmm_object : System, State, or Integrator
+        The OpenMM object to serialize
+
+    """
+    from simtk.openmm import XmlSerializer
+    serialized_object = XmlSerializer.serialize(openmm_object)
+    outfile = open(filename, 'w')
+    outfile.write(serialized_object)
+    outfile.close
+
 def get_data_filename(relative_path):
     """Get the full path to one of the reference files shipped for testing
 


### PR DESCRIPTION
These changes cause the initial conditions (`System`, `State`, `Integrator`) to be serialized to XML when `nan`s occur during propagation.

The debugging script to resume looks like this:
```python
#!/usr/bin/env python

from simtk import openmm, unit

def deserialize_object(filename):
    infile = open(filename, 'r')
    serialized = infile.read()
    infile.close()
    from simtk.openmm import XmlSerializer
    deserialized = XmlSerializer.deserialize(serialized)
    return deserialized

prefix = 'iteration22-replica46-state44-nan1'

def deserialize(prefix):
    print('deserializing...')
    system     = deserialize_object(prefix + '.system.xml')
    integrator = deserialize_object(prefix + '.integrator.xml')
    state      = deserialize_object(prefix + '.state.xml')
    return [system, integrator, state]

def create_context(system, integrator, state):
    print('creating Context...')
    context = openmm.Context(system, integrator)
    context.setPeriodicBoxVectors(*state.getPeriodicBoxVectors())
    context.setPositions(state.getPositions())
    context.setVelocities(state.getVelocities())
    for (parameter, value) in state.getParameters().items():
        context.setParameter(parameter, value)
    return [context, integrator]

niterations = 10
for iteration in range(niterations):
    print('Simulating attempt %d / %d...' % (iteration, niterations))
    [system, integrator, state] = deserialize(prefix)
    [context, integrator] = create_context(system, integrator, state)
    
    # Initial energy
    state = context.getState(getEnergy=True, getForces=True)

    # Step
    for step in range(1000):
        print(context.getState(getEnergy=True).getPotentialEnergy())
        integrator.step(1)
    # Clean up
    del system, context, integrator, state
```
So far, I see rapid explosions:
```
[chodera@gpu-1-15 abl-imatinib]$ python reproduce_nan.py
Simulating attempt 0 / 10...
deserializing...
creating Context...
-513489.94269172056 kJ/mol
-569576.2610505591 kJ/mol
-611669.391279317 kJ/mol
-462928.3334008227 kJ/mol
29226742.670561396 kJ/mol
42457666146.99868 kJ/mol
716121656989.9181 kJ/mol
2946770806793.3286 kJ/mol
nan kJ/mol
nan kJ/mol
nan kJ/mol
```