### PR TITLE
Fix select mol2 in YamlBuilder

### DIFF
--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -860,7 +860,7 @@ def test_strip_protons():
 # Combinatorial expansion
 # ==============================================================================
 
-class TestMultiMoleculeFiles():
+class TestMultiMoleculeFiles(object):
 
     @classmethod
     def setup_class(cls):
@@ -1198,6 +1198,11 @@ class TestMultiMoleculeFiles():
                                                    mol_id, mol_id + '.' + extension)
                     assert os.path.exists(os.path.join(single_mol_path))
                     assert os.path.getsize(os.path.join(single_mol_path)) > 0
+                    if extension == 'mol2':
+                        # OpenEye loses the resname when writing a mol2 file.
+                        mol2_file = utils.Mol2File(single_mol_path)
+                        assert len(mol2_file.resnames) == 1
+                        assert mol2_file.resname != '<0>'
 
                     # sdf files must be converted to mol2 to be fed to antechamber
                     if extension == 'sdf':

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1329,14 +1329,28 @@ class Mol2File(object):
 
     @property
     def resname(self):
+        """The name of the first molecule found in the mol2 file."""
         residue = parmed.load_file(self._file_path)
+        if isinstance(residue, parmed.modeller.residue.ResidueTemplateContainer):
+            return residue[0].name
         return residue.name
 
     @resname.setter
     def resname(self, value):
         residue = parmed.load_file(self._file_path)
-        residue.name = value
+        if isinstance(residue, parmed.modeller.residue.ResidueTemplateContainer):
+            residue[0].name = value
+        else:
+            residue.name = value
         parmed.formats.Mol2File.write(residue, self._file_path)
+
+    @property
+    def resnames(self):
+        """The list of the names of all the molecules in the file (read-only)."""
+        residues = parmed.load_file(self._file_path)
+        if isinstance(residues, parmed.modeller.residue.ResidueTemplateContainer):
+            return [residue.name for residue in residues]
+        return [residues.name]
 
     @property
     def net_charge(self):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.15.3"  # Primary base version of the build
+VERSION = "0.15.4"  # Primary base version of the build
 DEVBUILD = "0"      # Dev build status, Either None or Integer as string
 ISRELEASED = False  # Are we releasing this as a full cut?
 __version__ = VERSION


### PR DESCRIPTION
This fixes a bug where selecting a `mol2` files caused mdtraj to crash during DSL atom selection. Should be ready to be reviewed if tests pass.