### PR TITLE
New restraints API

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -387,8 +387,8 @@ class ReceptorLigandRestraint(ABC):
         left undefined in the constructor.
 
         """
-        raise NotImplemented('{} does not support automatic determination of '
-                             'the restraint parameters'.format(self.__class__.__name__))
+        raise NotImplementedError('{} does not support automatic determination of the '
+                                  'restraint parameters'.format(self.__class__.__name__))
 
 
 # ==============================================================================
@@ -618,8 +618,8 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         """
         # Raise exception only if the subclass doesn't already defines parameters.
         if self._bond_parameters is None:
-            raise NotImplemented('Restraint {} cannot automatically determine '
-                                 'bond parameters.'.format(self.__class__.__name__))
+            raise NotImplementedError('Restraint {} cannot automatically determine '
+                                      'bond parameters.'.format(self.__class__.__name__))
 
     # -------------------------------------------------------------------------
     # Internal-usage

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -316,6 +316,12 @@ class RestraintState(object):
         if found_restraint is False:
             raise RestraintStateError('The system does not have a restraint.')
 
+    def __getstate__(self):
+        return dict(lambda_restraints=self.lambda_restraints)
+
+    def __setstate__(self, serialization):
+        self.lambda_restraints = serialization['lambda_restraints']
+
 
 # ==============================================================================
 # Base class for receptor-ligand restraints.

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -6,8 +6,9 @@
 
 """
 
-Automated selection and imposition of receptor-ligand restraints for absolute alchemical binding
-free energy calculations, along with computation of the standard state correction.
+Automated selection and imposition of receptor-ligand restraints for absolute
+alchemical binding free energy calculations, along with computation of the
+standard state correction.
 
 """
 
@@ -16,7 +17,6 @@ free energy calculations, along with computation of the standard state correctio
 # ==============================================================================
 
 import abc
-import copy
 import math
 import random
 import inspect
@@ -101,38 +101,28 @@ def available_restraint_types():
     return available_restraints.keys()
 
 
-def create_restraints(restraint_type, topology, state, system, positions, receptor_atoms, ligand_atoms):
-    """
-    Initialize a receptor-ligand restraint class matching the specified restraint type name.
+def create_restraint(restraint_type, **kwargs):
+    """Factory of receptor-ligand restraint objects.
 
     Parameters
     ----------
     restraint_type : str
         Restraint type name matching a register (imported) subclass of ReceptorLigandRestraint.
-    topology : openmm.app.Topology
-        Reference topology for the complex
-    system : openmm.System
-        System containing all the forces and atoms that restraint will be added to
-    state : thermodynamics.ThermodynamicState
-        The thermodynamic state specifying temperature, pressure, etc. to which restraints are to be added
-    positions : simtk.unit.Quantity of natoms x 3 with units compatible with nanometers
-        Reference positions to use for imposing restraints
-    receptor_atoms : list of int
-        A complete list of receptor atoms
-    ligand_atoms : list of int
-        A complete list of ligand atoms
+    **kwargs
+        Parameters to pass to the restraint constructor.
 
     """
     available_restraints = available_restraint_classes()
-    if not (restraint_type in available_restraints):
-        raise ValueError("Restraint type '%s' unknown. Options are: %s" % (restraint_type, str(available_restraints.keys())))
+    if restraint_type not in available_restraints:
+        raise ValueError("Restraint type {} unknown. Options are: {}".format(
+            restraint_type, str(available_restraints.keys())))
     cls = available_restraints[restraint_type]
-    return cls(topology, state, system, positions, receptor_atoms, ligand_atoms)
+    return cls(**kwargs)
 
 
-# =============================================================================================
+# ==============================================================================
 # Base class for receptor-ligand restraints.
-# =============================================================================================
+# ==============================================================================
 
 ABC = abc.ABCMeta('ABC', (object,), {})  # compatible with Python 2 *and* 3
 
@@ -198,9 +188,9 @@ class ReceptorLigandRestraint(ABC):
                              'the restraint parameters'.format(self.__class__.__name__))
 
 
-# =============================================================================================
+# ==============================================================================
 # Base class for radially-symmetric receptor-ligand restraints.
-# =============================================================================================
+# ==============================================================================
 
 class RadiallySymmetricRestraint(ReceptorLigandRestraint):
     """Base class for radially-symmetric restraints between ligand and protein.
@@ -596,9 +586,9 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         return radius_of_gyration
 
 
-# =============================================================================================
+# ==============================================================================
 # Harmonic protein-ligand restraint.
-# =============================================================================================
+# ==============================================================================
 
 class Harmonic(RadiallySymmetricRestraint):
     """Impose a single harmonic restraint between ligand and protein.
@@ -729,9 +719,9 @@ class Harmonic(RadiallySymmetricRestraint):
         self.spring_constant = thermodynamic_state.kT / sigma**2
 
 
-# =============================================================================================
+# ==============================================================================
 # Flat-bottom protein-ligand restraint.
-# =============================================================================================
+# ==============================================================================
 
 class FlatBottom(RadiallySymmetricRestraint):
     """A receptor-ligand restraint using a flat potential well with harmonic walls.

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1081,9 +1081,11 @@ class FlatBottom(RadiallySymmetricRestraint):
         K = 0.6 * unit.kilocalories_per_mole / unit.angstroms**2
         logger.debug("K = %.1f kcal/mol/A^2" % (K / (unit.kilocalories_per_mole / unit.angstroms**2)))
 
-        # Store parameters.
-        self.spring_constant = K
-        self.well_radius = r0
+        # Store parameters if not already defined.
+        if self.spring_constant is None:
+            self.spring_constant = K
+        if self.well_radius is None:
+            self.well_radius = r0
 
 
 # ==============================================================================
@@ -1633,7 +1635,7 @@ class Boresch(ReceptorLigandRestraint):
                 setattr(self, attr_name, attr_value)
 
         # Set spring constants uniformly, as in Ref [1] Table 1 caption.
-        self.K_r = 20.0 * unit.kilocalories_per_mole / unit.angstrom**2
+        _assign_if_undefined('K_r', 20.0 * unit.kilocalories_per_mole / unit.angstrom**2)
         for parameter_name in ['K_thetaA', 'K_thetaB', 'K_phiA', 'K_phiB', 'K_phiC']:
             _assign_if_undefined(parameter_name, 20.0 * unit.kilocalories_per_mole / unit.radian**2)
 

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -17,13 +17,12 @@ This code is licensed under the latest available version of the MIT License.
 
 """
 
-#=============================================================================================
+# ==============================================================================
 # GLOBAL IMPORTS
-#=============================================================================================
+# ==============================================================================
 
 
 from openmmtools import testsystems
-import mdtraj
 from mdtraj.utils import enter_temp_directory
 
 from nose import tools
@@ -35,16 +34,40 @@ from yank.pipeline import find_components
 
 from yank.yank import *
 
-#=============================================================================================
+# ==============================================================================
 # MODULE CONSTANTS
-#=============================================================================================
+# ==============================================================================
 
 from simtk import unit
 kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA # Boltzmann constant
 
-#=============================================================================================
+
+# ==============================================================================
+# TEST TOPOLOGY OBJECT
+# ==============================================================================
+
+def test_topography():
+    """Test that topology components are isolated correctly by Topography."""
+    toluene_vacuum = testsystems.TolueneVacuum()
+    topography = Topography(toluene_vacuum.topology)
+    assert len(topography.ligand_atoms) == 0
+    assert len(topography.receptor_atoms) == 0
+    assert topography.solute_atoms == set(range(toluene_vacuum.system.getNumParticles()))
+    assert len(topography.solvent_atoms) == 0
+    assert len(topography.ions_atoms) == 0
+
+    host_guest_explicit = testsystems.HostGuestExplicit()
+    topography = Topography(host_guest_explicit.topology, ligand_atoms='resname B2')
+    assert topography.ligand_atoms == set(range(126, 156))
+    assert topography.receptor_atoms == set(range(126))
+    assert topography.solute_atoms == set(range(156))
+    assert topography.solvent_atoms == set(range(156, host_guest_explicit.system.getNumParticles()))
+    assert len(topography.ions_atoms) == 0
+
+
+# ==============================================================================
 # MAIN AND TESTS
-#=============================================================================================
+# ==============================================================================
 
 def test_parameters():
     """Test Yank parameters initialization."""

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -52,16 +52,16 @@ def test_topography():
     topography = Topography(toluene_vacuum.topology)
     assert len(topography.ligand_atoms) == 0
     assert len(topography.receptor_atoms) == 0
-    assert topography.solute_atoms == set(range(toluene_vacuum.system.getNumParticles()))
+    assert topography.solute_atoms == list(range(toluene_vacuum.system.getNumParticles()))
     assert len(topography.solvent_atoms) == 0
     assert len(topography.ions_atoms) == 0
 
     host_guest_explicit = testsystems.HostGuestExplicit()
     topography = Topography(host_guest_explicit.topology, ligand_atoms='resname B2')
-    assert topography.ligand_atoms == set(range(126, 156))
-    assert topography.receptor_atoms == set(range(126))
-    assert topography.solute_atoms == set(range(156))
-    assert topography.solvent_atoms == set(range(156, host_guest_explicit.system.getNumParticles()))
+    assert topography.ligand_atoms == list(range(126, 156))
+    assert topography.receptor_atoms == list(range(126))
+    assert topography.solute_atoms == list(range(156))
+    assert topography.solvent_atoms == list(range(156, host_guest_explicit.system.getNumParticles()))
     assert len(topography.ions_atoms) == 0
 
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -29,7 +29,7 @@ import simtk.openmm as openmm
 
 from alchemy import AbsoluteAlchemicalFactory
 from .sampling import ModifiedHamiltonianExchange
-from .restraints import create_restraints, V0
+from .restraints import create_restraint, V0
 
 from . import utils
 
@@ -88,6 +88,11 @@ class Topography(object):
         # Determine ligand and solvent atoms. Every other label is implied.
         self.ligand_atoms = ligand_atoms
         self.solvent_atoms = solvent_atoms
+
+    @property
+    def topology(self):
+        """mdtraj.Topology: A copy of the topology (read-only)."""
+        return copy.deepcopy(self._topology)
 
     @property
     def ligand_atoms(self):
@@ -587,9 +592,9 @@ class Yank(object):
         if is_complex and restraint_type is not None:
             logger.debug("Creating receptor-ligand restraints...")
             reference_positions = positions[0]
-            restraints = create_restraints(restraint_type, alchemical_phase.reference_topology,
-                                           thermodynamic_state, reference_system, reference_positions,
-                                           atom_indices['receptor'], atom_indices['ligand'])
+            restraints = create_restraint(restraint_type, alchemical_phase.reference_topology,
+                                          thermodynamic_state, reference_system, reference_positions,
+                                          atom_indices['receptor'], atom_indices['ligand'])
             force = restraints.get_restraint_force()  # Get Force object incorporating restraints.
             reference_system.addForce(force)
             metadata['standard_state_correction'] = restraints.get_standard_state_correction()  # in kT

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -1,8 +1,8 @@
 #!/usr/local/bin/env python
 
-# =============================================================================================
+# ==============================================================================
 # MODULE DOCSTRING
-# =============================================================================================
+# ==============================================================================
 
 """
 Yank
@@ -12,9 +12,9 @@ Interface for automated free energy calculations.
 
 """
 
-# =============================================================================================
+# ==============================================================================
 # GLOBAL IMPORTS
-# =============================================================================================
+# ==============================================================================
 
 import os
 import os.path
@@ -23,6 +23,7 @@ import inspect
 import logging
 import numpy as np
 
+import mdtraj
 import simtk.unit as unit
 import simtk.openmm as openmm
 
@@ -33,6 +34,148 @@ from .restraints import create_restraints, V0
 from . import utils
 
 logger = logging.getLogger(__name__)
+
+
+# ==============================================================================
+# TOPOGRAPHY
+# ==============================================================================
+
+class Topography(object):
+    """A class mapping and labelling the different components of a system.
+
+    The object holds the topology of a system and offers convenience functions
+    to identify its various parts such as solvent, receptor, ions and ligand
+    atoms.
+
+    A molecule should be labeled as a ligand, only if there is also a receptor.
+    If there is only a single molecule its atom indices can be obtained from
+    solute_atoms instead. In ligand-receptor system, solute_atoms provides the
+    atom indices for both molecules.
+
+    Parameters
+    ----------
+    topology : mdtraj.Topology or simtk.openmm.app.Topology
+        The topology object specifying the system.
+    ligand_atoms : iterable of int or str, optional
+        The atom indices of the ligand. A string is interpreted as an mdtraj
+        DSL specification of the ligand atoms.
+    solvent_atoms : iterable of int or str, optional
+        The atom indices of the solvent. A string is interpreted as an mdtraj
+        DSL specification of the solvent atoms. If 'auto', a list of common
+        solvent residue names will be used to automatically detect solvent
+        atoms (default is 'auto').
+
+    Attributes
+    ----------
+    ligand_atoms
+    receptor_atoms
+    solute_atoms
+    solvent_atoms
+    ions_atoms
+
+    """
+    def __init__(self, topology, ligand_atoms=frozenset(), solvent_atoms='auto'):
+        # Determine if we need to convert the topology to mdtraj.
+        if isinstance(topology, mdtraj.Topology):
+            self._topology = topology
+        else:
+            self._topology = mdtraj.Topology.from_openmm(topology)
+
+        # Determine ligand and solvent atoms. Every other label is implied.
+        self.ligand_atoms = ligand_atoms
+        self.solvent_atoms = solvent_atoms
+
+    @property
+    def ligand_atoms(self):
+        """The atom indices of the ligand.
+
+        This can be empty if this Topography doesn't represent a receptor-ligand
+        system. Use solute_atoms to obtain the atom indices of the molecule if
+        this is the case.
+
+        If assigned to a string, it will be interpreted as an mdtraj DSL specification
+        of the atom indices.
+
+        """
+        return self._ligand_atoms
+
+    @ligand_atoms.setter
+    def ligand_atoms(self, value):
+        self._ligand_atoms = self._resolve_atom_indices(value)
+
+    @property
+    def receptor_atoms(self):
+        """The atom indices of the receptor (read-only).
+
+        This can be empty if this Topography doesn't represent a receptor-ligand
+        system. Use solute_atoms to obtain the atom indices of the molecule if
+        this is the case.
+
+        """
+        # If there's no ligand, there's no receptor.
+        if len(self._ligand_atoms) == 0:
+            return frozenset()
+
+        # Receptor atoms are all solute atoms that are not ligand.
+        return frozenset([i for i in self.solute_atoms
+                          if i not in self._ligand_atoms])
+
+    @property
+    def solute_atoms(self):
+        """The atom indices of the non-solvent molecule(s) (read-only).
+
+        Practically, this are all the indices of the atoms that are not considered
+        solvent. In a receptor-ligand system, this includes the atom indices of
+        both the receptor and the ligand.
+
+        """
+        # The solute is everything that is not solvent.
+        return frozenset([i for i in range(self._topology.n_atoms)
+                          if i not in self._solvent_atoms])
+
+    @property
+    def solvent_atoms(self):
+        """The atom indices of the solvent molecules.
+
+        This includes eventual ions. If assigned to a string, it will be
+        interpreted as an mdtraj DSL specification of the atom indices. If
+        assigned to 'auto', a set of solvent auto indices is automatically
+        built from common solvent residue names.
+
+        """
+        return self._solvent_atoms
+
+    @solvent_atoms.setter
+    def solvent_atoms(self, value):
+        # If the user doesn't provide a solvent description,
+        # we use a default set of resnames in mdtraj.
+        if value == 'auto':
+            solvent_resnames = mdtraj.core.residue_names._SOLVENT_TYPES
+            self._solvent_atoms = frozenset([atom.index for atom in self._topology.atoms
+                                             if atom.residue.name in solvent_resnames])
+        else:
+            self._solvent_atoms = self._resolve_atom_indices(value)
+
+    @property
+    def ions_atoms(self):
+        """The indices of all ions atoms in the solvent (read-only)."""
+        # Ions are all atoms of the solvent whose residue name show a charge.
+        return frozenset([i for i in self._solvent_atoms
+                          if '-' in self._topology.atom(i).residue.name or
+                          '+' in self._topology.atom(i).residue.name])
+
+    # -------------------------------------------------------------------------
+    # Internal-usage
+    # -------------------------------------------------------------------------
+
+    def _resolve_atom_indices(self, atoms_description):
+        if isinstance(atoms_description, str):
+            # Assume this is DSL selection. select() returns a numpy array
+            # of int64 that we convert to python integers.
+            atoms_description = self._topology.select(atoms_description).tolist()
+        # Convert to a frozen set of indices.
+        return frozenset(atoms_description)
+
 
 # ==============================================================================
 # Class that define a single thermodynamic leg (phase) of the calculation

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - scipy
     - setuptools
     - netcdf4
-    - openmm >=7.0.1
+    - openmm >=7.1
     - mdtraj >=1.7.2
     - openmmtools
     - pymbar
@@ -37,7 +37,7 @@ requirements:
     - scipy
     - cython
     - netcdf4
-    - openmm >=7.0.1
+    - openmm >=7.1
     - mdtraj >=1.7.2
     - openmmtools
     - pymbar


### PR DESCRIPTION
Ready for review. Tests are not expected to pass yet so I'll temporarily merge to `development`.

- The API allow us to specify manually the parameters of the restraints ([here is an example](https://github.com/choderalab/yank/blob/new-restraints/Yank/restraints.py#L1175-L1206).
- I've split the automatic determination of parameters into its own function, because I thought that users implementing their own `Restraint`s may not want to support that functionality.
- I've also implemented a new composable `RestraintState` class to control the `lambda_restraints` parameter, which I've removed from `AlchemicalState` in choderalab/openmmtools#145 ([here is an example](https://github.com/choderalab/yank/blob/new-restraints/Yank/restraints.py#L152-L192)).