### PR TITLE
Fix test default lambda value after new alchemy release

### DIFF
--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1682,7 +1682,7 @@ def test_get_alchemical_path():
     assert isinstance(complex_path[0], AlchemicalState)
     assert complex_path[3]['lambda_electrostatics'] == 0.6
     assert complex_path[4]['lambda_sterics'] == 0.4
-    assert complex_path[5]['lambda_restraints'] == 0.0
+    assert complex_path[5]['lambda_restraints'] == 1.0
     assert len(complex_path) == 7
 
 


### PR DESCRIPTION
Just fixing a test that now fails with changes included in alchemy 1.2.3 release. Ready to be reviewed.