### PR TITLE
New states classes

### DIFF
--- a/Yank/cache.py
+++ b/Yank/cache.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Provide cache classes to handle creation of OpenMM Context objects.
+
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import collections
+
+
+# =============================================================================
+# GENERAL LRU CACHE
+# =============================================================================
+
+class LRUCache(object):
+    """A simple LRU cache."""
+
+    def __init__(self, capacity, time_to_live=None):
+        self._data = collections.OrderedDict()
+        self._capacity = capacity
+        self._ttl = time_to_live
+        self._n_access = 0
+
+    def __getitem__(self, key):
+        self._n_access += 1
+
+        # When we access data, push element at the
+        # end to make it the most recently used.
+        entry = self._data.pop(key)
+        self._data[key] = entry
+
+        # Update expiration and cleanup expired values.
+        if self._ttl is not None:
+            entry.expiration = self._n_access + self._ttl
+            self._remove_expired()
+        return entry.value
+
+    def __setitem__(self, key, value):
+        self._n_access += 1
+
+        # When we access data, push element at the
+        # end to make it the most recently used.
+        try:
+            self._data.pop(key)
+        except KeyError:
+            # Remove first item if we hit maximum capacity.
+            if len(self._data) >= self._capacity:
+                self._data.popitem(last=False)
+
+        # Determine expiration and clean up expired.
+        if self._ttl is None:
+            ttl = None
+        else:
+            ttl = self._ttl + self._n_access
+            self._remove_expired()
+        self._data[key] = _CacheEntry(value, ttl)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __contains__(self, item):
+        return item in self._data
+
+    def _remove_expired(self):
+        """Remove all expired cache entries.
+
+        Assumes that entries were created with an expiration attribute.
+
+        """
+        keys_to_remove = set()
+        for key, entry in self._data.items():
+            if entry.expiration <= self._n_access:
+                keys_to_remove.add(key)
+            else:
+                # Later entries have been accessed later
+                # and they surely haven't expired yet.
+                break
+        for key in keys_to_remove:
+            del self._data[key]
+
+
+# =============================================================================
+# CACHE ENTRY (MODULE INTERNAL USAGE)
+# =============================================================================
+
+class _CacheEntry(object):
+    """A cache entry holding an optional expiration attribute."""
+    def __init__(self, value, expiration=None):
+        self.value = value
+
+        # We create the self.expiration attribute only if requested
+        # to save memory in case the cache stores a lot of entries.
+        if expiration is not None:
+            self.expiration = expiration

--- a/Yank/states.py
+++ b/Yank/states.py
@@ -1150,6 +1150,7 @@ class SamplerState(object):
         if check_consistency:
             self.positions = openmm_state.getPositions(asNumpy=True)
         else:
+            # The positions in md units cache is updated below.
             self._positions = openmm_state.getPositions(asNumpy=True)
 
         self.velocities = openmm_state.getVelocities(asNumpy=True)

--- a/Yank/states.py
+++ b/Yank/states.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Classes that represent a portion of the state of an OpenMM context.
+
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import copy
+
+from simtk import openmm
+
+
+# =============================================================================
+# CUSTOM EXCEPTIONS
+# =============================================================================
+
+class ThermodynamicsException(Exception):
+
+    # TODO substitute this with enum when we drop Python 2.7 support
+    (NO_BAROSTAT,
+     MULTIPLE_BAROSTATS,
+     UNSUPPORTED_BAROSTAT,
+     INCONSISTENT_BAROSTAT) = range(4)
+
+    error_messages = {
+        NO_BAROSTAT: "System is incompatible with NPT ensemble: missing barostat.",
+        MULTIPLE_BAROSTATS: "System has multiple barostats.",
+        UNSUPPORTED_BAROSTAT: "Found unsupported barostat {} in system.",
+        INCONSISTENT_BAROSTAT: "System barostat is inconsistent with thermodynamic state."
+    }
+
+    def __init__(self, code, *args):
+        error_message = self.error_messages[code].format(*args)
+        super(ThermodynamicsException, self).__init__(error_message)
+        self.code = code
+
+
+# =============================================================================
+# THERMODYNAMIC STATE
+# =============================================================================
+
+class ThermodynamicState(object):
+    """The state of a Context that does not change with integration."""
+
+    # -------------------------------------------------------------------------
+    # Public interface
+    # -------------------------------------------------------------------------
+
+    def __init__(self, system, temperature, pressure=None, force_system_state=False):
+        """Constructor."""
+        system = copy.deepcopy(system)  # do not modify original system
+
+        self._pressure = pressure
+        self._temperature = temperature
+        self._system = system
+
+        # Check system compatibility
+        if pressure is not None:
+            barostat = self._find_barostat(system)
+            if barostat is None and force_system_state:
+                self._add_barostat(system)
+            elif barostat is None and not force_system_state:
+                raise ThermodynamicsException(ThermodynamicsException.NO_BAROSTAT)
+            elif not force_system_state and not self._is_barostat_consistent(barostat):
+                raise ThermodynamicsException(ThermodynamicsException.INCONSISTENT_BAROSTAT)
+            elif force_system_state:
+                self._configure_barostat(system)
+
+    @property
+    def system(self):
+        return copy.deepcopy(self._system)
+
+    # -------------------------------------------------------------------------
+    # Internal-usage: barostat handling
+    # -------------------------------------------------------------------------
+
+    _SUPPORTED_BAROSTATS = {'MonteCarloBarostat'}
+
+    @classmethod
+    def _find_barostat(cls, system):
+        """Return the first barostat found in the system.
+
+        Parameters
+        ----------
+        system : simtk.openmm.System
+            The OpenMM system containing the barostat.
+
+        Returns
+        -------
+        The barostat OpenMM Force object found in system or None if no
+        barostat Force is found.
+
+        Raises
+        ------
+        ThermodynamicsException
+            If the system contains multiple or unsupported barostats.
+
+        """
+        barostat_forces = [force for force in system.getForces()
+                           if 'Barostat' in force.__class__.__name__]
+        if len(barostat_forces) == 0:
+            return None
+        if len(barostat_forces) > 1:
+            raise ThermodynamicsException(ThermodynamicsException.MULTIPLE_BAROSTATS)
+
+        barostat = barostat_forces[0]
+        if barostat.__class__.__name__ not in cls._SUPPORTED_BAROSTATS:
+            raise ThermodynamicsException(ThermodynamicsException.UNSUPPORTED_BAROSTAT,
+                                          barostat.__class__.__name__)
+        return barostat
+
+    def _is_barostat_consistent(self, barostat):
+        """Check the barostat's temperature and pressure."""
+        try:
+            barostat_temperature = barostat.getDefaultTemperature()
+        except AttributeError:  # versions previous to OpenMM 7.1
+            barostat_temperature = barostat.getTemperature()
+        barostat_pressure = barostat.getDefaultPressure()
+
+        is_consistent = barostat_temperature == self._temperature
+        is_consistent = is_consistent and barostat_pressure == self._pressure
+        return is_consistent
+
+    def _configure_barostat(self, system):
+        """Configure the barostat to be consistent with this state."""
+        barostat = self._find_barostat(system)
+        try:
+            barostat.setDefaultTemperature(self._temperature)
+        except AttributeError:  # versions previous to OpenMM 7.1
+            barostat.setTemperature(self._temperature)
+        barostat.setDefaultPressure(self._pressure)
+
+    def _add_barostat(self, system):
+        """Add a MonteCarloBarostat to the given system."""
+        assert self._find_barostat(system) is None  # pre-condition
+        barostat = openmm.MonteCarloBarostat(self._pressure, self._temperature)
+        system.addForce(barostat)

--- a/Yank/states.py
+++ b/Yank/states.py
@@ -370,8 +370,10 @@ class ThermodynamicState(object):
 
     @pressure.setter
     def pressure(self, value):
+        # Invalidate cache if the ensemble changes.
+        if (value is None) != (self._barostat is None):
+            self._cached_standard_system_hash = None
         self._set_system_pressure(self._system, value)
-        self._cached_standard_system_hash = None  # Invalidate cache.
 
     @property
     def volume(self):

--- a/Yank/states.py
+++ b/Yank/states.py
@@ -1678,7 +1678,8 @@ class IComposableState(utils.SubhookedABCMeta):
         """Apply changes to the context to be consistent with the state."""
         pass
 
-    @abc.abstractclassmethod
+    @classmethod
+    @abc.abstractmethod
     def standardize_system(cls, system):
         """Standardize the given system.
 

--- a/Yank/states.py
+++ b/Yank/states.py
@@ -723,8 +723,8 @@ class ThermodynamicState(object):
                                       barostat.__class__.__name__)
         return barostat
 
-    @classmethod
-    def _find_barostat_index(cls, system):
+    @staticmethod
+    def _find_barostat_index(system):
         """Return the index of the first barostat found in the system.
 
         Returns

--- a/Yank/tests/test_cache.py
+++ b/Yank/tests/test_cache.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test Context cache classes in cache.py.
+
+"""
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+from yank.cache import *
+
+
+# =============================================================================
+# TEST LRU CACHE
+# =============================================================================
+
+def test_lru_cache_cache_entry_unpacking():
+    """Values in LRUCache are unpacked from CacheEntry."""
+    cache = LRUCache(capacity=5)
+    cache['first'] = 1
+    assert cache['first'] == 1
+
+    # When we don't require a time-to-leave, there's
+    # no expiration attribute in the cache entry.
+    assert not hasattr(cache._data['first'], 'expiration')
+
+
+def test_lru_cache_maximum_capacity():
+    """Maximum size of LRUCache is handled correctly."""
+    cache = LRUCache(capacity=2)
+    cache['first'] = 1
+    cache['second'] = 2
+    assert len(cache) == 2
+    cache['third'] = 3
+    assert len(cache) == 2
+    assert 'first' not in cache
+
+
+def test_lru_cache_eliminate_least_recently_used():
+    """LRUCache deletes LRU element when size exceeds capacity."""
+    cache = LRUCache(capacity=3)
+    cache['first'] = 1
+    cache['second'] = 2
+
+    # We access 'first' through setting, so that it becomes the LRU.
+    cache['first'] = 1
+    cache['third'] = 3
+    cache['fourth'] = 4  # Here size exceed capacity.
+    assert len(cache) == 3
+    assert 'second' not in cache
+
+    # We access 'first' through getting now.
+    cache['first']
+    cache['fifth'] = 5  # Size exceed capacity.
+    assert len(cache) == 3
+    assert 'third' not in cache
+
+
+def test_lru_cache_access_to_live():
+    """LRUCache deletes element after specified number of accesses."""
+    def almost_expire_first():
+        cache['first'] = 1  # Update expiration.
+        for _ in range(ttl - 1):
+            cache['second']
+            assert 'first' in cache
+
+    ttl = 3
+    cache = LRUCache(capacity=2, time_to_live=ttl)
+    cache['first'] = 1
+    cache['second'] = 2  # First access.
+    assert cache._data['first'].expiration == ttl + 1
+    cache['first']  # Expiration gets updated.
+    assert cache._data['first'].expiration == ttl + 3
+
+    # At the ttl-th read access, 'first' gets deleted.
+    almost_expire_first()
+    cache['second']
+    assert 'second' in cache
+    assert 'first' not in cache
+
+    # The same happen at the ttl-th write access.
+    almost_expire_first()
+    cache['second'] = 2
+    assert 'second' in cache
+    assert 'first' not in cache
+
+    # If we touch at the last minute 'first', it remains in memory.
+    almost_expire_first()
+    cache['first']
+    assert 'second' in cache
+    assert 'first' in cache

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -164,6 +164,23 @@ class TestThermodynamicState(object):
             state.pressure = None
             assert state._barostat is None
 
+    def test_property_volume(self):
+        """Check that volume is computed correctly."""
+        # For volume-fluctuating systems volume is None.
+        state = ThermodynamicState(self.barostated_alanine, self.temperature)
+        assert state.volume is None
+
+        # For periodic systems in NVT, volume is correctly computed.
+        system = self.alanine_explicit
+        box_vectors = system.getDefaultPeriodicBoxVectors()
+        volume = box_vectors[0][0] * box_vectors[1][1] * box_vectors[2][2]
+        state = ThermodynamicState(system, self.temperature)
+        assert state.volume == volume
+
+        # For non-periodic systems, volume is None.
+        state = ThermodynamicState(self.toluene_vacuum, self.temperature)
+        assert state.volume is None
+
     def test_constructor_unsupported_barostat(self):
         """Exception is raised on construction with unsupported barostats."""
         TE = ThermodynamicsError  # shortcut

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -302,8 +302,9 @@ class TestThermodynamicState(object):
             state.set_system(system)
         assert cm.exception.code == ThermodynamicsError.NO_THERMOSTAT
 
-        state.set_system(system, fix_thermostat=True)
+        state.set_system(system, fix_state=True)
         assert state._thermostat.getDefaultTemperature() == self.std_temperature
+        assert state._barostat is None
 
         # In NPT, we can't set the system without adding a barostat.
         system = state.system  # System with thermostat.
@@ -312,7 +313,7 @@ class TestThermodynamicState(object):
             state.set_system(system)
         assert cm.exception.code == ThermodynamicsError.NO_BAROSTAT
 
-        state.set_system(system, fix_barostat=True)
+        state.set_system(system, fix_state=True)
         assert state._barostat.getDefaultPressure() == self.std_pressure
         assert get_barostat_temperature(state._barostat) == self.std_temperature
 
@@ -983,8 +984,8 @@ class TestCompoundThermodynamicState(object):
         compound_state.temp = 0
         assert 'temp' in compound_state.__dict__
 
-    def test_property_system(self):
-        """CompoundThermodynamicState.system setting."""
+    def test_set_system(self):
+        """CompoundThermodynamicState.system and set_system method."""
         thermodynamic_state = ThermodynamicState(self.alanine_explicit, self.std_temperature)
         compound_state = CompoundThermodynamicState(thermodynamic_state, [self.dummy_state])
 
@@ -993,6 +994,13 @@ class TestCompoundThermodynamicState(object):
         self.DummyState.set_dummy_parameter(system, self.dummy_parameter + 1.0)
         with nose.tools.assert_raises(ValueError):
             compound_state.system = system
+
+        # Same for set_system when called with default arguments.
+        with nose.tools.assert_raises(ValueError):
+            compound_state.set_system(system)
+
+        # This doesn't happen if we fix the state.
+        compound_state.set_system(system, fix_state=True)
 
     def test_method_standardize_system(self):
         """CompoundThermodynamicState._standardize_system method."""

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -599,6 +599,7 @@ class TestThermodynamicState(object):
         reduced_potential = state.reduced_potential(sampler_state)
         potential_energy = reduced_potential / beta / kj_mol
         assert np.isclose(sampler_state.potential_energy / kj_mol, potential_energy)
+        assert reduced_potential == state.reduced_potential(context)
 
         # Compute constant pressure reduced potential.
         state.pressure = self.std_pressure
@@ -607,6 +608,7 @@ class TestThermodynamicState(object):
                                 unit.AVOGADRO_CONSTANT_NA)
         potential_energy = (reduced_potential / beta - pressure_volume_work) / kj_mol
         assert np.isclose(sampler_state.potential_energy / kj_mol, potential_energy)
+        assert reduced_potential == state.reduced_potential(context)
 
         # Raise error if SamplerState is not compatible.
         incompatible_sampler_state = sampler_state[:-1]

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -160,6 +160,10 @@ class TestThermodynamicState(object):
             assert barostat.getDefaultPressure() == new_pressure
             assert get_barostat_temperature(barostat) == self.temperature
 
+            # Setting pressure to None removes barostat
+            state.pressure = None
+            assert state._barostat is None
+
     def test_constructor_unsupported_barostat(self):
         """Exception is raised on construction with unsupported barostats."""
         TE = ThermodynamicsError  # shortcut

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -26,7 +26,7 @@ from yank.states import *
 
 def get_barostat_temperature(barostat):
     """Backward-compatibly get barostat's temperature"""
-    try:
+    try:  # TODO drop this when we stop openmm7.0 support
         return barostat.getDefaultTemperature()
     except AttributeError:  # versions previous to OpenMM 7.1
         return barostat.setTemperature()
@@ -113,18 +113,6 @@ class TestThermodynamicState(object):
         assert not state._is_barostat_consistent(barostat)
         barostat = openmm.MonteCarloBarostat(pressure, temperature + 10*unit.kelvin)
         assert not state._is_barostat_consistent(barostat)
-
-    def test_method_add_barostat(self):
-        """ThermodynamicState._add_barostat() method."""
-        state = InconsistentThermodynamicState(system=copy.deepcopy(self.toluene_vacuum),
-                                               temperature=self.temperature)
-        assert state._barostat is None  # Test pre-condition
-
-        state._add_barostat(self.pressure)
-        barostat = state._barostat
-        assert isinstance(barostat, openmm.MonteCarloBarostat)
-        assert barostat.getDefaultPressure() == self.pressure
-        assert get_barostat_temperature(barostat) == self.temperature
 
     def test_property_temperature(self):
         """ThermodynamicState.temperature property."""

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -640,7 +640,7 @@ class TestThermodynamicState(object):
         reduced_potential = state.reduced_potential(sampler_state)
         potential_energy = reduced_potential / beta / kj_mol
         assert np.isclose(sampler_state.potential_energy / kj_mol, potential_energy)
-        assert reduced_potential == state.reduced_potential(context)
+        assert np.isclose(reduced_potential, state.reduced_potential(context))
 
         # Compute constant pressure reduced potential.
         state.pressure = self.std_pressure
@@ -649,7 +649,7 @@ class TestThermodynamicState(object):
                                 unit.AVOGADRO_CONSTANT_NA)
         potential_energy = (reduced_potential / beta - pressure_volume_work) / kj_mol
         assert np.isclose(sampler_state.potential_energy / kj_mol, potential_energy)
-        assert reduced_potential == state.reduced_potential(context)
+        assert np.isclose(reduced_potential, state.reduced_potential(context))
 
         # Raise error if SamplerState is not compatible.
         incompatible_sampler_state = sampler_state[:-1]

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -201,9 +201,10 @@ class TestThermodynamicState(object):
     def test_method_set_system_pressure(self):
         """ThermodynamicState._set_system_pressure() method."""
         state = ThermodynamicState(self.alanine_explicit, self.std_temperature)
-        assert not state._set_system_pressure(state._system, None)
-        assert state._set_system_pressure(state._system, self.std_pressure)
-        assert not state._set_system_pressure(state._system, self.std_pressure)
+        state._set_system_pressure(state._system, None)
+        assert state._barostat is None
+        state._set_system_pressure(state._system, self.std_pressure)
+        assert state._barostat.getDefaultPressure() == self.std_pressure
 
     def test_property_pressure(self):
         """ThermodynamicState.pressure property."""

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -204,7 +204,8 @@ class TestThermodynamicState(object):
         assert state.pressure == self.pressure  # pre-condition
 
         TE = ThermodynamicsError  # shortcut
-        test_cases = [(self.barostated_toluene, TE.BAROSTATED_NONPERIODIC),
+        test_cases = [(self.toluene_vacuum, TE.BAROSTATED_NONPERIODIC),
+                      (self.barostated_toluene, TE.BAROSTATED_NONPERIODIC),
                       (self.multiple_barostat_alanine, TE.MULTIPLE_BAROSTATS),
                       (self.inconsistent_pressure_alanine, TE.INCONSISTENT_BAROSTAT),
                       (self.inconsistent_temperature_alanine, TE.INCONSISTENT_BAROSTAT)]
@@ -315,7 +316,7 @@ class TestThermodynamicState(object):
         assert not state._set_integrator_temperature(integrator)
 
     def test_method_turn_to_standard_system(self):
-        """ThermodynamicState._turn_to_standard_system() class method."""
+        """ThermodynamicState.turn_to_standard_system() class method."""
         system = copy.deepcopy(self.barostated_alanine)
 
         ThermodynamicState.turn_to_standard_system(system)

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test State classes in states.py.
+
+"""
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import nose
+from simtk import unit
+from openmmtools import testsystems
+
+from yank.states import *
+
+
+# =============================================================================
+# UTILITY CLASSES
+# =============================================================================
+
+class InconsistentThermodynamicState(ThermodynamicState):
+    """ThermodynamicState that does not run consistency checks on init.
+
+    It is useful to test private methods used to check for consistency.
+
+    """
+    def __init__(self, system=None, temperature=None, pressure=None):
+        self._system = system
+        self._temperature = temperature
+        self._pressure = pressure
+
+
+# =============================================================================
+# TEST THERMODYNAMIC STATE
+# =============================================================================
+
+class TestThermodynamicState(object):
+
+    @classmethod
+    def setup_class(cls):
+        """Create the test systems used in the test suite."""
+        cls.temperature = 300*unit.kelvin
+        cls.pressure = 1.0*unit.atmosphere
+        cls.toluene_vacuum = testsystems.TolueneVacuum().system
+
+        # A system correctly barostated
+        cls.barostated_toluene = copy.deepcopy(cls.toluene_vacuum)
+        barostat = openmm.MonteCarloBarostat(cls.pressure, cls.temperature)
+        cls.barostated_toluene.addForce(barostat)
+
+        # A system with two identical MonteCarloBarostats
+        cls.multiple_barostat_toluene = copy.deepcopy(cls.barostated_toluene)
+        barostat = openmm.MonteCarloBarostat(cls.pressure, cls.temperature)
+        cls.multiple_barostat_toluene.addForce(barostat)
+
+        # A system with an unsupported MonteCarloAnisotropicBarostat
+        cls.unsupported_barostat_toluene = copy.deepcopy(cls.toluene_vacuum)
+        pressure_in_bars = cls.pressure / unit.bar
+        anisotropic_pressure = openmm.Vec3(pressure_in_bars, pressure_in_bars,
+                                           pressure_in_bars)
+        barostat = openmm.MonteCarloAnisotropicBarostat(anisotropic_pressure,
+                                                        cls.temperature)
+        cls.unsupported_barostat_toluene.addForce(barostat)
+
+        # A system a barostated at the incorrect temperature
+        cls.incompatible_pressure_barostat_toluene = copy.deepcopy(cls.toluene_vacuum)
+        barostat = openmm.MonteCarloBarostat(cls.pressure,
+                                             cls.temperature + 1*unit.kelvin)
+        cls.incompatible_pressure_barostat_toluene.addForce(barostat)
+
+        # A system a barostat at the incorrect pressure
+        cls.incompatible_temperature_barostat_toluene = copy.deepcopy(cls.toluene_vacuum)
+        barostat = openmm.MonteCarloBarostat(cls.pressure + 0.1*unit.atmosphere,
+                                             cls.temperature)
+        cls.incompatible_temperature_barostat_toluene.addForce(barostat)
+
+    def test_method_find_barostat(self):
+        """ThermodynamicState._find_barostat() method."""
+        barostated_system = copy.deepcopy(self.barostated_toluene)
+        barostat = ThermodynamicState._find_barostat(barostated_system)
+        assert isinstance(barostat, openmm.MonteCarloBarostat)
+
+        # Raise exception if multiple or unsupported barostats found
+        multiple_system = self.multiple_barostat_toluene
+        unsupported_system = self.unsupported_barostat_toluene
+
+        test_cases = [(multiple_system, ThermodynamicsException.MULTIPLE_BAROSTATS),
+                      (unsupported_system, ThermodynamicsException.UNSUPPORTED_BAROSTAT)]
+        for system, err_code in test_cases:
+            with nose.tools.assert_raises(ThermodynamicsException) as cm:
+                ThermodynamicState._find_barostat(system)
+            assert cm.exception.code == err_code
+
+    def test_method_is_barostat_consistent(self):
+        """ThermodynamicState._is_barostat_consistent() method."""
+        temperature = 300*unit.kelvin
+        pressure = 1.0*unit.atmosphere
+        state = InconsistentThermodynamicState(None, temperature, pressure)
+
+        barostat = openmm.MonteCarloBarostat(pressure, temperature)
+        assert state._is_barostat_consistent(barostat)
+        barostat = openmm.MonteCarloBarostat(pressure + 0.2*unit.atmosphere, temperature)
+        assert not state._is_barostat_consistent(barostat)
+        barostat = openmm.MonteCarloBarostat(pressure, temperature + 10*unit.kelvin)
+        assert not state._is_barostat_consistent(barostat)
+
+    def test_method_configure_barostat(self):
+        """ThermodynamicState._configure_barostat() method."""
+        barostated_system = copy.deepcopy(self.barostated_toluene)
+        temperature = self.temperature + 10.0*unit.kelvin
+        pressure = self.pressure + 0.2*unit.atmosphere
+        state = InconsistentThermodynamicState(barostated_system, temperature, pressure)
+
+        state._configure_barostat(barostated_system)
+        barostat = state._find_barostat(barostated_system)
+        assert state._is_barostat_consistent(barostat)
+
+    def test_method_add_barostat(self):
+        """ThermodynamicState._add_barostat() method."""
+        toluene_system = copy.deepcopy(self.toluene_vacuum)
+        state = InconsistentThermodynamicState(temperature=self.temperature, pressure=self.pressure)
+        assert state._find_barostat(toluene_system) is None  # Test pre-condition
+
+        state._add_barostat(toluene_system)
+        barostat = state._find_barostat(toluene_system)
+        assert isinstance(barostat, openmm.MonteCarloBarostat)
+        assert state._is_barostat_consistent(barostat)
+
+    def test_constructor_npt_incompatible_systems(self):
+        """Exception is raised on construction with NPT-incompatible systems."""
+        TE = ThermodynamicsException  # shortcut
+        test_cases = [(self.toluene_vacuum, TE.NO_BAROSTAT),
+                      (self.multiple_barostat_toluene, TE.MULTIPLE_BAROSTATS),
+                      (self.unsupported_barostat_toluene, TE.UNSUPPORTED_BAROSTAT),
+                      (self.incompatible_pressure_barostat_toluene, TE.INCONSISTENT_BAROSTAT),
+                      (self.incompatible_temperature_barostat_toluene, TE.INCONSISTENT_BAROSTAT)]
+        for system, err_code in test_cases:
+            with nose.tools.assert_raises(TE) as cm:
+                ThermodynamicState(system=system, temperature=self.temperature,
+                                   pressure=self.pressure)
+            assert cm.exception.code == err_code
+
+    def test_constructor_force_barostat(self):
+        test_cases = [self.toluene_vacuum,
+                      self.incompatible_pressure_barostat_toluene,
+                      self.incompatible_temperature_barostat_toluene]
+
+        for system in test_cases:
+            old_hash = openmm.XmlSerializer.serialize(system).__hash__()
+
+            # Force ThermodynamicState to add a barostat.
+            state = ThermodynamicState(system=system, temperature=self.temperature,
+                                       pressure=self.pressure, force_system_state=True)
+
+            # The new system has now a compatible barostat.
+            barostat = ThermodynamicState._find_barostat(state.system)
+            assert isinstance(barostat, openmm.MonteCarloBarostat)
+            assert state._is_barostat_consistent(barostat)
+
+            # The original system is unaltered.
+            new_hash = openmm.XmlSerializer.serialize(system).__hash__()
+            assert new_hash == old_hash

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -57,7 +57,7 @@ class TestThermodynamicState(object):
     def setup_class(cls):
         """Create the test systems used in the test suite."""
         cls.temperature = 300*unit.kelvin
-        cls.pressure = 1.0*unit.atmosphere
+        cls.pressure = 1.01325*unit.bar
         cls.toluene_vacuum = testsystems.TolueneVacuum().system
         cls.toluene_implicit = testsystems.TolueneImplicit().system
         cls.alanine_explicit = testsystems.AlanineDipeptideExplicit().system
@@ -88,7 +88,7 @@ class TestThermodynamicState(object):
 
         # A system with an inconsistent pressure in the barostat.
         cls.inconsistent_pressure_alanine = copy.deepcopy(cls.alanine_explicit)
-        barostat = openmm.MonteCarloBarostat(cls.pressure + 0.2*unit.atmosphere,
+        barostat = openmm.MonteCarloBarostat(cls.pressure + 0.2*unit.bar,
                                              cls.temperature)
         cls.inconsistent_pressure_alanine.addForce(barostat)
 
@@ -114,13 +114,13 @@ class TestThermodynamicState(object):
 
     def test_method_is_barostat_consistent(self):
         """ThermodynamicState._is_barostat_consistent() method."""
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmosphere
+        temperature = self.temperature
+        pressure = self.pressure
         state = ThermodynamicState(self.barostated_alanine, temperature)
 
         barostat = openmm.MonteCarloBarostat(pressure, temperature)
         assert state._is_barostat_consistent(barostat)
-        barostat = openmm.MonteCarloBarostat(pressure + 0.2*unit.atmosphere, temperature)
+        barostat = openmm.MonteCarloBarostat(pressure + 0.2*unit.bar, temperature)
         assert not state._is_barostat_consistent(barostat)
         barostat = openmm.MonteCarloBarostat(pressure, temperature + 10*unit.kelvin)
         assert not state._is_barostat_consistent(barostat)
@@ -146,7 +146,7 @@ class TestThermodynamicState(object):
 
             # We can't set the pressure on non-periodic systems
             with nose.tools.assert_raises(ThermodynamicsError) as cm:
-                state.pressure = 1*unit.atmosphere
+                state.pressure = 1.0*unit.bar
             assert cm.exception.code == ThermodynamicsError.BAROSTATED_NONPERIODIC
 
         # Correctly reads and set system pressures
@@ -164,7 +164,7 @@ class TestThermodynamicState(object):
             assert get_barostat_temperature(barostat) == self.temperature
 
             # Setting new pressure changes the barostat parameters
-            new_pressure = self.pressure + 1.0*unit.atmosphere
+            new_pressure = self.pressure + 1.0*unit.bar
             state.pressure = new_pressure
             assert state.pressure == new_pressure
             barostat = state._barostat
@@ -210,7 +210,7 @@ class TestThermodynamicState(object):
         # It is possible to set an inconsistent system
         # if thermodynamic state is changed first.
         inconsistent_system = self.inconsistent_pressure_alanine
-        state.pressure = self.pressure + 0.2*unit.atmosphere
+        state.pressure = self.pressure + 0.2*unit.bar
         state.system = self.inconsistent_pressure_alanine
         state_system_str = openmm.XmlSerializer.serialize(state.system)
         inconsistent_system_str = openmm.XmlSerializer.serialize(inconsistent_system)

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -117,18 +117,19 @@ class TestThermodynamicState(object):
         pressure = self.pressure + 0.2*unit.atmosphere
         state = InconsistentThermodynamicState(barostated_system, temperature, pressure)
 
-        state._configure_barostat(barostated_system)
-        barostat = state._find_barostat(barostated_system)
+        state._configure_barostat()
+        barostat = state._find_barostat(state.system)
         assert state._is_barostat_consistent(barostat)
 
     def test_method_add_barostat(self):
         """ThermodynamicState._add_barostat() method."""
-        toluene_system = copy.deepcopy(self.toluene_vacuum)
-        state = InconsistentThermodynamicState(temperature=self.temperature, pressure=self.pressure)
-        assert state._find_barostat(toluene_system) is None  # Test pre-condition
+        state = InconsistentThermodynamicState(system=copy.deepcopy(self.toluene_vacuum),
+                                               temperature=self.temperature,
+                                               pressure=self.pressure)
+        assert state._find_barostat(state.system) is None  # Test pre-condition
 
-        state._add_barostat(toluene_system)
-        barostat = state._find_barostat(toluene_system)
+        state._add_barostat()
+        barostat = state._find_barostat(state.system)
         assert isinstance(barostat, openmm.MonteCarloBarostat)
         assert state._is_barostat_consistent(barostat)
 
@@ -159,7 +160,7 @@ class TestThermodynamicState(object):
                                        pressure=self.pressure, force_system_state=True)
 
             # The new system has now a compatible barostat.
-            barostat = ThermodynamicState._find_barostat(state.system)
+            barostat = state._find_barostat(state.system)
             assert isinstance(barostat, openmm.MonteCarloBarostat)
             assert state._is_barostat_consistent(barostat)
 

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -36,6 +36,7 @@ def get_barostat_temperature(barostat):
 # =============================================================================
 
 class TestThermodynamicState(object):
+    """Test suite for states.ThermodynamicState class."""
 
     @classmethod
     def setup_class(cls):
@@ -412,7 +413,7 @@ class TestThermodynamicState(object):
 
     def test_method_reduced_potential(self):
         """ThermodynamicState.reduced_potential() method."""
-        kJmol = unit.kilojoule_per_mole
+        kj_mol = unit.kilojoule_per_mole
         beta = 1.0 / (unit.MOLAR_GAS_CONSTANT_R * self.temperature)
         state = ThermodynamicState(self.alanine_explicit, self.temperature)
         integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
@@ -422,16 +423,16 @@ class TestThermodynamicState(object):
 
         # Compute constant volume reduced potential.
         reduced_potential = state.reduced_potential(sampler_state)
-        potential_energy = reduced_potential / beta / kJmol
-        assert np.isclose(sampler_state.potential_energy / kJmol, potential_energy)
+        potential_energy = reduced_potential / beta / kj_mol
+        assert np.isclose(sampler_state.potential_energy / kj_mol, potential_energy)
 
         # Compute constant pressure reduced potential.
         state.pressure = self.pressure
         reduced_potential = state.reduced_potential(sampler_state)
         pressure_volume_work = (self.pressure * sampler_state.volume *
                                 unit.AVOGADRO_CONSTANT_NA)
-        potential_energy = (reduced_potential / beta - pressure_volume_work) / kJmol
-        assert np.isclose(sampler_state.potential_energy / kJmol, potential_energy)
+        potential_energy = (reduced_potential / beta - pressure_volume_work) / kj_mol
+        assert np.isclose(sampler_state.potential_energy / kj_mol, potential_energy)
 
         # Raise error if SamplerState is not compatible.
         incompatible_sampler_state = sampler_state[:-1]
@@ -445,9 +446,11 @@ class TestThermodynamicState(object):
 # =============================================================================
 
 class TestSamplerState(object):
+    """Test suite for states.SamplerState class."""
 
     @classmethod
     def setup_class(cls):
+        """Create various variables shared by tests in suite."""
         temperature = 300*unit.kelvin
         alanine_vacuum = testsystems.AlanineDipeptideVacuum()
         cls.alanine_vacuum_positions = alanine_vacuum.positions
@@ -461,6 +464,7 @@ class TestSamplerState(object):
 
     @staticmethod
     def is_sampler_state_equal_context(sampler_state, context):
+        """Check sampler and openmm states in context are equal."""
         equal = True
         ss = sampler_state  # Shortcut.
         os = context.getState(getPositions=True, getEnergy=True,
@@ -630,6 +634,7 @@ class TestSamplerState(object):
 # =============================================================================
 
 class TestCompoundThermodynamicState(object):
+    """Test suite for states.CompoundThermodynamicState class."""
 
     class DummyState(object):
         """A state that keeps track of a useless system parameter."""
@@ -701,6 +706,7 @@ class TestCompoundThermodynamicState(object):
 
     @classmethod
     def setup_class(cls):
+        """Create various variables shared by tests in suite."""
         cls.pressure = 1.01325*unit.bars
         cls.temperature = 300*unit.kelvin
 
@@ -733,6 +739,7 @@ class TestCompoundThermodynamicState(object):
         assert compound_state.temperature == new_temperature
 
     def test_constructor_set_state(self):
+        """IComposableState.set_state is called on construction."""
         thermodynamic_state = ThermodynamicState(self.alanine_explicit, self.temperature)
 
         assert self.get_dummy_parameter(thermodynamic_state.system) != self.dummy_parameter

--- a/Yank/tests/test_states.py
+++ b/Yank/tests/test_states.py
@@ -462,15 +462,21 @@ class TestSamplerState(object):
     @staticmethod
     def is_sampler_state_equal_context(sampler_state, context):
         equal = True
-        openmm_state = context.getState(getPositions=True, getEnergy=True,
-                                        getVelocities=True)
-        equal = equal and np.all(sampler_state.positions == openmm_state.getPositions())
-        equal = equal and np.all(sampler_state.velocities == openmm_state.getVelocities())
-        equal = equal and np.all(sampler_state.box_vectors == openmm_state.getPeriodicBoxVectors())
-        equal = equal and sampler_state.potential_energy == openmm_state.getPotentialEnergy()
-        equal = equal and sampler_state.kinetic_energy == openmm_state.getKineticEnergy()
-        nm3 = unit.nanometers**3
-        equal = equal and np.isclose(sampler_state.volume / nm3, openmm_state.getPeriodicBoxVolume() / nm3)
+        ss = sampler_state  # Shortcut.
+        os = context.getState(getPositions=True, getEnergy=True,
+                              getVelocities=True)
+        equal = equal and np.allclose(ss.positions.value_in_unit(ss.positions.unit),
+                                      os.getPositions().value_in_unit(ss.positions.unit))
+        equal = equal and np.allclose(ss.velocities.value_in_unit(ss.velocities.unit),
+                                      os.getVelocities().value_in_unit(ss.velocities.unit))
+        equal = equal and np.allclose(ss.box_vectors.value_in_unit(ss.box_vectors.unit),
+                                      os.getPeriodicBoxVectors().value_in_unit(ss.box_vectors.unit))
+        equal = equal and np.isclose(ss.potential_energy.value_in_unit(ss.potential_energy.unit),
+                                     os.getPotentialEnergy().value_in_unit(ss.potential_energy.unit))
+        equal = equal and np.isclose(ss.kinetic_energy.value_in_unit(ss.kinetic_energy.unit),
+                                     os.getKineticEnergy().value_in_unit(ss.kinetic_energy.unit))
+        equal = equal and np.isclose(ss.volume.value_in_unit(ss.volume.unit),
+                                     os.getPeriodicBoxVolume().value_in_unit(ss.volume.unit))
         return equal
 
     @staticmethod

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -23,14 +23,6 @@ from yank.utils import *
 # TESTING FUNCTIONS
 #=============================================================================================
 
-def test_is_iterable_container():
-    """Test utility function not_iterable_container()."""
-    assert is_iterable_container(3) == False
-    assert is_iterable_container('ciao') == False
-    assert is_iterable_container([1, 2, 3]) == True
-    assert is_iterable_container(CombinatorialLeaf([1, 2, 3])) == True
-
-
 def test_set_tree_path():
     """Test getting and setting of CombinatorialTree paths."""
     test = CombinatorialTree({'a': 2})

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -323,3 +323,36 @@ def test_TLeap_export_run():
         assert os.path.getsize(output_path + '.inpcrd') > 0
         assert os.path.isfile(os.path.join(tmp_dir, 'benzene.leap.log'))
 
+
+def test_subhooked_abcmeta():
+    """Test class SubhookedABCMeta."""
+    # Define an interface
+    class IInterface(SubhookedABCMeta):
+        @abc.abstractmethod
+        def my_method(self): pass
+
+        @abc.abstractproperty
+        def my_property(self): pass
+
+        @staticmethod
+        @abc.abstractmethod
+        def my_static_method(): pass
+
+    # Define object implementing the interface with duck typing
+    class InterfaceImplementation(object):
+        def my_method(self): pass
+
+        def my_property(self): pass
+
+        @staticmethod
+        def my_static_method(): pass
+
+    implementation_instance = InterfaceImplementation()
+    assert isinstance(implementation_instance, IInterface)
+
+    # Define incomplete implementation
+    class WrongInterfaceImplementation(object):
+        def my_method(self): pass
+
+    implementation_instance = WrongInterfaceImplementation()
+    assert not isinstance(implementation_instance, IInterface)

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -650,6 +650,21 @@ def with_metaclass(metaclass, *bases):
     return type.__new__(Metaclass, 'temporary_class', (), {})
 
 
+class SubhookedABCMeta(with_metaclass(abc.ABCMeta)):
+    """Abstract class with an implementation of __subclasshook__.
+
+    The __subclasshook__ method checks that the instance implement the
+    abstract properties and methods defined by the abstract class.
+
+    """
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        for abstract_method in cls.__abstractmethods__:
+            if not any(abstract_method in C.__dict__ for C in subclass.__mro__):
+                return False
+        return True
+
+
 #========================================================================================
 # Miscellaneous functions
 #========================================================================================

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+import abc
 import sys
 import copy
 import glob
@@ -626,6 +627,27 @@ class CombinatorialTree(collections.MutableMapping):
             for leaf_path, leaf_val in zip(leaf_paths, combination):
                 template_tree[leaf_path] = leaf_val
             yield copy.deepcopy(template_tree._d)
+
+
+# =============================================================================
+# METACLASS UTILITIES
+# =============================================================================
+
+# TODO Remove this when we drop Python 2 support.
+def with_metaclass(metaclass, *bases):
+    """Create a base class with a metaclass.
+
+    Imported from six (MIT license): https://pypi.python.org/pypi/six.
+    Provide a Python2/3 compatible way to create an metaclass.
+
+    """
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class Metaclass(metaclass):
+        def __new__(cls, name, this_bases, d):
+            return metaclass(name, bases, d)
+    return type.__new__(Metaclass, 'temporary_class', (), {})
 
 
 #========================================================================================

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -684,18 +684,6 @@ def find_phases_in_store_directory(store_directory):
     return phases
 
 
-def is_iterable_container(value):
-    """Check whether the given value is a list-like object or not.
-
-    Returns
-    -------
-    Flase if value is a string or not iterable, True otherwise.
-
-    """
-    # strings are iterable too so we have to treat them as a special case
-    return not isinstance(value, str) and isinstance(value, collections.Iterable)
-
-
 # ==============================================================================
 # Conversion utilities
 # ==============================================================================

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -654,7 +654,19 @@ class SubhookedABCMeta(with_metaclass(abc.ABCMeta)):
     """Abstract class with an implementation of __subclasshook__.
 
     The __subclasshook__ method checks that the instance implement the
-    abstract properties and methods defined by the abstract class.
+    abstract properties and methods defined by the abstract class. This
+    allow classes to implement an abstraction without explicitly
+    subclassing.
+
+    Examples
+    --------
+    >>> class MyInterface(SubhookedABCMeta):
+    ...     @abc.abstractmethod
+    ...     def my_method(self): pass
+    >>> class Implementation(object):
+    ...     def my_method(self): return True
+    >>> isinstance(Implementation(), MyInterface)
+    True
 
     """
     @classmethod


### PR DESCRIPTION
This is the first big chunk of stuff for the new API. I've added a new module `states.py` implementing `ThermodynamicState`, `SamplerState` and `CompoundThermodynamicState`. The last one allows to extend `ThermodynamicState` by composition rather than inheritance and it will be used to mix `ThermodynamicState` with `AlchemicalState`. I've added a lot of documentation and tests so hopefully it should be clear and it shouldn't introduce new bugs.

Nothing is attached to the main code yet. Before doing it, I need to adapt `alchemy.AlchemicalState`, and if we want to directly move to a scheme that uses `MCMoves`, I'll also add a `ContextCache`. Next thing is to write the first implementation of the lower level `Storage` class.