### PR TITLE
Cleanup from running the tests.

### DIFF
--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -25,7 +25,7 @@ usage = """
 YANK script
 
 Usage:
-  yank script (-y FILEPATH | --yaml=FILEPATH) [--platform=PLATFORM] [-o OVERRIDE]...
+  yank script (-y FILEPATH | --yaml=FILEPATH) [-o OVERRIDE]...
 
 Description:
   Set up and run free energy calculations from a YAML script. All options can be specified in the YAML script.
@@ -34,9 +34,6 @@ Required Arguments:
   -y, --yaml=FILEPATH           Path to the YAML script specifying options and/or how to set up and run the experiment.
 
 Optional Arguments:
-  --platform=PLATFORM           Choose a specific hardware platform to run on based on OpenMM types.
-                                Valid options are: Reference, CPU, OpenCL, CUDA, Fastest.
-                                Defaults to Fastest when not chosen.
 
   -o, --override=OVERRIDE       Override a single option in the script file. May be specified multiple times.
                                 Specified as a nested dictionary of the form:

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -901,7 +901,8 @@ class Boresch(OrientationDependentRestraint):
         heavy_ligand_atoms = set(ligand_atoms) & heavy_atoms
         heavy_receptor_atoms = set(receptor_atoms) & heavy_atoms
         if (len(heavy_receptor_atoms) < 3) or (len(heavy_ligand_atoms) < 3):
-            raise ValueError('There must be at least three heavy atoms in receptor_atoms (# heavy %d) and ligand_atoms (# heavy %d).' % (len(heavy_receptor_atoms), len(heavy_ligand_atoms)))
+            raise ValueError('There must be at least three heavy atoms in receptor_atoms (# heavy %d) and ligand_atoms '
+                             '(# heavy %d).' % (len(heavy_receptor_atoms), len(heavy_ligand_atoms)))
         # Find valid pairs of ligand/receptor atoms within a cutoff
         max_distance = 4 * unit.angstrom/unit.nanometer
         min_distance = 1 * unit.angstrom/unit.nanometer
@@ -924,6 +925,8 @@ class Boresch(OrientationDependentRestraint):
             restraint_atoms = random.sample(heavy_receptor_atoms-raA_set, 2) + raA_atoms + random.sample(heavy_ligand_atoms-raA_set, 2)
             # Reject collinear sets of atoms.
             accepted = not self._is_collinear(positions, restraint_atoms)
+        # Cast to Python ints to avoid type issues when passing to OpenMM
+        restraint_atoms = [int(i) for i in restraint_atoms]
 
         return restraint_atoms
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -160,4 +160,13 @@ To see which platforms your current installation supports, you can query the lis
 You can either leave the choice of platform up to YANK---in which case it will choose the fastest available platform---or specify
 the desired platform via the :ref:`platform argument <yaml_options_platform>` in a YAML file.
 
+You can also (*although not recommended*) override the platform selection through the ``yank script -o`` flag.
+For example, to force YANK to use the ``OpenCL`` platform:
+
+.. code-block:: bash
+
+   $ yank script --yaml=yank.yaml -o options:platform:OpenCL
+
+See the ``yank script`` command line docs for more information on the ``-o`` flag.
+
 .. note:: The ``CPU`` platform will automatically use all available cores/hyperthreads in serial mode, but in MPI mode, will use a single thread to avoid causing problems in queue-regulated parallel systems.  To control the number of threads yourself, set the ``OPENMM_NUM_THREADS`` environment variable to the desired number of threads.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -158,10 +158,6 @@ To see which platforms your current installation supports, you can query the lis
       3 OpenCL
 
 You can either leave the choice of platform up to YANK---in which case it will choose the fastest available platform---or specify
-the desired platform via the ``--platform`` argument to ``yank``.  For example, to force YANK to use the ``OpenCL`` platform:
-
-.. code-block:: bash
-
-   $ yank script --yaml=yank.yaml --platform=OpenCL
+the desired platform via the :ref:`platform argument <yaml_options_platform>` in a YAML file.
 
 .. note:: The ``CPU`` platform will automatically use all available cores/hyperthreads in serial mode, but in MPI mode, will use a single thread to avoid causing problems in queue-regulated parallel systems.  To control the number of threads yourself, set the ``OPENMM_NUM_THREADS`` environment variable to the desired number of threads.


### PR DESCRIPTION
* Fixed restraints sometimes choosing numpy int instead of Python ints causing OpenMM crash
* Removed old --platform argument from the `yank script` CLI
* Updated docs to reflect CLI changes