### PR TITLE
Change extension formalism, add docs about it

### DIFF
--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -554,7 +554,7 @@ class ReplicaExchange(object):
                           'timestep': 2.0 * unit.femtosecond,
                           'nsteps_per_iteration': 500,
                           'number_of_iterations': 1,
-                          'number_of_extension_iterations': 0,  # Do not save this option as its an on-the-fly setting
+                          'extension_simulation': False,  # Do not save this option as its an on-the-fly setting
                           'equilibration_timestep': 1.0 * unit.femtosecond,
                           'number_of_equilibration_iterations': 1,
                           'title': 'Replica-exchange simulation created using ReplicaExchange class of repex.py on %s' % time.asctime(time.localtime()),
@@ -770,8 +770,8 @@ class ReplicaExchange(object):
         r += "timestep: {:s}\n".format(self.timestep)
         r += "number of steps/iteration: {:d}\n".format(self.nsteps_per_iteration)
         r += "number of iterations: {:d}\n".format(self.number_of_iterations)
-        if self.number_of_extension_iterations > 0:
-            r += "extended by {:d}\n".format(self.number_of_extension_iterations)
+        if self.extension_simulation:
+            r += "Iterations extending existing data.\n"
         r += "equilibration timestep: {:s}\n".format(self.equilibration_timestep)
         r += "number of equilibration iterations: {:d}\n".format(self.number_of_equilibration_iterations)
         r += "\n"
@@ -860,10 +860,9 @@ class ReplicaExchange(object):
         # Main loop
         run_start_time = time.time()
         run_start_iteration = self.iteration
-        if self.number_of_extension_iterations > 0:
-            default_iteration_limit = self.iteration + self.number_of_extension_iterations
-        else:
-            default_iteration_limit = self.number_of_iterations
+        default_iteration_limit = self.number_of_iterations
+        if self.extension_simulation:
+            default_iteration_limit += self.iteration
         if niterations_to_run:
             iteration_limit = min(self.iteration + niterations_to_run, default_iteration_limit)
         else:
@@ -924,7 +923,7 @@ class ReplicaExchange(object):
         """
 
         if self._initialized:
-            raise Error("Simulation has already been initialized.")
+            raise Exception("Simulation has already been initialized.")
 
         # Extract a representative system.
         representative_system = self.states[0].system

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -670,7 +670,7 @@ class ReplicaExchange(object):
         # Check to make sure all states have the same number of atoms and are in the same thermodynamic ensemble.
         for state in self.states:
             if not state.is_compatible_with(self.states[0]):
-                raise ParameterError("Provided ThermodynamicState states must all be from the same thermodynamic ensemble.")
+                raise ValueError("Provided ThermodynamicState states must all be from the same thermodynamic ensemble.")
 
         # Distribute coordinate information to replicas in a round-robin fashion.
         # We have to explicitly check to see if z is a list or a set here because it turns out that np 2D arrays are iterable as well.
@@ -728,7 +728,7 @@ class ReplicaExchange(object):
         # Check to make sure all states have the same number of atoms and are in the same thermodynamic ensemble.
         for state in self.states:
             if not state.is_compatible_with(self.states[0]):
-                raise ParameterError("Provided ThermodynamicState states must all be from the same thermodynamic ensemble.")
+                raise ValueError("Provided ThermodynamicState states must all be from the same thermodynamic ensemble.")
 
         # Handle provided 'options' dict, replacing any options provided by caller in dictionary.
         # TODO: Check to make sure that only allowed overrides are specified.
@@ -993,7 +993,7 @@ class ReplicaExchange(object):
         """
 
         if self._initialized:
-            raise Error("Simulation has already been initialized.")
+            raise RuntimeError("Simulation has already been initialized.")
 
         # Extract a representative system.
         representative_system = self.states[0].system
@@ -2345,7 +2345,7 @@ class ReplicaExchange(object):
         natoms = self.ncfile.variables['energies'].shape[2]
 
         # Extract energies.
-        energies = ncfile.variables['energies']
+        energies = self.ncfile.variables['energies']
         u_kln_replica = np.zeros([nstates, nstates, niterations], np.float64)
         for n in range(niterations):
             u_kln_replica[:,:,n] = energies[n,:,:]
@@ -2353,7 +2353,7 @@ class ReplicaExchange(object):
         # Deconvolute replicas
         u_kln = np.zeros([nstates, nstates, niterations], np.float64)
         for iteration in range(niterations):
-            state_indices = ncfile.variables['states'][iteration,:]
+            state_indices = self.ncfile.variables['states'][iteration,:]
             u_kln[state_indices,:,iteration] = energies[iteration,:,:]
 
         # Compute total negative log probability over all iterations.

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -554,7 +554,7 @@ class ReplicaExchange(object):
                           'timestep': 2.0 * unit.femtosecond,
                           'nsteps_per_iteration': 500,
                           'number_of_iterations': 1,
-                          'extension_simulation': False,  # Do not save this option as its an on-the-fly setting
+                          'extend_simulation': False,  # Do not save this option as its an on-the-fly setting
                           'equilibration_timestep': 1.0 * unit.femtosecond,
                           'number_of_equilibration_iterations': 1,
                           'title': 'Replica-exchange simulation created using ReplicaExchange class of repex.py on %s' % time.asctime(time.localtime()),
@@ -770,7 +770,7 @@ class ReplicaExchange(object):
         r += "timestep: {:s}\n".format(self.timestep)
         r += "number of steps/iteration: {:d}\n".format(self.nsteps_per_iteration)
         r += "number of iterations: {:d}\n".format(self.number_of_iterations)
-        if self.extension_simulation:
+        if self.extend_simulation:
             r += "Iterations extending existing data.\n"
         r += "equilibration timestep: {:s}\n".format(self.equilibration_timestep)
         r += "number of equilibration iterations: {:d}\n".format(self.number_of_equilibration_iterations)
@@ -861,7 +861,7 @@ class ReplicaExchange(object):
         run_start_time = time.time()
         run_start_iteration = self.iteration
         default_iteration_limit = self.number_of_iterations
-        if self.extension_simulation:
+        if self.extend_simulation:
             default_iteration_limit += self.iteration
         if niterations_to_run:
             iteration_limit = min(self.iteration + niterations_to_run, default_iteration_limit)
@@ -923,7 +923,7 @@ class ReplicaExchange(object):
         """
 
         if self._initialized:
-            raise Exception("Simulation has already been initialized.")
+            raise RuntimeError("Simulation has already been initialized.")
 
         # Extract a representative system.
         representative_system = self.states[0].system

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -183,7 +183,8 @@ def test_replica_exchange(mpicomm=None, verbose=True, verbose_simulation=False):
     simulation.run()  # run the simulation
 
     # Run an extension simulation
-    simulation.number_of_extension_iterations = 1
+    simulation.extension_simulation = True
+    simulation.number_of_iterations = 1
     simulation.run()
     utils.config_root_logger(True)
 

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -183,7 +183,7 @@ def test_replica_exchange(mpicomm=None, verbose=True, verbose_simulation=False):
     simulation.run()  # run the simulation
 
     # Run an extension simulation
-    simulation.extension_simulation = True
+    simulation.extend_simulation = True
     simulation.number_of_iterations = 1
     simulation.run()
     utils.config_root_logger(True)

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -185,21 +185,21 @@ In order to extend simulations, set the following options in a YAML fie:
 .. code-block:: yaml
 
   number_of_iterations: <Integer>
-  extension_simulation: True
+  extend_simulation: True
 
 First you set :ref:`yaml_options_number_of_iterations` to an integer number of iterations you wish to extend the
 simulation. If no simulation has been run yet, then one will be run for the number of iterations.
-Setting :ref:`yaml_options_extension_simulation` to ``True`` modifies the behavior of
+Setting :ref:`yaml_options_extend_simulation` to ``True`` modifies the behavior of
 :ref:`yaml_options_number_of_iterations` to extend the simulation by the specified number, adding on to what is already
 on the file.
 
 One could optionally just increase :ref:`yaml_options_number_of_iterations`, but then you have to change
-the YAML file every time you want to extend the run. Setting :ref:`yaml_options_extension_simulation` allows you to run
+the YAML file every time you want to extend the run. Setting :ref:`yaml_options_extend_simulation` allows you to run
 the same YAML file without modification to do the same thing.
 
 
 You should also set the following two options as well as :ref:`yaml_options_number_of_iterations` and
-:ref:`yaml_options_extension_simulation`:
+:ref:`yaml_options_extend_simulation`:
 
 .. code-block:: yaml
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -210,3 +210,21 @@ You should also set the following two options as well as :ref:`yaml_options_numb
 YANK to resume simulations if it detects existing setup file or simulation output respectively. YANK will raise an error
 if these are not set and files exist to protect against overwrite. The only reason these are not mandatory is that if
 no files exist (i.e. fresh simulation), then the simulation will run without error once.
+
+
+Extending Previous Simulations from Command Line
+------------------------------------------------
+
+You may already have a simulation that you previously ran, but do not want to modify the YAML to extend the simulation.
+In this case, your YAML file has ``extend_simulation: False`` or is not set, and you only want to interact with the
+simulation through the command line. You can override individual settings from the command line; the settings for
+extending simulation would look like:
+
+.. code-block:: bash
+
+   $ yank script --yaml=yank.yaml -o options:extend_simulation:True -o options:number_of_iterations:X
+
+where ``X`` is the integer number you wish to extend the simulation by. The second option to override
+``number_of_iterations`` is optional if you are happy the existing option in the YAML file.
+
+See the ``yank script`` command line docs for more information on the ``-o`` flag.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -213,7 +213,7 @@ no files exist (i.e. fresh simulation), then the simulation will run without err
 
 
 Extending Previous Simulations from Command Line
-------------------------------------------------
+""""""""""""""""""""""""""""""""""""""""""""""""
 
 You may already have a simulation that you previously ran, but do not want to modify the YAML to extend the simulation.
 In this case, your YAML file has ``extend_simulation: False`` or is not set, and you only want to interact with the

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -170,3 +170,43 @@ For example, to force YANK to use the ``OpenCL`` platform:
 See the ``yank script`` command line docs for more information on the ``-o`` flag.
 
 .. note:: The ``CPU`` platform will automatically use all available cores/hyperthreads in serial mode, but in MPI mode, will use a single thread to avoid causing problems in queue-regulated parallel systems.  To control the number of threads yourself, set the ``OPENMM_NUM_THREADS`` environment variable to the desired number of threads.
+
+
+Extending Simulations
+=====================
+
+One common operation when running simulations is to collect additional samples from an already run simulation to get
+better statistics. Alternately, when running on shared resources, you may need to break up long simulations into smaller
+simulations run in series. YANK provides a way to run its simulations in this manner by extending its simulations.
+
+YANK's :doc:`YAML <yamlpages/yaml>` files have two main options that work together to extend simulations.
+In order to extend simulations, set the following options in a YAML fie:
+
+.. code-block:: yaml
+
+  number_of_iterations: <Integer>
+  extension_simulation: True
+
+First you set :ref:`yaml_options_number_of_iterations` to an integer number of iterations you wish to extend the
+simulation. If no simulation has been run yet, then one will be run for the number of iterations.
+Setting :ref:`yaml_options_extension_simulation` to ``True`` modifies the behavior of
+:ref:`yaml_options_number_of_iterations` to extend the simulation by the specified number, adding on to what is already
+on the file.
+
+One could optionally just increase :ref:`yaml_options_number_of_iterations`, but then you have to change
+the YAML file every time you want to extend the run. Setting :ref:`yaml_options_extension_simulation` allows you to run
+the same YAML file without modification to do the same thing.
+
+
+You should also set the following two options as well as :ref:`yaml_options_number_of_iterations` and
+:ref:`yaml_options_extension_simulation`:
+
+.. code-block:: yaml
+
+  resume_setup: yes
+  resume_simulation: yes
+
+:ref:`resume_setup <yaml_options_resume_setup>` and :ref:`resume_simulation <yaml_options_resume_simulation>` allow
+YANK to resume simulations if it detects existing setup file or simulation output respectively. YANK will raise an error
+if these are not set and files exist to protect against overwrite. The only reason these are not mandatory is that if
+no files exist (i.e. fresh simulation), then the simulation will run without error once.

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -394,14 +394,14 @@ set, this option can be used to extend previous simulations past their original 
 Valid Options (1): <Integer>
 
 
-.. _yaml_options_extension_simulation:
+.. _yaml_options_extend_simulation:
 
-extension_simulation
+extend_simulation
 --------------------
 .. code-block:: yaml
 
     options:
-      extension_simulation: False
+      extend_simulation: False
 
 Special modification of :ref:`yaml_options_number_of_iterations` which allows **extending** a simulation by
 :ref:`yaml_options_number_of_iterations` instead of running for a maximum. If set to ``True``,
@@ -414,10 +414,13 @@ This is helpful for running consecutive batches of simulations for time lengths 
 :ref:`resume_simulation <yaml_options_resume_simulation>` to allow resuming simulations.
 
 *Example*: You have a simulation that ran for 500 iterations, you wish to add an additional 1000 iterations. You would
-set ``number_of_iterations: 1000`` and ``extension_simulation: True`` in your YAML file and rerun. The simulation would
+set ``number_of_iterations: 1000`` and ``extend_simulation: True`` in your YAML file and rerun. The simulation would
 then resume at iteration 500, then continue to iteration 1500. The same behavior would be achieved if you set
-``number_of_iterations: 1500``, but the ``extension_simulation`` has the advantage that it can be run multiple times to
+``number_of_iterations: 1500``, but the ``extend_simulation`` has the advantage that it can be run multiple times to
 keep extending the simulation without modifying the YAML file.
+
+**WARNING**: Extending simulations affects ALL simulations for :doc:`Combinatorial <combinatorial>`. You cannot extend
+a subset of simulations from a combinatorial setup; all simulations will be extended if this option is set.
 
 **OPTIONAL** and **MODIFIES** :ref:`yaml_options_number_of_iterations`
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -394,28 +394,34 @@ set, this option can be used to extend previous simulations past their original 
 Valid Options (1): <Integer>
 
 
-.. _yaml_options_number_of_extension_iterations:
+.. _yaml_options_extension_simulation:
 
-number_of_extension_iterations
-------------------------------
+extension_simulation
+--------------------
 .. code-block:: yaml
 
     options:
-      number_of_extension_iterations: 0
+      extension_simulation: False
 
-Special override of :ref:`yaml_options_number_of_iterations` which allows extending a simulation by an arbitrary number
-of iterations. The simulation will run the additional specified number of iterations, even if a simulation already has
-run for a length of time. For fresh simulations, the resulting simulation is identical to specifying
-:ref:`yaml_options_number_of_iterations` of the same length.
+Special modification of :ref:`yaml_options_number_of_iterations` which allows **extending** a simulation by
+:ref:`yaml_options_number_of_iterations` instead of running for a maximum. If set to ``True``,
+the simulation will run the additional specified number of iterations, even if a simulation already has
+run for a length of time. For fresh simulations, the resulting simulation is identical to not setting this flag.
 
 This is helpful for running consecutive batches of simulations for time lengths that are unknown.
 
 *Recommended*: Also set :ref:`resume_setup <yaml_options_resume_setup>` and
 :ref:`resume_simulation <yaml_options_resume_simulation>` to allow resuming simulations.
 
-**OPTIONAL** and **SUPERSEDES** :ref:`yaml_options_number_of_iterations`
+*Example*: You have a simulation that ran for 500 iterations, you wish to add an additional 1000 iterations. You would
+set ``number_of_iterations: 1000`` and ``extension_simulation: True`` in your YAML file and rerun. The simulation would
+then resume at iteration 500, then continue to iteration 1500. The same behavior would be achieved if you set
+``number_of_iterations: 1500``, but the ``extension_simulation`` has the advantage that it can be run multiple times to
+keep extending the simulation without modifying the YAML file.
 
-Valid Options (0): <Integer>
+**OPTIONAL** and **MODIFIES** :ref:`yaml_options_number_of_iterations`
+
+Valid Options: True/[False]
 
 
 .. _yaml_options_nsteps_per_iteration:

--- a/docs/yamlpages/systems.rst
+++ b/docs/yamlpages/systems.rst
@@ -101,8 +101,8 @@ MDTraj is required to use this options since picking the ligand out of the files
 * ``phase2_path``: The set of files which fully describe the second phase of the free energy simulation you want to run.
 * ``ligand_dsl``: An MDTraj DSL string which identifies the ligand in the files provided by ``phase1_path`` and ``phase2_path``.
 * ``solvent_dsl``: An optional MDTraj DSL string which identifies the solvent atoms in the files provided by ``phase1_path``
-and ``phase2_path``. If not specified, a list of common solvent residue names will be used to automatically detect
-solvent atoms.
+  and ``phase2_path``. If not specified, a list of common solvent residue names will be used to automatically detect
+  solvent atoms.
 * ``solvent``: A ``{UserDefinedSolvent}`` to put the two phases in. Only one solvent is allowed for this calculation.
   This option must be omitted if using XML/PDB files, since the solvent options are inherently specified in the XML
   definition of the system. Finally, if the two phases require two different solvents, it is possible to substitute the

--- a/docs/yamlpages/yaml.rst
+++ b/docs/yamlpages/yaml.rst
@@ -62,7 +62,7 @@ Detailed Options List
     * :ref:`number_of_equilibration_iterations <yaml_options_number_of_equilibration_iterations>`
     * :ref:`equilibration_timestep <yaml_options_equilibration_timestep>`
     * :ref:`number_of_iterations <yaml_options_number_of_iterations>`
-    * :ref:`number_of_extension_iterations <yaml_options_number_of_extension_iterations>`
+    * :ref:`extension_simulation <yaml_options_extension_simulation>`
     * :ref:`nsteps_per_iteration <yaml_options_nsteps_per_iteration>`
     * :ref:`timestep <yaml_options_timestep>`
     * :ref:`replica_mixing_scheme <yaml_options_replica_mixing_scheme>`

--- a/docs/yamlpages/yaml.rst
+++ b/docs/yamlpages/yaml.rst
@@ -62,7 +62,7 @@ Detailed Options List
     * :ref:`number_of_equilibration_iterations <yaml_options_number_of_equilibration_iterations>`
     * :ref:`equilibration_timestep <yaml_options_equilibration_timestep>`
     * :ref:`number_of_iterations <yaml_options_number_of_iterations>`
-    * :ref:`extension_simulation <yaml_options_extension_simulation>`
+    * :ref:`extend_simulation <yaml_options_extend_simulation>`
     * :ref:`nsteps_per_iteration <yaml_options_nsteps_per_iteration>`
     * :ref:`timestep <yaml_options_timestep>`
     * :ref:`replica_mixing_scheme <yaml_options_replica_mixing_scheme>`


### PR DESCRIPTION
Changed how extending a simulation works by reducing syntax length and removing ambiguity with `number_of_iterations` in the YAML file. Added documentation on the `running.rst` page to help users access this feature.