### PR TITLE
Add `anisotrpic_dispersion_correction` and its cutoff to YAML options.

### DIFF
--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 # CONSTANTS
 # =============================================================================
 
-HIGHEST_VERSION = '1.1'  # highest version of YAML syntax
+HIGHEST_VERSION = '1.2'  # highest version of YAML syntax
 
 
 # =============================================================================================

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -43,7 +43,7 @@ All simulations are run using the same OpenMM ``Platform`` choice (``CUDA``, ``O
 
 .. todo::
    - ``$CUDA_VISIBLE_DEVICES``
-   - MPI ``configfile``s
+   - MPI ``configfile``
    - SLURM
 
 No GPU management is needed on single GPU/node systems.

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -70,6 +70,8 @@ Detailed Options List
     * :ref:`collision_rate <yaml_options_collision_rate>`
     * :ref:`constraint_tolerance <yaml_options_constraint_tolerance>`
     * :ref:`mc_displacement_sigma <yaml_options_mc_displacement_sigma>`
+    * :ref:`yaml_options_anisotropic_dispersion_correction`
+    * :ref:`yaml_options_anisotropic_dispersion_cutoff`
 
   * :ref:`Alchemy Parameters <yaml_options_alchemy_parameters>`
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -241,10 +241,51 @@ Constrain bond lengths and angles. See OpenMM ``createSystem()`` documentation f
 
 Valid options: [Hbonds]/AllBonds/HAngles
 
+
+.. _yaml_options_anisotropic_dispersion_correction:
+
+anisotropic_dispersion_correction
+---------------------------------
+.. code-block:: yaml
+
+   options:
+     anisotropic_dispersion_correction: yes
+
+Tell YANK to compute anisotropic dispersion corrections for long-range interactions. YANK accounts for these effects
+by creating two additional thermodynamic states at either end of the :ref:`thermodynamic cycle <yank_cycle>` with
+larger long-range cutoffs to remove errors introduced from treating long-range interactions as a homogenous, equal
+density medium. We estimate the free energy relative to these expanded cutoff states. No simulation is actually carried
+out at these states but energies from simulations are evaluated at them.
+
+This option only applies if you have specified a
+:ref:`system with periodic boundary conditions <yaml_solvents_nonbonded_method>`. You set the size of these expanded
+cutoffs through the :ref:`yaml_options_anisotropic_dispersion_cutoff` option.
+
+We put this option in the general options category instead of the :doc:`solvents <solvents>` section since these
+additional states are unique to YANK's setup.
+
+Valid options: [yes]/no
+
+
+.. _yaml_options_anisotropic_dispersion_cutoff:
+
+anisotropic_dispersion_cutoff
+-----------------------------
+.. code-block:: yaml
+
+   options:
+     anisotropic_dispersion_cutoff: 16.0 * angstrom
+
+Specify the expanded cutoff distance for YANK's :ref:`yaml_options_anisotropic_dispersion_correction` setting.
+Please see the main :ref:`yaml_options_anisotropic_dispersion_correction` option for details/
+
+Valid options (16 * angstrom): <Quantity Length> [1]_
+
+.. note:: This will be combined with :ref:`yaml_options_anisotropic_dispersion_correction` in our version 2.0 of our YAML code.
+
 |
 
 .. _yaml_options_simulation_parameters:
-
 
 Simulation Parameters
 =====================

--- a/docs/yamlpages/version.rst
+++ b/docs/yamlpages/version.rst
@@ -9,6 +9,6 @@ The header provides a means to ensure that your YAML file will be supported by t
 
 .. code-block:: yaml
 
-    version: 1.1
+    version: 1.2
 
-Valid Options: [1.0, 1.1]
+Valid Options: [1.0, 1.1, 1.2]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.15.1"  # Primary base version of the build
+VERSION = "0.15.2"  # Primary base version of the build
 DEVBUILD = "0"      # Dev build status, Either None or Integer as string
 ISRELEASED = False  # Are we releasing this as a full cut?
 __version__ = VERSION


### PR DESCRIPTION
 * Documented the `anisotrpic_dispersion_correction`
 * Added option for `anisotrpic_dispersion_cutoff`
 * Added test for AD_correction
 * Bumped YAML version
 * Bumped YANK minor version

Fixes #641, Fixes #483