### PR TITLE
Make clearance optional only for amber/gromacs/openmm systems

### DIFF
--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -272,6 +272,7 @@ def test_yaml_parsing():
         randomize_ligand_sigma_multiplier: 2.0
         randomize_ligand_close_cutoff: 1.5 * angstrom
         mc_displacement_sigma: 10.0 * angstroms
+        anisotropic_dispersion_correction: no
         collision_rate: 5.0 / picosecond
         constraint_tolerance: 1.0e-6
         timestep: 2.0 * femtosecond
@@ -292,8 +293,8 @@ def test_yaml_parsing():
     """
 
     yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
-    assert len(yaml_builder.options) == 34
-    assert len(yaml_builder.yank_options) == 22
+    assert len(yaml_builder.options) == 35
+    assert len(yaml_builder.yank_options) == 23
 
     # Check correct types
     assert yaml_builder.options['pressure'] is None
@@ -1693,6 +1694,7 @@ def test_run_experiment_from_amber_files():
     solvent_path = examples_paths()['bentol-solvent']
     with omt.utils.temporary_directory() as tmp_dir:
         yaml_script = get_template_script(tmp_dir)
+        yaml_script['options']['anisotropic_dispersion_correction'] = False
         del yaml_script['molecules']  # we shouldn't need any molecule
         yaml_script['systems'] = {'explicit-system':
                 {'phase1_path': complex_path, 'phase2_path': solvent_path,
@@ -1724,6 +1726,7 @@ def test_run_experiment_from_gromacs_files():
     include_path = examples_paths()['pxylene-gro-include']
     with omt.utils.temporary_directory() as tmp_dir:
         yaml_script = get_template_script(tmp_dir)
+        yaml_script['options']['anisotropic_dispersion_correction'] = False
         del yaml_script['molecules']  # we shouldn't need any molecule
         yaml_script['systems'] = {'explicit-system':
                 {'phase1_path': complex_path, 'phase2_path': solvent_path,

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -380,6 +380,7 @@ def test_validation_correct_solvents():
     solvents = [
         {'nonbonded_method': 'NoCutoff', 'nonbonded_cutoff': '3*nanometers'},
         {'nonbonded_method': 'PME', 'clearance': '3*angstroms'},
+        {'nonbonded_method': 'PME'},
         {'nonbonded_method': 'NoCutoff', 'implicit_solvent': 'OBC2'},
         {'nonbonded_method': 'CutoffPeriodic', 'nonbonded_cutoff': '9*angstroms',
          'clearance': '9*angstroms', 'positive_ion': 'Na+', 'negative_ion': 'Cl-'},
@@ -415,13 +416,15 @@ def test_validation_correct_systems():
     solvents:
         solv: {{nonbonded_method: NoCutoff}}
         solv2: {{nonbonded_method: NoCutoff, implicit_solvent: OBC2}}
+        solv3: {{nonbonded_method: PME, clearance: 10*angstroms}}
+        solv4: {{nonbonded_method: PME}}
     """.format(data_paths['lysozyme'])
     basic_script = yaml.load(textwrap.dedent(basic_script))
 
     systems = [
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv'},
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv', 'pack': True},
-        {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv',
+        {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv3',
             'leap': {'parameters': ['leaprc.gaff', 'leaprc.ff14SB']}},
 
         {'phase1_path': data_paths['bentol-complex'],
@@ -429,7 +432,10 @@ def test_validation_correct_systems():
          'ligand_dsl': 'resname BEN', 'solvent': 'solv'},
         {'phase1_path': data_paths['bentol-complex'],
          'phase2_path': data_paths['bentol-solvent'],
-         'ligand_dsl': 'resname BEN', 'solvent1': 'solv',
+         'ligand_dsl': 'resname BEN', 'solvent': 'solv4'},
+        {'phase1_path': data_paths['bentol-complex'],
+         'phase2_path': data_paths['bentol-solvent'],
+         'ligand_dsl': 'resname BEN', 'solvent1': 'solv3',
          'solvent2': 'solv2'},
 
         {'phase1_path': data_paths['pxylene-complex'],
@@ -466,6 +472,8 @@ def test_validation_wrong_systems():
     solvents:
         solv: {{nonbonded_method: NoCutoff}}
         solv2: {{nonbonded_method: NoCutoff, implicit_solvent: OBC2}}
+        solv3: {{nonbonded_method: PME, clearance: 10*angstroms}}
+        solv4: {{nonbonded_method: PME}}
     """.format(data_paths['lysozyme'])
     basic_script = yaml.load(textwrap.dedent(basic_script))
 
@@ -474,7 +482,9 @@ def test_validation_wrong_systems():
         {'receptor': 'rec', 'ligand': 1, 'solvent': 'solv'},
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': ['solv', 'solv']},
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'unknown'},
-        {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv',
+        {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv4',
+            'leap': {'parameters': ['leaprc.gaff', 'leaprc.ff14SB']}},
+        {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv3',
             'parameters': 'leaprc.ff14SB'},
 
         {'phase1_path': data_paths['bentol-complex'][0],
@@ -1696,6 +1706,7 @@ def test_run_experiment_from_amber_files():
         yaml_script = get_template_script(tmp_dir)
         yaml_script['options']['anisotropic_dispersion_correction'] = False
         del yaml_script['molecules']  # we shouldn't need any molecule
+        del yaml_script['solvents']['PME']['clearance']  # we shouldn't need this
         yaml_script['systems'] = {'explicit-system':
                 {'phase1_path': complex_path, 'phase2_path': solvent_path,
                  'ligand_dsl': 'resname TOL', 'solvent': 'PME'}}

--- a/docs/yamlpages/solvents.rst
+++ b/docs/yamlpages/solvents.rst
@@ -216,12 +216,10 @@ We highly recommend  having a
 :ref:`number of equilibration iterations <yaml_options_number_of_equilibration_iterations>` 
 when this option is invoked.
 
-If not specified, this process is not carried out and no solvent will be added to the systems. Because this is a rare
-scenario, YANK warns the user that no solvent will be added. It is up to the user to provide input files with appropriate
-Periodic Boundary Conditions. Please see :ref:`the documentation for providing your own phases <yaml_systems_user_defined>`
-for this scenario.
+This option is mandatory only for systems that need to go through the automatic preparation pipeline, and it is ignored
+for systems :ref:`defined by Amber, GROMACS, or OpenMM files <yaml_systems_user_defined>`.
 
-Nonbonded Methods: ``CuttoffPeriodic``, ``Ewald``, ``PME``
+Nonbonded Methods: ``CuttoffNonPeriodic``, ``CuttoffPeriodic``, ``Ewald``, ``PME``
 
 Valid Options: <Quantity Length> [1]_
 

--- a/docs/yamlpages/systems.rst
+++ b/docs/yamlpages/systems.rst
@@ -92,7 +92,7 @@ Arbitrary Phase Free Energies Setup by User
        gromacs_include_dir: include/
 
 YANK will allow users to specify arbitrary free energy calculations with systems they have prepared themselves.
-Both Amber and GROMACS input file types are accepted. It is also possible to specify a pair of ``[*.pdb, *.xml]
+Both Amber and GROMACS input file types are accepted. It is also possible to specify a pair of ``[*.pdb, *.xml]``
 files for each phase, where the XML contains a serialized OpenMM system.
 MDTraj is required to use this options since picking the ligand out of the files is done with an MDTraj DSL.
 
@@ -101,7 +101,8 @@ MDTraj is required to use this options since picking the ligand out of the files
 * ``lidand_dsl``: An MDTraj DSL string which identifies the ligand in the files provided by ``phase1_path`` and ``phase2_path``. 
 * ``solvent``: A ``{UserDefinedSolvent}`` to put the two phases in. Only one solvent is allowed for this calculation.
   This option must be omitted if using XML/PDB files, since the solvent options are inherently specified in the XML
-  definition of the system.
+  definition of the system. Finally, if the two phases require two different solvents, it is possible to substitute the
+  ``solvent`` option with two ``solvent1`` and ``solvent2``, which are associated to phase 1 and phase 2 respectively.
 * ``gromacs_include_dir``: *Optional*, Tells YANK where the GROMACS include directory is to pull files and parameters from.
   This is particularly helpful if your topology file does not contain all parameters.
   Path is relative to the YAML script.


### PR DESCRIPTION
Ready for review if tests pass.

I've also updated the docs with the new `clearance` behavior, I mentioned that it is possible to use `solvent1` and `solvent2` with Amber/GROMACS/OpenMM systems, and I've added a couple of tests for the new `anisotropic_dispersion_correction` option.