### PR TITLE
New application layer

### DIFF
--- a/Yank/__init__.py
+++ b/Yank/__init__.py
@@ -6,15 +6,14 @@ YANK
 """
 
 # Define global version.
-from . import version #Needed for yank 3.X.
+from . import version  # Needed for yank 3.X.
 __version__ = version.version
 
 # Self module imports
 from . import utils
 from . import repex
-from . import sampling
 from . import restraints
 from . import pipeline
 from . import yamlbuild
 from . import analyze
-from .yank import Yank
+from .yank import Topography, AlchemicalPhase

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -18,13 +18,11 @@ import inspect
 import logging
 import itertools
 
-import mdtraj
 import numpy as np
 import openmmtools as mmtools
 from simtk import openmm, unit
 
 from . import utils
-from .yank import AlchemicalPhase
 
 logger = logging.getLogger(__name__)
 
@@ -194,117 +192,72 @@ def compute_net_charge(system, atom_indices):
     return net_charge
 
 
-# Common solvent and ions.
-_SOLVENT_RESNAMES = frozenset(['118', '119', '1AL', '1CU', '2FK', '2HP', '2OF', '3CO', '3MT',
-        '3NI', '3OF', '4MO', '543', '6MO', 'ACT', 'AG', 'AL', 'ALF', 'ATH',
-        'AU', 'AU3', 'AUC', 'AZI', 'Ag', 'BA', 'BAR', 'BCT', 'BEF', 'BF4',
-        'BO4', 'BR', 'BS3', 'BSY', 'Be', 'CA', 'CA+2', 'Ca+2', 'CAC', 'CAD',
-        'CAL', 'CD', 'CD1', 'CD3', 'CD5', 'CE', 'CES', 'CHT', 'CL', 'CL-',
-        'CLA', 'Cl-', 'CO', 'CO3', 'CO5', 'CON', 'CR', 'CS', 'CSB', 'CU',
-        'CU1', 'CU3', 'CUA', 'CUZ', 'CYN', 'Cl-', 'Cr', 'DME', 'DMI', 'DSC',
-        'DTI', 'DY', 'E4N', 'EDR', 'EMC', 'ER3', 'EU', 'EU3', 'F', 'FE', 'FE2',
-        'FPO', 'GA', 'GD3', 'GEP', 'HAI', 'HG', 'HGC', 'HOH', 'IN', 'IOD',
-        'ION', 'IR', 'IR3', 'IRI', 'IUM', 'K', 'K+', 'KO4', 'LA', 'LCO', 'LCP',
-        'LI', 'LIT', 'LU', 'MAC', 'MG', 'MH2', 'MH3', 'MLI', 'MMC', 'MN',
-        'MN3', 'MN5', 'MN6', 'MO1', 'MO2', 'MO3', 'MO4', 'MO5', 'MO6', 'MOO',
-        'MOS', 'MOW', 'MW1', 'MW2', 'MW3', 'NA', 'NA+2', 'NA2', 'NA5', 'NA6',
-        'NAO', 'NAW', 'Na+2', 'NET', 'NH4', 'NI', 'NI1', 'NI2', 'NI3', 'NO2',
-        'NO3', 'NRU', 'Na+', 'O4M', 'OAA', 'OC1', 'OC2', 'OC3', 'OC4', 'OC5',
-        'OC6', 'OC7', 'OC8', 'OCL', 'OCM', 'OCN', 'OCO', 'OF1', 'OF2', 'OF3',
-        'OH', 'OS', 'OS4', 'OXL', 'PB', 'PBM', 'PD', 'PER', 'PI', 'PO3', 'PO4',
-        'POT', 'PR', 'PT', 'PT4', 'PTN', 'RB', 'RH3', 'RHD', 'RU', 'RUB', 'Ra',
-        'SB', 'SCN', 'SE4', 'SEK', 'SM', 'SMO', 'SO3', 'SO4', 'SOD', 'SR',
-        'Sm', 'Sn', 'T1A', 'TB', 'TBA', 'TCN', 'TEA', 'THE', 'TL', 'TMA',
-        'TRA', 'UNX', 'V', 'V2+', 'VN3', 'VO4', 'W', 'WO5', 'Y1', 'YB', 'YB2',
-        'YH', 'YT3', 'ZN', 'ZN2', 'ZN3', 'ZNA', 'ZNO', 'ZO3'])
+def find_alchemical_counterions(system, topography, region_name):
+    """Return the atom indices of the ligand or solute counterions.
 
-_NONPERIODIC_NONBONDED_METHODS = [openmm.app.NoCutoff, openmm.app.CutoffNonPeriodic]
-
-
-def find_components(system, topology, ligand_dsl, solvent_dsl=None):
-    """Determine the atom indices of the system components.
-
-    Ligand atoms are specified through MDTraj domain-specific language (DSL),
-    while receptor atoms are everything else excluding solvent.
-
-    If ligand_net_charge is non-zero, the function also isolates the indices
-    of ligand-neutralizing counterions in the 'ligand_counterions' component.
+    In periodic systems, the solvation box needs to be neutral, and
+    if the decoupled molecule is charged, it will cause trouble. This
+    can be used to find a set of ions in the system that neutralize
+    the molecule, so that the solvation box will remain neutral all
+    the time.
 
     Parameters
     ----------
-    system : simtk.openmm.app.System
-        The system object containing partial charges to perceive the net charge
-        of the ligand.
-    topology : mdtraj.Topology, simtk.openmm.app.Topology
-        The topology object specifying the system. If simtk.openmm.app.Topology
-        is passed instead this will be converted.
-    ligand_dsl : str
-        DSL specification of the ligand atoms.
-    solvent_dsl : str, optional
-        Optional DSL specification of the ligand atoms. If None, a list of
-        common solvent residue names will be used to automatically detect
-        solvent atoms (default is None).
+    system : simtk.openmm.System
+        The system object containing the atoms of interest.
+    topography : yank.Topography
+        The topography object holding the indices of the ions and the
+        ligand (for binding free energy) or solute (for transfer free
+        energy).
+    region_name : str
+        The region name in the topography (e.g. "ligand_atoms") for
+        which to find counterions.
 
     Returns
     -------
-    atom_indices : dict of list of int
-        atom_indices[component] is a list of atom indices belonging to that
-        component, where component is one of 'receptor', 'ligand', 'solvent',
-        'complex', and 'ligand_counterions'.
+    counterions_indices : list of int
+        The list of atom indices in the system of the counterions
+        neutralizing the region.
+
+    Raises
+    ------
+    ValueError
+        If the topography region has no atoms, or if it impossible
+        to neutralize the region with the ions in the system.
 
     """
-    atom_indices = {}
+    # Check whether we need to find counterions of ligand or solute.
+    atom_indices = getattr(topography, region_name)
+    if len(atom_indices) == 0:
+        raise ValueError("Cannot find counterions for region {}. "
+                         "The region has no atoms.")
 
-    # Determine if we need to convert the topology to mdtraj
-    # I'm using isinstance() to check this and not duck typing with hasattr() in
-    # case openmm Topology will implement a select() method in the future
-    if isinstance(topology, mdtraj.Topology):
-        mdtraj_top = topology
-    else:
-        mdtraj_top = mdtraj.Topology.from_openmm(topology)
+    # If the net charge of alchemical atoms is 0, we don't need counterions.
+    mol_net_charge = compute_net_charge(system, atom_indices)
+    logger.debug('{} net charge: {}'.format(region_name, mol_net_charge))
+    if mol_net_charge == 0:
+        return []
 
-    # Determine ligand atoms
-    atom_indices['ligand'] = mdtraj_top.select(ligand_dsl).tolist()
+    # Find net charge of all ions in the system.
+    ions_net_charges = {ion_id: compute_net_charge(system, [ion_id])
+                        for ion_id in topography.ions_atoms}
+    print(ions_net_charges)
+    topology = topography.topology
+    ions_names_charges = [(topology.atom(ion_id).residue.name, ions_net_charges[ion_id])
+                          for ion_id in ions_net_charges]
+    logger.debug('Ions net charges: {}'.format(ions_names_charges))
 
-    # Determine solvent and receptor atoms
-    # I did some benchmarking and this is still faster than a single for loop
-    # through all the atoms in mdtraj_top.atoms
-    if solvent_dsl is not None:
-        solvent_indices = mdtraj_top.select(solvent_dsl).tolist()
-        solvent_resnames = [mdtraj_top.atom(i).residue.name for i in solvent_indices]
-        atom_indices['solvent'] = solvent_indices
-    else:
-        solvent_resnames = _SOLVENT_RESNAMES
-        atom_indices['solvent'] = [atom.index for atom in mdtraj_top.atoms
-                                   if atom.residue.name in solvent_resnames]
-    not_receptor_set = frozenset(atom_indices['ligand'] + atom_indices['solvent'])
-    atom_indices['receptor'] = [atom.index for atom in mdtraj_top.atoms
-                                if atom.index not in not_receptor_set]
-    atom_indices['complex'] = atom_indices['receptor'] + atom_indices['ligand']
+    # Find minimal subset of counterions whose charges sums to -mol_net_charge.
+    for n_ions in range(1, len(ions_net_charges) + 1):
+        for ion_subset in itertools.combinations(ions_net_charges.items(), n_ions):
+            counterions_indices, counterions_charges = zip(*ion_subset)
+            if sum(counterions_charges) == -mol_net_charge:
+                return counterions_indices
 
-    # Perceive ligand net charge
-    ligand_net_charge = compute_net_charge(system, atom_indices['ligand'])
-    logger.debug('Ligand net charge: {}'.format(ligand_net_charge))
-
-    # Isolate ligand-neutralizing counterions.
-    if ligand_net_charge != 0:
-        if ligand_net_charge > 0:
-            counterions_set = {name for name in solvent_resnames if '-' in name}
-        elif ligand_net_charge < 0:
-            counterions_set = {name for name in solvent_resnames if '+' in name}
-
-        ligand_counterions = [atom.index for atom in mdtraj_top.atoms
-                              if atom.residue.name in counterions_set]
-        atom_indices['ligand_counterions'] = ligand_counterions[:abs(ligand_net_charge)]
-        logger.debug('Found {} ligand counterions.'.format(len(atom_indices['ligand_counterions'])))
-
-        # Eliminate ligand counterions indices from solvent component
-        atom_indices['solvent'] = [i for i in atom_indices['solvent']
-                                   if i not in atom_indices['ligand_counterions']]
-    else:
-        atom_indices['ligand_counterions'] = []
-
-    return atom_indices
+    # We couldn't find any subset of counterions neutralizing the region.
+    raise ValueError('Impossible to find a solution for region {}. '
+                     'Net charge: {}, system ions: {}.'.format(
+        region_name, mol_net_charge, ions_names_charges))
 
 
 # See Amber manual Table 4.1 http://ambermd.org/doc12/Amber15.pdf
@@ -343,6 +296,9 @@ def get_leap_recommended_pbradii(implicit_solvent):
         return _OPENMM_TO_TLEAP_PBRADII[str(implicit_solvent)]
     except KeyError:
         raise ValueError('Implicit solvent {} is not supported.'.format(implicit_solvent))
+
+
+_NONPERIODIC_NONBONDED_METHODS = [openmm.app.NoCutoff, openmm.app.CutoffNonPeriodic]
 
 
 def create_system(parameters_file, box_vectors, create_system_args, system_options):
@@ -413,8 +369,8 @@ def create_system(parameters_file, box_vectors, create_system_args, system_optio
     return system
 
 
-def prepare_phase(positions_file_path, parameters_file_path, ligand_dsl, system_options,
-                  solvent_dsl=None, gromacs_include_dir=None, verbose=False):
+def read_system_files(positions_file_path, parameters_file_path, system_options,
+                      gromacs_include_dir=None):
     """Create a Yank arguments for a phase from system files.
 
     Parameters
@@ -423,16 +379,10 @@ def prepare_phase(positions_file_path, parameters_file_path, ligand_dsl, system_
         Path to system position file (e.g. 'complex.inpcrd/.gro/.pdb').
     parameters_file_path : str
         Path to system parameters file (e.g. 'complex.prmtop/.top/.xml').
-    ligand_dsl : str
-        MDTraj DSL string that specify the ligand atoms.
     system_options : dict
         system_options[phase] is a a dictionary containing options to
         pass to createSystem(). If the parameters file is an OpenMM
         system in XML format, this will be ignored.
-    solvent_dsl : str, optional
-        Optional DSL specification of the ligand atoms. If None, a list of
-        common solvent residue names will be used to automatically detect
-        solvent atoms (default is None).
     gromacs_include_dir : str, optional
         Path to directory in which to look for other files included
         from the gromacs top file.
@@ -441,73 +391,84 @@ def prepare_phase(positions_file_path, parameters_file_path, ligand_dsl, system_
 
     Returns
     -------
-    alchemical_phase : AlchemicalPhase
-        The alchemical phase for Yank calculation with unspecified name, and protocol.
+    system : simtk.openmm.System
+        The OpenMM System built from the given files.
+    topology : openmm.app.Topology
+        The OpenMM Topology built from the given files.
+    sampler_state : openmmtools.states.SamplerState
+        The sampler state containing the positions of the atoms.
 
     """
     # Load system files
     parameters_file_extension = os.path.splitext(parameters_file_path)[1]
+
+    # Read OpenMM XML and PDB files.
     if parameters_file_extension == '.xml':
-        # Read Amber prmtop and inpcrd files
-        if verbose:
-            logger.info("xml: %s" % parameters_file_path)
-            logger.info("pdb: %s" % positions_file_path)
+        logger.debug("xml: {}".format(parameters_file_path))
+        logger.debug("pdb: {}".format(positions_file_path))
+
+        positions_file = openmm.app.PDBFile(positions_file_path)
+        parameters_file = positions_file  # Needed for topology.
         with open(parameters_file_path, 'r') as f:
             serialized_system = f.read()
+
         system = openmm.XmlSerializer.deserialize(serialized_system)
-        positions_file = openmm.app.PDBFile(positions_file_path)
-        parameters_file = positions_file  # needed for topology
+
+    # Read Amber prmtop and inpcrd files.
     elif parameters_file_extension == '.prmtop':
-        # Read Amber prmtop and inpcrd files
-        if verbose:
-            logger.info("prmtop: %s" % parameters_file_path)
-            logger.info("inpcrd: %s" % positions_file_path)
+        logger.debug("prmtop: {}".format(parameters_file_path))
+        logger.debug("inpcrd: {}".format(positions_file_path))
+
         parameters_file = openmm.app.AmberPrmtopFile(parameters_file_path)
         positions_file = openmm.app.AmberInpcrdFile(positions_file_path)
         box_vectors = positions_file.boxVectors
         create_system_args = set(inspect.getargspec(openmm.app.AmberPrmtopFile.createSystem).args)
+
         system = create_system(parameters_file, box_vectors, create_system_args, system_options)
+
+    # Read Gromacs top and gro files.
     elif parameters_file_extension == '.top':
-        # Read Gromacs top and gro files
-        if verbose:
-            logger.info("top: %s" % parameters_file_path)
-            logger.info("gro: %s" % positions_file_path)
+        logger.debug("top: {}".format(parameters_file_path))
+        logger.debug("gro: {}".format(positions_file_path))
 
         positions_file = openmm.app.GromacsGroFile(positions_file_path)
-        if ('nonbonded_method' in system_options) and (system_options['nonbonded_method'] in _NONPERIODIC_NONBONDED_METHODS):
-            # gro files must contain box vectors, so we must determine whether system is non-periodic or not from provided nonbonded options
-            # WARNING: This uses the private API for GromacsGroFile, and may break.
-            logger.info('nonbonded_method = %s, so removing periodic box vectors from gro file' % system_options['nonbonded_method'])
-            for (frame, box_vectors) in enumerate(positions_file._periodicBoxVectors):
+
+        # gro files must contain box vectors, so we must determine whether system
+        # is non-periodic or not from provided nonbonded options
+        # WARNING: This uses the private API for GromacsGroFile, and may break.
+        if ('nonbonded_method' in system_options and
+                system_options['nonbonded_method'] in _NONPERIODIC_NONBONDED_METHODS):
+            logger.info('nonbonded_method = {}, so removing periodic box vectors '
+                        'from gro file'.format(system_options['nonbonded_method']))
+            for frame, box_vectors in enumerate(positions_file._periodicBoxVectors):
                 positions_file._periodicBoxVectors[frame] = None
+
         box_vectors = positions_file.getPeriodicBoxVectors()
         parameters_file = openmm.app.GromacsTopFile(parameters_file_path,
                                                     periodicBoxVectors=box_vectors,
                                                     includeDir=gromacs_include_dir)
         create_system_args = set(inspect.getargspec(openmm.app.GromacsTopFile.createSystem).args)
+
         system = create_system(parameters_file, box_vectors, create_system_args, system_options)
+
+    # Unsupported file format.
     else:
         raise ValueError('Unsupported format for parameter file {}'.format(parameters_file_extension))
 
-    # Store numpy positions
+    # Store numpy positions and create SamplerState.
     positions = positions_file.getPositions(asNumpy=True)
+    sampler_state = mmtools.states.SamplerState(positions=positions)
 
     # Check to make sure number of atoms match between prmtop and inpcrd.
-    system_natoms = system.getNumParticles()
-    positions_natoms = positions.shape[0]
-    if system_natoms != positions_natoms:
+    n_atoms_system = system.getNumParticles()
+    n_atoms_positions = positions.shape[0]
+    if n_atoms_system != n_atoms_positions:
         err_msg = "Atom number mismatch: {} has {} atoms; {} has {} atoms.".format(
-            parameters_file_path, system_natoms, positions_file_path, positions_natoms)
+            parameters_file_path, n_atoms_system, positions_file_path, n_atoms_positions)
         logger.error(err_msg)
         raise RuntimeError(err_msg)
 
-    # Find ligand atoms and receptor atoms
-    atom_indices = find_components(system, parameters_file.topology, ligand_dsl,
-                                   solvent_dsl=solvent_dsl)
-
-    alchemical_phase = AlchemicalPhase('', system, parameters_file.topology,
-                                       positions, atom_indices, None)
-    return alchemical_phase
+    return system, parameters_file.topology, sampler_state
 
 
 if __name__ == '__main__':

--- a/Yank/tests/test_pipeline.py
+++ b/Yank/tests/test_pipeline.py
@@ -18,12 +18,30 @@ import os
 from simtk import openmm
 
 from yank import utils
-from yank.pipeline import find_components
+from yank.pipeline import *
 
 
 # =============================================================================
 # TESTS
 # =============================================================================
+
+def test_compute_min_dist():
+    """Test computation of minimum distance between two molecules"""
+    mol1_pos = np.array([[-1, -1, -1], [1, 1, 1]], np.float)
+    mol2_pos = np.array([[3, 3, 3], [3, 4, 5]], np.float)
+    mol3_pos = np.array([[2, 2, 2], [2, 4, 5]], np.float)
+    assert compute_min_dist(mol1_pos, mol2_pos, mol3_pos) == np.sqrt(3)
+
+
+def test_compute_min_max_dist():
+    """Test compute_min_max_dist() function."""
+    mol1_pos = np.array([[-1, -1, -1], [1, 1, 1]])
+    mol2_pos = np.array([[2, 2, 2], [2, 4, 5]])  # determine min dist
+    mol3_pos = np.array([[3, 3, 3], [3, 4, 5]])  # determine max dist
+    min_dist, max_dist = compute_min_max_dist(mol1_pos, mol2_pos, mol3_pos)
+    assert min_dist == np.linalg.norm(mol1_pos[1] - mol2_pos[0])
+    assert max_dist == np.linalg.norm(mol1_pos[1] - mol3_pos[1])
+
 
 def test_method_find_components():
     """Test find_components() function."""

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -133,14 +133,6 @@ def test_expand_id_nodes():
                             'sys3': {'prmtopfile': 'mysystem.prmtop'}}
 
 
-def test_topology_serialization():
-    """Correct serialization of Topology objects."""
-    topology = testsystems.AlanineDipeptideImplicit().topology
-    topology_str = serialize_topology(topology)
-    deserialized_topology = deserialize_topology(topology_str)
-    assert mdtraj.Topology.from_openmm(topology) == deserialized_topology
-
-
 def test_generate_signature_schema():
     """Test generate_signature_schema() function."""
     def f(a, b, camelCase=True, none=None, quantity=3.0*unit.angstroms):

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -91,9 +91,12 @@ def get_template_script(output_dir='.'):
     ---
     options:
         output_dir: {output_dir}
-        number_of_iterations: 1
+        number_of_iterations: 0
         temperature: 300*kelvin
         pressure: 1*atmosphere
+        minimize: no
+        verbose: no
+        nsteps_per_iteration: 1
     molecules:
         benzene:
             filepath: {benzene_path}
@@ -187,12 +190,12 @@ def test_compute_min_dist():
     assert compute_min_dist(mol1_pos, mol2_pos, mol3_pos) == np.sqrt(3)
 
 
-def test_compute_dist_bound():
-    """Test compute_dist_bound() function."""
+def test_compute_min_max_dist():
+    """Test compute_min_max_dist() function."""
     mol1_pos = np.array([[-1, -1, -1], [1, 1, 1]])
     mol2_pos = np.array([[2, 2, 2], [2, 4, 5]])  # determine min dist
     mol3_pos = np.array([[3, 3, 3], [3, 4, 5]])  # determine max dist
-    min_dist, max_dist = compute_dist_bound(mol1_pos, mol2_pos, mol3_pos)
+    min_dist, max_dist = compute_min_max_dist(mol1_pos, mol2_pos, mol3_pos)
     assert min_dist == np.linalg.norm(mol1_pos[1] - mol2_pos[0])
     assert max_dist == np.linalg.norm(mol1_pos[1] - mol3_pos[1])
 
@@ -233,7 +236,7 @@ def test_pack_transformation():
     for mol, transf in zip(mols_affine, transformations):
         assert isinstance(transf, np.ndarray)
         mol2 = mol.dot(transf.T)[:, :3]  # transform and "de-affine"
-        min_dist, max_dist = compute_dist_bound(mol1, mol2)
+        min_dist, max_dist = compute_min_max_dist(mol1, mol2)
         assert CLASH_DIST <= min_dist and max_dist <= BOX_SIZE
 
 
@@ -250,15 +253,13 @@ def test_yaml_parsing():
     test: 2
     """
     yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
-    assert len(yaml_builder.options) == len(yaml_builder.DEFAULT_OPTIONS)
-    assert len(yaml_builder.yank_options) == 0
+    expected_n_options = (len(yaml_builder.GENERAL_DEFAULT_OPTIONS) +
+                          len(yaml_builder.EXPERIMENT_DEFAULT_OPTIONS))
+    assert len(yaml_builder.options) == expected_n_options
 
     # Correct parsing
     yaml_content = """
     ---
-    metadata:
-        title: Test YANK YAML YAY!
-
     options:
         verbose: true
         resume_setup: true
@@ -267,18 +268,20 @@ def test_yaml_parsing():
         setup_dir: /path/to/output/setup/
         experiments_dir: /path/to/output/experiments/
         platform: CPU
-        precision: single
+        precision: mixed
+        switch_experiment_every: -2.0
+        switch_phase_every: 32
         temperature: 300*kelvin
         pressure: null
         constraints: AllBonds
         hydrogen_mass: 2*amus
         randomize_ligand: yes
-        randomize_ligand_sigma_multiplier: 2.0
+        randomize_ligand_sigma_multiplier: 1.0e-2
         randomize_ligand_close_cutoff: 1.5 * angstrom
         mc_displacement_sigma: 10.0 * angstroms
         anisotropic_dispersion_correction: no
+        anisotropic_dispersion_cutoff: 1 * angstrom
         collision_rate: 5.0 / picosecond
-        constraint_tolerance: 1.0e-6
         timestep: 2.0 * femtosecond
         nsteps_per_iteration: 2500
         number_of_iterations: 1000.999
@@ -288,30 +291,24 @@ def test_yaml_parsing():
         minimize_tolerance: 1.0 * kilojoules_per_mole / nanometers
         minimize_max_iterations: 0
         replica_mixing_scheme: swap-all
-        online_analysis: no
-        online_analysis_min_iterations: 20
-        show_energies: True
-        show_mixing_statistics: yes
         annihilate_sterics: no
         annihilate_electrostatics: true
     """
 
     yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
-    assert len(yaml_builder.options) == 35
-    assert len(yaml_builder.yank_options) == 23
+    assert len(yaml_builder.options) == 32
 
     # Check correct types
     assert yaml_builder.options['pressure'] is None
     assert yaml_builder.options['constraints'] == openmm.app.AllBonds
-    assert yaml_builder.yank_options['replica_mixing_scheme'] == 'swap-all'
-    assert yaml_builder.yank_options['timestep'] == 2.0 * unit.femtoseconds
-    assert yaml_builder.yank_options['constraint_tolerance'] == 1.0e-6
-    assert yaml_builder.yank_options['nsteps_per_iteration'] == 2500
-    assert type(yaml_builder.yank_options['nsteps_per_iteration']) is int
-    assert yaml_builder.yank_options['number_of_iterations'] == 1000
-    assert type(yaml_builder.yank_options['number_of_iterations']) is int
-    assert yaml_builder.yank_options['minimize'] is False
-    assert yaml_builder.yank_options['show_mixing_statistics'] is True
+    assert yaml_builder.options['replica_mixing_scheme'] == 'swap-all'
+    assert yaml_builder.options['timestep'] == 2.0 * unit.femtoseconds
+    assert yaml_builder.options['randomize_ligand_sigma_multiplier'] == 1.0e-2
+    assert yaml_builder.options['nsteps_per_iteration'] == 2500
+    assert type(yaml_builder.options['nsteps_per_iteration']) is int
+    assert yaml_builder.options['number_of_iterations'] == 1000
+    assert type(yaml_builder.options['number_of_iterations']) is int
+    assert yaml_builder.options['minimize'] is False
 
 
 def test_validation_wrong_options():
@@ -321,7 +318,7 @@ def test_validation_wrong_options():
         {'minimize': 100}
     ]
     for option in options:
-        yield assert_raises, YamlParseError, YamlBuilder._validate_options, option
+        yield assert_raises, YamlParseError, YamlBuilder._validate_options, option, True
 
 
 def test_validation_correct_molecules():
@@ -790,7 +787,7 @@ def test_clashing_atoms():
             toluene_pos2 = positions.take(atom_indices['ligand'], axis=0)
 
             # Test that clashes are resolved in the system
-            min_dist, max_dist = compute_dist_bound(toluene_pos2, benzene_pos2)
+            min_dist, max_dist = compute_min_max_dist(toluene_pos2, benzene_pos2)
             assert min_dist >= SetupDatabase.CLASH_THRESHOLD
 
             # For solvent we check that molecule is within the box
@@ -1428,19 +1425,29 @@ def test_charged_ligand():
             for i, phase_name in enumerate(['complex', 'solvent']):
                 inpcrd_file_path = system_files_paths[i].position_path
                 prmtop_file_path = system_files_paths[i].parameters_path
-                phase = pipeline.prepare_phase(inpcrd_file_path, prmtop_file_path, 'resname MOL',
-                                               {'nonbondedMethod': openmm.app.PME})
 
-                # Safety check: receptor must be negatively charged as expected
+                system, topology, _ = pipeline.read_system_files(
+                    inpcrd_file_path, prmtop_file_path, {'nonbondedMethod': openmm.app.PME})
+
+                # Identify components.
                 if phase_name == 'complex':
-                    receptor_net_charge = pipeline.compute_net_charge(phase.reference_system,
-                                                                      phase.atom_indices['receptor'])
-                    assert receptor_net_charge == receptors[receptor]
+                    alchemical_region = 'ligand_atoms'
+                    topography = Topography(topology, ligand_atoms='resname MOL')
 
-                # 'ligand_counterions' component contain one cation
-                assert len(phase.atom_indices['ligand_counterions']) == 1
-                ion_idx = phase.atom_indices['ligand_counterions'][0]
-                ion_atom = next(itertools.islice(phase.reference_topology.atoms(), ion_idx, None))
+                    # Safety check: receptor must be negatively charged as expected
+                    receptor_net_charge = pipeline.compute_net_charge(system,
+                                                                      topography.receptor_atoms)
+                    assert receptor_net_charge == receptors[receptor]
+                else:
+                    alchemical_region = 'solute_atoms'
+                    topography = Topography(topology)
+
+                # There is a single ligand/solute counterion.
+                ligand_counterions = pipeline.find_alchemical_counterions(system, topography,
+                                                                          alchemical_region)
+                assert len(ligand_counterions) == 1
+                ion_idx = ligand_counterions[0]
+                ion_atom = next(itertools.islice(topology.atoms(), ion_idx, None))
                 assert '-' in ion_atom.residue.name
 
                 # In complex, there should be both ions even if the system is globally
@@ -1528,21 +1535,6 @@ def test_setup_multiple_parameters_system():
 # ==============================================================================
 # Platform configuration tests
 # ==============================================================================
-
-def test_select_fastest_platform():
-    """Test that YamlBuilder select the fastest platform available when unspecified."""
-    available_platforms = [openmm.Platform.getPlatform(i).getName()
-                           for i in range(openmm.Platform.getNumPlatforms())]
-    if 'CUDA' in available_platforms:
-        fastest_platform = 'CUDA'
-    elif 'OpenCL' in available_platforms:
-        fastest_platform = 'OpenCL'
-    else:
-        fastest_platform = 'CPU'
-
-    platform = YamlBuilder._determine_fastest_platform()
-    assert platform.getName() == fastest_platform
-
 
 def test_platform_precision_configuration():
     """Test that the precision for platform is configured correctly."""
@@ -1776,27 +1768,6 @@ def test_yaml_extension():
             assert yaml.load(f) == yank_load(expected_yaml_content)
 
 
-def test_get_alchemical_path():
-    """Check that conversion to list of AlchemicalStates is correct."""
-    yaml_content = """
-    ---
-    protocols:{}
-    """.format(standard_protocol)
-    yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
-    alchemical_paths = yaml_builder._get_alchemical_paths('absolute-binding')
-
-    assert len(alchemical_paths) == 2
-    assert 'complex' in alchemical_paths
-    assert 'solvent' in alchemical_paths
-
-    complex_path = alchemical_paths['complex']
-    assert isinstance(complex_path[0], AlchemicalState)
-    assert complex_path[3]['lambda_electrostatics'] == 0.6
-    assert complex_path[4]['lambda_sterics'] == 0.4
-    assert complex_path[5]['lambda_restraints'] == 1.0
-    assert len(complex_path) == 7
-
-
 @attr('slow')  # Skip on Travis-CI
 def test_run_experiment_from_amber_files():
     """Test experiment run from prmtop/inpcrd files."""
@@ -1813,10 +1784,10 @@ def test_run_experiment_from_amber_files():
 
         yaml_builder = YamlBuilder(yaml_script)
         yaml_builder._check_resume()  # check_resume should not raise exceptions
-        yaml_builder.build_experiments()
+        yaml_builder.run_experiments()
 
         # The experiments folders are correctly named and positioned
-        output_dir = yaml_builder._get_experiment_dir(yaml_builder.options, '')
+        output_dir = yaml_builder._get_experiment_dir('')
         assert os.path.isdir(output_dir)
         assert os.path.isfile(os.path.join(output_dir, 'complex.nc'))
         assert os.path.isfile(os.path.join(output_dir, 'solvent.nc'))
@@ -1847,10 +1818,10 @@ def test_run_experiment_from_gromacs_files():
 
         yaml_builder = YamlBuilder(yaml_script)
         yaml_builder._check_resume()  # check_resume should not raise exceptions
-        yaml_builder.build_experiments()
+        yaml_builder.run_experiments()
 
         # The experiments folders are correctly named and positioned
-        output_dir = yaml_builder._get_experiment_dir(yaml_builder.options, '')
+        output_dir = yaml_builder._get_experiment_dir('')
         assert os.path.isdir(output_dir)
         assert os.path.isfile(os.path.join(output_dir, 'complex.nc'))
         assert os.path.isfile(os.path.join(output_dir, 'solvent.nc'))
@@ -1873,14 +1844,14 @@ def test_run_experiment_from_xml_files():
         del yaml_script['molecules']  # we shouldn't need any molecule
         yaml_script['systems'] = {'explicit-system':
                 {'phase1_path': solvent_path, 'phase2_path': vacuum_path,
-                 'ligand_dsl': 'resname TOL', 'solvent_dsl': 'not resname TOL'}}
+                 'solvent_dsl': 'not resname TOL'}}
 
         yaml_builder = YamlBuilder(yaml_script)
         yaml_builder._check_resume()  # check_resume should not raise exceptions
-        yaml_builder.build_experiments()
+        yaml_builder.run_experiments()
 
         # The experiments folders are correctly named and positioned
-        output_dir = yaml_builder._get_experiment_dir(yaml_builder.options, '')
+        output_dir = yaml_builder._get_experiment_dir('')
         assert os.path.isdir(output_dir)
         assert os.path.isfile(os.path.join(output_dir, 'complex.nc'))
         assert os.path.isfile(os.path.join(output_dir, 'solvent.nc'))
@@ -1902,8 +1873,11 @@ def test_run_experiment():
         options:
             resume_setup: no
             resume_simulation: no
-            number_of_iterations: 1
-            output_dir: overwritten
+            number_of_iterations: 0
+            output_dir: {}
+            setup_dir: ''
+            experiments_dir: ''
+            minimize: no
             annihilate_sterics: yes
         molecules:
             T4lysozyme:
@@ -1928,15 +1902,11 @@ def test_run_experiment():
                 solvent: !Combinatorial [vacuum, GBSA-OBC2]
         experiments:
             system: system
-            options:
-                output_dir: {}
-                setup_dir: ''
-                experiments_dir: ''
             protocol: absolute-binding
             restraint:
                 type: FlatBottom
-        """.format(examples_paths()['lysozyme'], examples_paths()['p-xylene'],
-                   indent(standard_protocol), tmp_dir)
+        """.format(tmp_dir, examples_paths()['lysozyme'], examples_paths()['p-xylene'],
+                   indent(standard_protocol))
 
         yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
 
@@ -1947,7 +1917,7 @@ def test_run_experiment():
         err_msg = ''
         yaml_builder._db._setup_molecules('p-xylene')
         try:
-            yaml_builder.build_experiments()
+            yaml_builder.run_experiments()
         except YamlParseError as e:
             err_msg = str(e)
         assert 'molecule' in err_msg
@@ -1957,7 +1927,7 @@ def test_run_experiment():
         system_dir = os.path.dirname(
             yaml_builder._db.get_system('system_GBSAOBC2')[0].position_path)
         try:
-            yaml_builder.build_experiments()
+            yaml_builder.run_experiments()
         except YamlParseError as e:
             err_msg = str(e)
         assert 'system' in err_msg
@@ -1969,7 +1939,7 @@ def test_run_experiment():
         prmtop_file = os.path.join(system_dir, 'complex.prmtop')
         molecule_last_touched = os.stat(frcmod_file).st_mtime
         system_last_touched = os.stat(prmtop_file).st_mtime
-        yaml_builder.build_experiments()
+        yaml_builder.run_experiments()
 
         # Neither the system nor the molecule has been processed again
         assert molecule_last_touched == os.stat(frcmod_file).st_mtime
@@ -1992,14 +1962,14 @@ def test_run_experiment():
 
         # Now we can't run the experiment again with resume_simulation: no
         try:
-            yaml_builder.build_experiments()
+            yaml_builder.run_experiments()
         except YamlParseError as e:
             err_msg = str(e)
         assert 'experiment' in err_msg
 
         # We set resume_simulation: yes and now things work
         yaml_builder.options['resume_simulation'] = True
-        yaml_builder.build_experiments()
+        yaml_builder.run_experiments()
 
 
 def test_run_solvation_experiment():
@@ -2025,10 +1995,10 @@ def test_run_solvation_experiment():
 
         yaml_builder = YamlBuilder(yaml_script)
         yaml_builder._check_resume()  # check_resume should not raise exceptions
-        yaml_builder.build_experiments()
+        yaml_builder.run_experiments()
 
         # The experiments folders are correctly named and positioned
-        output_dir = yaml_builder._get_experiment_dir(yaml_builder.options, '')
+        output_dir = yaml_builder._get_experiment_dir('')
         assert os.path.isdir(output_dir)
         assert os.path.isfile(os.path.join(output_dir, 'solvent1.nc'))
         assert os.path.isfile(os.path.join(output_dir, 'solvent2.nc'))
@@ -2039,19 +2009,6 @@ def test_run_solvation_experiment():
         analysis_script_path = os.path.join(output_dir, 'analysis.yaml')
         with open(analysis_script_path, 'r') as f:
             assert yaml.load(f) == [['solvent1', 1], ['solvent2', -1]]
-
-        # Check that solvated phase has a barostat.
-        from netCDF4 import Dataset
-        ncfile = Dataset(os.path.join(output_dir, 'solvent1.nc'), 'r')
-        ncgrp_stateinfo = ncfile.groups['thermodynamic_states']
-        system = openmm.System()
-        system.__setstate__(str(ncgrp_stateinfo.variables['base_system'][0]))
-        has_barostat = False
-        for force in system.getForces():
-            if force.__class__.__name__ == 'MonteCarloBarostat':
-                has_barostat = True
-        if not has_barostat:
-            raise Exception('Explicit solvent phase of hydration free energy calculation does not have a barostat.')
 
 if __name__ == '__main__':
     test_run_solvation_experiment()

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -177,37 +177,19 @@ def get_template_script(output_dir='.'):
 
     return yank_load(template_script)
 
+
 # ==============================================================================
 # YamlBuild utility functions
 # ==============================================================================
-
-
-def test_compute_min_dist():
-    """Test computation of minimum distance between two molecules"""
-    mol1_pos = np.array([[-1, -1, -1], [1, 1, 1]], np.float)
-    mol2_pos = np.array([[3, 3, 3], [3, 4, 5]], np.float)
-    mol3_pos = np.array([[2, 2, 2], [2, 4, 5]], np.float)
-    assert compute_min_dist(mol1_pos, mol2_pos, mol3_pos) == np.sqrt(3)
-
-
-def test_compute_min_max_dist():
-    """Test compute_min_max_dist() function."""
-    mol1_pos = np.array([[-1, -1, -1], [1, 1, 1]])
-    mol2_pos = np.array([[2, 2, 2], [2, 4, 5]])  # determine min dist
-    mol3_pos = np.array([[3, 3, 3], [3, 4, 5]])  # determine max dist
-    min_dist, max_dist = compute_min_max_dist(mol1_pos, mol2_pos, mol3_pos)
-    assert min_dist == np.linalg.norm(mol1_pos[1] - mol2_pos[0])
-    assert max_dist == np.linalg.norm(mol1_pos[1] - mol3_pos[1])
-
 
 def test_remove_overlap():
     """Test function remove_overlap()."""
     mol1_pos = np.array([[-1, -1, -1], [1, 1, 1]], np.float)
     mol2_pos = np.array([[1, 1, 1], [3, 4, 5]], np.float)
     mol3_pos = np.array([[2, 2, 2], [2, 4, 5]], np.float)
-    assert compute_min_dist(mol1_pos, mol2_pos, mol3_pos) < 0.1
+    assert pipeline.compute_min_dist(mol1_pos, mol2_pos, mol3_pos) < 0.1
     mol1_pos = remove_overlap(mol1_pos, mol2_pos, mol3_pos, min_distance=0.1, sigma=2.0)
-    assert compute_min_dist(mol1_pos, mol2_pos, mol3_pos) >= 0.1
+    assert pipeline.compute_min_dist(mol1_pos, mol2_pos, mol3_pos) >= 0.1
 
 
 def test_pull_close():
@@ -218,8 +200,8 @@ def test_pull_close():
     translation2 = pull_close(mol1_pos, mol2_pos, 1.5, 5)
     translation3 = pull_close(mol1_pos, mol3_pos, 1.5, 5)
     assert isinstance(translation2, np.ndarray)
-    assert 1.5 <= compute_min_dist(mol1_pos, mol2_pos + translation2) <= 5
-    assert 1.5 <= compute_min_dist(mol1_pos, mol3_pos + translation3) <= 5
+    assert 1.5 <= pipeline.compute_min_dist(mol1_pos, mol2_pos + translation2) <= 5
+    assert 1.5 <= pipeline.compute_min_dist(mol1_pos, mol3_pos + translation3) <= 5
 
 
 def test_pack_transformation():
@@ -236,7 +218,7 @@ def test_pack_transformation():
     for mol, transf in zip(mols_affine, transformations):
         assert isinstance(transf, np.ndarray)
         mol2 = mol.dot(transf.T)[:, :3]  # transform and "de-affine"
-        min_dist, max_dist = compute_min_max_dist(mol1, mol2)
+        min_dist, max_dist = pipeline.compute_min_max_dist(mol1, mol2)
         assert CLASH_DIST <= min_dist and max_dist <= BOX_SIZE
 
 
@@ -770,7 +752,7 @@ def test_clashing_atoms():
         # Sanity check: at the beginning molecules clash
         toluene_pos = utils.get_oe_mol_positions(utils.read_oe_molecule(toluene_path))
         benzene_pos = utils.get_oe_mol_positions(utils.read_oe_molecule(benzene_path))
-        assert compute_min_dist(toluene_pos, benzene_pos) < SetupDatabase.CLASH_THRESHOLD
+        assert pipeline.compute_min_dist(toluene_pos, benzene_pos) < SetupDatabase.CLASH_THRESHOLD
 
         yaml_builder = YamlBuilder(yaml_content)
 
@@ -787,7 +769,7 @@ def test_clashing_atoms():
             toluene_pos2 = positions.take(atom_indices['ligand'], axis=0)
 
             # Test that clashes are resolved in the system
-            min_dist, max_dist = compute_min_max_dist(toluene_pos2, benzene_pos2)
+            min_dist, max_dist = pipeline.compute_min_max_dist(toluene_pos2, benzene_pos2)
             assert min_dist >= SetupDatabase.CLASH_THRESHOLD
 
             # For solvent we check that molecule is within the box

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -21,27 +21,31 @@ This code is licensed under the latest available version of the MIT License.
 # GLOBAL IMPORTS
 # ==============================================================================
 
+import functools
+import contextlib
 
-import openmmtools as mmtools
-from openmmtools import testsystems
+from openmmtools.constants import kB
+from openmmtools import testsystems, states
 from mdtraj.utils import enter_temp_directory
 
-from nose import tools
+import nose
 import netCDF4 as netcdf
 
-from yank.repex import ThermodynamicState
-from yank.pipeline import find_components
-
+import yank.restraints
+from yank.repex import ReplicaExchange
 
 from yank.yank import *
 
+
 # ==============================================================================
-# MODULE CONSTANTS
+# TEST UTILITIES
 # ==============================================================================
 
-from simtk import unit
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA # Boltzmann constant
-
+def prepare_yield(func, test_case_name, *args):
+    """Create a description for a test function to yield."""
+    f = functools.partial(func, *args)
+    f.description = test_case_name + ': ' + func.__doc__
+    return f
 
 # ==============================================================================
 # TEST TOPOLOGY OBJECT
@@ -78,6 +82,212 @@ def test_topography_serialization():
 
 
 # ==============================================================================
+# TEST ALCHEMICAL PHASE
+# ==============================================================================
+
+class TestAlchemicalPhase(object):
+    """Test suite for class AlchemicalPhase."""
+
+    @classmethod
+    def setup_class(cls):
+        """Shared test cases for the suite."""
+        temperature = 300 * unit.kelvin
+
+        # Default protocols for tests.
+        cls.protocol = dict(lambda_electrostatics=[1.0, 0.5, 0.0, 0.0, 0.0],
+                            lambda_sterics=[1.0, 1.0, 1.0, 0.5, 0.0])
+        cls.restrained_protocol = dict(lambda_electrostatics=[1.0, 1.0, 0.0, 0.0],
+                                       lambda_sterics=[1.0, 1.0, 1.0, 0.0],
+                                       lambda_restraints=[0.0, 1.0, 1.0, 1.0])
+
+        # Ligand-receptor in implicit solvent.
+        test_system = testsystems.HostGuestImplicit()
+        thermodynamic_state = states.ThermodynamicState(test_system.system,
+                                                        temperature=temperature)
+        sampler_state = states.SamplerState(test_system.positions)
+        topography = Topography(test_system.topology, ligand_atoms='resname B2')
+        cls.host_guest_implicit = ('Host-guest implicit', thermodynamic_state, sampler_state, topography)
+
+        # Ligand-receptor in explicit solvent.
+        test_system = testsystems.HostGuestExplicit()
+        thermodynamic_state = states.ThermodynamicState(test_system.system,
+                                                        temperature=temperature)
+        sampler_state = states.SamplerState(test_system.positions)
+        topography = Topography(test_system.topology, ligand_atoms='resname B2')
+        cls.host_guest_explicit = ('Host-guest explicit', thermodynamic_state, sampler_state, topography)
+
+        # Peptide solvated in explicit solvent.
+        test_system = testsystems.AlanineDipeptideExplicit()
+        thermodynamic_state = states.ThermodynamicState(test_system.system,
+                                                        temperature=temperature)
+        sampler_state = states.SamplerState(test_system.positions)
+        topography = Topography(test_system.topology)
+        cls.alanine_explicit = ('Alanine dipeptide explicit', thermodynamic_state, sampler_state, topography)
+
+        # All test cases
+        cls.all_test_cases = [cls.host_guest_implicit, cls.host_guest_explicit, cls.alanine_explicit]
+
+    @staticmethod
+    @contextlib.contextmanager
+    def temporary_storage_path():
+        """Generate a storage path in a temporary folder and share it.
+
+        It makes it possible to run tests on multiple nodes with MPI.
+
+        """
+        mpicomm = mpi.get_mpicomm()
+        with mmtools.utils.temporary_directory() as tmp_dir_path:
+            storage_file_path = os.path.join(tmp_dir_path, 'test_storage.nc')
+            if mpicomm is not None:
+                storage_file_path = mpicomm.bcast(storage_file_path, root=0)
+            yield storage_file_path
+
+    @staticmethod
+    def check_protocol(alchemical_phase, protocol):
+        """The compound thermodynamic states created follow the requested protocol."""
+        for i, state in enumerate(alchemical_phase._sampler._thermodynamic_states):
+            for protocol_key, protocol_values in protocol.items():
+                assert getattr(state, protocol_key) == protocol_values[i]
+
+    @staticmethod
+    def check_standard_state_correction(alchemical_phase, topography):
+        """AlchemicalPhase carries the correct standard state correction."""
+        is_complex = len(topography.ligand_atoms) > 0
+        metadata = alchemical_phase._sampler.metadata
+        standard_state_correction = metadata['standard_state_correction']
+        if is_complex:
+            assert standard_state_correction != 0
+        else:
+            assert standard_state_correction == 0
+
+    @staticmethod
+    def check_expanded_states(alchemical_phase, protocol, expected_cutoff):
+        """The expanded states have been setup correctly."""
+        cutoff_unit = expected_cutoff.unit
+        thermodynamic_state = alchemical_phase._sampler._thermodynamic_states[0]
+        unsampled_states = alchemical_phase._sampler._unsampled_states
+
+        is_periodic = thermodynamic_state.is_periodic
+
+        # Anisotropic correction is not applied to non-periodic systems.
+        if not is_periodic:
+            assert len(unsampled_states) == 0
+            return
+        assert len(unsampled_states) == 2
+
+        # Find all nonbonded forces and verify their cutoff.
+        for state in unsampled_states:
+            for force in state.system.getForces():
+                try:
+                    cutoff = force.getCutoffDistance()
+                except AttributeError:
+                    continue
+                else:
+                    err_msg = 'obtained {}, expected {}'.format(cutoff, expected_cutoff)
+                    assert np.isclose(cutoff / cutoff_unit, expected_cutoff / cutoff_unit), err_msg
+
+        # The noninteracting state, must be in the same state as the last one.
+        noninteracting_state = unsampled_states[1]
+        for protocol_key, protocol_values in protocol.items():
+            assert getattr(noninteracting_state, protocol_key) == protocol_values[-1]
+
+    def test_create(self):
+        """Alchemical state correctly creates the simulation object."""
+        available_restraints = list(yank.restraints.available_restraint_classes().values())
+        correction_cutoff = 12 * unit.angstroms
+
+        for test_case in self.all_test_cases:
+            test_name, thermodynamic_state, sampler_state, topography = test_case
+
+            # Add random restraint if this is ligand-receptor system in implicit solvent.
+            if len(topography.ligand_atoms) > 0 and not thermodynamic_state.is_periodic:
+                restraint_cls = available_restraints[np.random.randint(0, len(available_restraints))]
+                restraint = restraint_cls()
+                protocol = self.restrained_protocol
+            else:
+                restraint = None
+                protocol = self.protocol
+
+            alchemical_phase = AlchemicalPhase(sampler=ReplicaExchange())
+            with self.temporary_storage_path() as storage_path:
+                alchemical_phase.create(thermodynamic_state, sampler_state, topography,
+                                        protocol, storage_path, restraint=restraint,
+                                        anisotropic_dispersion_cutoff=correction_cutoff)
+
+                yield prepare_yield(self.check_protocol, test_name, alchemical_phase, protocol)
+                yield prepare_yield(self.check_standard_state_correction, test_name,
+                                    alchemical_phase, topography)
+                yield prepare_yield(self.check_expanded_states, test_name, alchemical_phase,
+                                    protocol, correction_cutoff)
+
+    def test_default_alchemical_region(self):
+        """The default alchemical region modify the correct system elements."""
+        # We test two protocols: with and without alchemically
+        # modified bonds, angles and torsions.
+        simple_protocol = dict(lambda_electrostatics=[1.0, 0.5, 0.0, 0.0, 0.0],
+                               lambda_sterics=[1.0, 1.0, 1.0, 0.5, 0.0])
+        full_protocol = dict(lambda_electrostatics=[1.0, 0.5, 0.0, 0.0, 0.0],
+                             lambda_sterics=[1.0, 1.0, 1.0, 0.5, 0.0],
+                             lambda_bonds=[1.0, 1.0, 1.0, 0.5, 0.0],
+                             lambda_angles=[1.0, 1.0, 1.0, 0.5, 0.0],
+                             lambda_torsions=[1.0, 1.0, 1.0, 0.5, 0.0])
+        protocols = [simple_protocol, full_protocol]
+
+        # Create two test systems with a charged solute and counterions.
+        sodium_chloride = testsystems.SodiumChlorideCrystal()
+        negative_solute = Topography(sodium_chloride.topology, solvent_atoms=[0])
+        positive_solute = Topography(sodium_chloride.topology, solvent_atoms=[1])
+
+        # Test case: (system, topography, topography_region)
+        test_cases = [
+            (self.host_guest_implicit[1].system, self.host_guest_implicit[3], 'ligand_atoms'),
+            (self.host_guest_explicit[1].system, self.host_guest_explicit[3], 'ligand_atoms'),
+            (self.alanine_explicit[1].system, self.alanine_explicit[3], 'solute_atoms'),
+            (sodium_chloride.system, negative_solute, 'solute_atoms'),
+            (sodium_chloride.system, positive_solute, 'solute_atoms')
+        ]
+
+        for system, topography, alchemical_region_name in test_cases:
+            expected_alchemical_atoms = getattr(topography, alchemical_region_name)
+
+            # Compute net charge of alchemical atoms.
+            net_charge = pipeline.compute_net_charge(system, expected_alchemical_atoms)
+            if net_charge != 0:
+                # Sodium chloride test systems.
+                expected_alchemical_atoms = [0, 1]
+
+            for protocol in protocols:
+                alchemical_region = AlchemicalPhase._build_default_alchemical_region(
+                    system, topography, protocol)
+                assert alchemical_region.alchemical_atoms == expected_alchemical_atoms
+
+                # The alchemical region must be neutralized.
+                assert pipeline.compute_net_charge(system, expected_alchemical_atoms) == 0
+
+                # We modify elements other than sterics and electrostatics when requested.
+                if 'lambda_bonds' in protocol:
+                    assert alchemical_region.alchemical_bonds is True
+                    assert alchemical_region.alchemical_angles is True
+                    assert alchemical_region.alchemical_torsions is True
+
+    def test_illegal_restraint(self):
+        """Raise an error when restraint is handled incorrectly."""
+        # An error is raised with ligand-receptor systems in implicit without restraint.
+        test_name, thermodynamic_state, sampler_state, topography = self.host_guest_implicit
+        alchemical_phase = AlchemicalPhase(sampler=ReplicaExchange())
+        with nose.tools.assert_raises(ValueError):
+            alchemical_phase.create(thermodynamic_state, sampler_state, topography,
+                                    self.protocol, 'not_created.nc')
+
+        # An error is raised when trying to apply restraint to non ligand-receptor systems.
+        restraint = yank.restraints.Harmonic()
+        test_name, thermodynamic_state, sampler_state, topography = self.alanine_explicit
+        with nose.tools.assert_raises(RuntimeError):
+            alchemical_phase.create(thermodynamic_state, sampler_state, topography,
+                                    self.protocol, 'not_created.nc', restraint=restraint)
+
+
+# ==============================================================================
 # MAIN AND TESTS
 # ==============================================================================
 
@@ -87,13 +297,13 @@ def test_parameters():
     # Check that both Yank and Repex parameters are accepted
     Yank(store_directory='test', randomize_ligand=True, nsteps_per_iteration=1)
 
-@tools.raises(TypeError)
+@nose.tools.raises(TypeError)
 def test_unknown_parameters():
     """Test whether Yank raises exception on wrong initialization."""
     Yank(store_directory='test', wrong_parameter=False)
 
 
-@tools.raises(ValueError)
+@nose.tools.raises(ValueError)
 def test_no_alchemical_atoms():
     """Test whether Yank raises exception when no alchemical atoms are specified."""
     toluene = testsystems.TolueneImplicit()

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -286,6 +286,23 @@ class TestAlchemicalPhase(object):
             alchemical_phase.create(thermodynamic_state, sampler_state, topography,
                                     self.protocol, 'not_created.nc', restraint=restraint)
 
+    def test_from_storage(self):
+        """When resuming, the AlchemicalPhase recover the correct sampler."""
+        _, thermodynamic_state, sampler_state, topography = self.host_guest_implicit
+        restraint = yank.restraints.Harmonic()
+
+        with self.temporary_storage_path() as storage_path:
+            alchemical_phase = AlchemicalPhase(ReplicaExchange())
+            alchemical_phase.create(thermodynamic_state, sampler_state, topography,
+                                    self.protocol, storage_path, restraint=restraint)
+
+            # Delete old alchemical phase to close storage file.
+            del alchemical_phase
+
+            # Resume, the sampler has the correct class.
+            alchemical_phase = AlchemicalPhase.from_storage(storage_path)
+            assert isinstance(alchemical_phase._sampler, ReplicaExchange)
+
     @staticmethod
     def test_find_similar_sampler_states():
         """Test helper method AlchemicalPhase._find_similar_sampler_states."""

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -22,6 +22,7 @@ This code is licensed under the latest available version of the MIT License.
 # ==============================================================================
 
 
+import openmmtools as mmtools
 from openmmtools import testsystems
 from mdtraj.utils import enter_temp_directory
 
@@ -63,6 +64,17 @@ def test_topography():
     assert topography.solute_atoms == list(range(156))
     assert topography.solvent_atoms == list(range(156, host_guest_explicit.system.getNumParticles()))
     assert len(topography.ions_atoms) == 0
+
+
+def test_topography_serialization():
+    """Correct serialization of Topography objects."""
+    test_system = testsystems.AlanineDipeptideImplicit()
+    topography = Topography(test_system.topology)
+    serialized_topography = mmtools.utils.serialize(topography)
+    restored_topography = mmtools.utils.deserialize(serialized_topography)
+    assert topography.topology == restored_topography.topology
+    assert topography.ligand_atoms == restored_topography.ligand_atoms
+    assert topography.solvent_atoms == restored_topography.solvent_atoms
 
 
 # ==============================================================================

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -3,10 +3,8 @@ import re
 import sys
 import copy
 import glob
-import json
 import shutil
 import signal
-import pandas
 import inspect
 import logging
 import itertools
@@ -24,6 +22,8 @@ from schema import Optional, Use
 from simtk.openmm import XmlSerializer
 
 from openmoltools.utils import wraps_py2, unwrap_py2  # Shortcuts for other modules
+
+from yank import mpi
 
 #========================================================================================
 # Logging functions
@@ -52,7 +52,7 @@ def is_terminal_verbose():
 
     return is_verbose
 
-def config_root_logger(verbose, log_file_path=None, mpicomm=None):
+def config_root_logger(verbose, log_file_path=None):
     """Setup the the root logger's configuration.
 
      The log messages are printed in the terminal and saved in the file specified
@@ -75,8 +75,6 @@ def config_root_logger(verbose, log_file_path=None, mpicomm=None):
     log_file_path : str, optional, default = None
         If not None, this is the path where all the logger's messages of level
         logging.DEBUG or higher are saved.
-    mpicomm : mpi4py.MPI.COMM communicator, optional, default=None
-        If specified, this communicator will be used to determine node rank.
 
     """
 
@@ -109,6 +107,7 @@ def config_root_logger(verbose, log_file_path=None, mpicomm=None):
             root_logger.removeHandler(root_logger.handlers[0])
 
     # If this is a worker node, don't save any log file
+    mpicomm = mpi.get_mpicomm()
     if mpicomm:
         rank = mpicomm.rank
     else:
@@ -716,56 +715,6 @@ def is_iterable_container(value):
 # ==============================================================================
 # Conversion utilities
 # ==============================================================================
-
-def serialize_topology(topology):
-    """Serialize topology to string.
-
-    Parameters
-    ----------
-    topology : mdtraj.Topology, simtk.openmm.app.Topology
-        The topology object to serialize.
-
-    Returns
-    -------
-    serialized_topology : str
-        String obtained by jsonizing the return value of to_dataframe() of the
-        mdtraj Topology object.
-
-    """
-    # Check if we need to convert the topology to mdtraj
-    if isinstance(topology, mdtraj.Topology):
-        mdtraj_top = topology
-    else:
-        mdtraj_top = mdtraj.Topology.from_openmm(topology)
-
-    atoms, bonds = mdtraj_top.to_dataframe()
-    separators = (',', ':')  # don't dump whitespaces to save space
-    serialized_topology = json.dumps({'atoms': atoms.to_json(orient='records'),
-                                      'bonds': bonds.tolist()},
-                                     separators=separators)
-    return serialized_topology
-
-
-def deserialize_topology(serialized_topology):
-    """Serialize topology to string.
-
-    Parameters
-    ----------
-    serialized_topology : str
-        Serialized topology as returned by serialize_topology().
-
-    Returns
-    -------
-    topology : mdtraj.Topology
-        The deserialized topology object.
-
-    """
-    topology_dict = json.loads(serialized_topology)
-    atoms = pandas.read_json(topology_dict['atoms'], orient='records')
-    bonds = np.array(topology_dict['bonds'])
-    topology = mdtraj.Topology.from_dataframe(atoms, bonds)
-    return topology
-
 
 def typename(atype):
     """Convert a type object into a fully qualified typename.

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 
-# =============================================================================================
+# =============================================================================
 # MODULE DOCSTRING
-# =============================================================================================
+# =============================================================================
 
 """
 Tools to build Yank experiments from a YAML configuration file.
 
 """
 
-# =============================================================================================
+# =============================================================================
 # GLOBAL IMPORTS
-# =============================================================================================
+# =============================================================================
 
 import os
 import re
@@ -22,16 +22,13 @@ import collections
 
 import numpy as np
 import openmoltools as omt
+import openmmtools as mmtools
 from simtk import unit, openmm
 from simtk.openmm.app import PDBFile, AmberPrmtopFile
-from alchemy import AlchemicalState, AbsoluteAlchemicalFactory
 from schema import Schema, And, Or, Use, Optional, SchemaError
 
-from . import utils
-from . import pipeline
-from .yank import Yank
-from .repex import ReplicaExchange, ThermodynamicState
-from .sampling import ModifiedHamiltonianExchange
+from yank import utils, pipeline, mpi, restraints, repex
+from yank.yank import AlchemicalPhase, Topography
 
 logger = logging.getLogger(__name__)
 
@@ -42,9 +39,9 @@ logger = logging.getLogger(__name__)
 HIGHEST_VERSION = '1.2'  # highest version of YAML syntax
 
 
-# =============================================================================================
+# =============================================================================
 # UTILITY FUNCTIONS
-# =============================================================================================
+# =============================================================================
 
 def compute_min_dist(mol_positions, *args):
     """Compute the minimum distance between a molecule and a set of other molecules.
@@ -84,7 +81,7 @@ def compute_min_dist(mol_positions, *args):
     return min_dist
 
 
-def compute_dist_bound(mol_positions, *args):
+def compute_min_max_dist(mol_positions, *args):
     """Compute minimum and maximum distances between a molecule and a set of
     other molecules.
 
@@ -115,7 +112,7 @@ def compute_dist_bound(mol_positions, *args):
     >>> mol1_pos = np.array([[-1, -1, -1], [1, 1, 1]], np.float)
     >>> mol2_pos = np.array([[2, 2, 2], [2, 4, 5]], np.float)  # determine min dist
     >>> mol3_pos = np.array([[3, 3, 3], [3, 4, 5]], np.float)  # determine max dist
-    >>> min_dist, max_dist = compute_dist_bound(mol1_pos, mol2_pos, mol3_pos)
+    >>> min_dist, max_dist = compute_min_max_dist(mol1_pos, mol2_pos, mol3_pos)
     >>> min_dist == np.linalg.norm(mol1_pos[1] - mol2_pos[0])
     True
     >>> max_dist == np.linalg.norm(mol1_pos[1] - mol3_pos[1])
@@ -186,8 +183,7 @@ def remove_overlap(mol_positions, *args, **kwargs):
         x0 = x.mean(0)
 
         # Randomize orientation of ligand.
-        q = ModifiedHamiltonianExchange._generate_uniform_quaternion()
-        Rq = ModifiedHamiltonianExchange._rotation_matrix_from_quaternion(q)
+        Rq = mmtools.mcmc.MCRotationMove.generate_random_rotation_matrix()
         x = ((Rq * np.matrix(x - x0).T).T + x0).A
 
         # Choose a random displacement vector and translate
@@ -236,19 +232,18 @@ def pack_transformation(mol1_pos, mol2_pos, min_distance, max_distance):
 
     # Try until we have a non-overlapping conformation w.r.t. all fixed molecules
     i = 0
-    min_dist, max_dist = compute_dist_bound(mol1_pos, mol2_pos)
+    min_dist, max_dist = compute_min_max_dist(mol1_pos, mol2_pos)
     while min_dist < min_distance or max_distance <= max_dist:
         # Select random atom of fixed molecule and use it to propose new x0 position
         mol1_atom_idx = np.random.random_integers(0, len(mol1_pos) - 1)
         translation = mol1_pos[mol1_atom_idx] + max_distance * np.random.randn(3) - x0
 
         # Generate random rotation matrix
-        q = ModifiedHamiltonianExchange._generate_uniform_quaternion()
-        Rq = ModifiedHamiltonianExchange._rotation_matrix_from_quaternion(q)
+        Rq = mmtools.mcmc.MCRotationMove.generate_random_rotation_matrix()
 
         # Apply random transformation and test
         x = ((Rq * np.matrix(mol2_pos - x0).T).T + x0).A + translation
-        min_dist, max_dist = compute_dist_bound(mol1_pos, x)
+        min_dist, max_dist = compute_min_max_dist(mol1_pos, x)
 
         # Check n iterations
         i += 1
@@ -370,9 +365,9 @@ def update_nested_dict(original, updated):
     return new
 
 
-# ============================================================================================
+# ==============================================================================
 # UTILITY CLASSES
-# ============================================================================================
+# ==============================================================================
 
 class YamlParseError(Exception):
     """Represent errors occurring during parsing of Yank YAML file."""
@@ -423,6 +418,10 @@ class YankDumper(yaml.Dumper):
         """YAML representer OrderedDict nodes."""
         return dumper.represent_mapping(u'!Ordered', data)
 
+
+# ==============================================================================
+# SETUP DATABASE
+# ==============================================================================
 
 class SetupDatabase:
     """Provide utility functions to set up systems and molecules.
@@ -1098,11 +1097,147 @@ class SetupDatabase:
             logger.warning('TLeap: ' + warning)
 
 
-#=============================================================================================
+# ==============================================================================
 # BUILDER CLASS
-#=============================================================================================
+# ==============================================================================
 
-class YamlBuilder:
+class YamlPhaseFactory(object):
+
+    DEFAULT_OPTIONS = {
+        'anisotropic_dispersion_correction': True,
+        'anisotropic_dispersion_cutoff': 16.0*unit.angstroms,
+        'minimize': True,
+        'minimize_tolerance': 1.0 * unit.kilojoules_per_mole/unit.nanometers,
+        'minimize_max_iterations': 0,
+        'randomize_ligand': False,
+        'randomize_ligand_sigma_multiplier': 2.0,
+        'randomize_ligand_close_cutoff': 1.5 * unit.angstrom,
+        'number_of_equilibration_iterations': 0,
+        'equilibration_timestep': 1.0 * unit.femtosecond,
+    }
+
+    def __init__(self, sampler, thermodynamic_state, sampler_states, topography,
+                 protocol, storage, restraint=None, alchemical_regions=None,
+                 alchemical_factory=None, metadata=None, **options):
+        self.sampler = sampler
+        self.thermodynamic_state = thermodynamic_state
+        self.sampler_states = sampler_states
+        self.topography = topography
+        self.protocol = protocol
+        self.storage = storage
+        self.restraint = restraint
+        self.alchemical_regions = alchemical_regions
+        self.alchemical_factory = alchemical_factory
+        self.metadata = metadata
+        self.options = self.DEFAULT_OPTIONS.copy()
+        self.options.update(options)
+
+    def create_alchemical_phase(self):
+        alchemical_phase = AlchemicalPhase(self.sampler)
+        create_kwargs = self.__dict__.copy()
+        create_kwargs.pop('options')
+        create_kwargs.pop('sampler')
+        if self.options['anisotropic_dispersion_correction'] is True:
+            dispersion_cutoff = self.options['anisotropic_dispersion_cutoff']
+        else:
+            dispersion_cutoff = None
+        alchemical_phase.create(**create_kwargs, anisotropic_dispersion_cutoff=dispersion_cutoff)
+        return alchemical_phase
+
+    def initialize_alchemical_phase(self):
+        alchemical_phase = self.create_alchemical_phase()
+
+        # Minimize if requested.
+        if self.options['minimize']:
+            tolerance = self.options['minimize_tolerance']
+            max_iterations = self.options['minimize_max_iterations']
+            alchemical_phase.minimize(tolerance=tolerance, max_iterations=max_iterations)
+
+        # Randomize ligand if requested.
+        if self.options['randomize_ligand']:
+            sigma_multiplier = self.options['randomize_ligand_sigma_multiplier']
+            close_cutoff = self.options['randomize_ligand_close_cutoff']
+            alchemical_phase.randomize_ligand(sigma_multiplier=sigma_multiplier,
+                                              close_cutoff=close_cutoff)
+
+        # Equilibrate if requested.
+        if self.options['number_of_equilibration_iterations'] > 0:
+            n_iterations = self.options['number_of_equilibration_iterations']
+            mcmc_move = mmtools.mcmc.LangevinDynamicsMove(timestep=self.options['equilibration_timestep'],
+                                                          collision_rate=90.0/unit.picosecond,
+                                                          n_steps=500, reassign_velocities=True,
+                                                          n_restart_attempts=6)
+            alchemical_phase.equilibrate(n_iterations, mcmc_moves=mcmc_move)
+
+        return alchemical_phase
+
+
+class YamlExperiment(object):
+    """An experiment built by YamlBuilder."""
+    def __init__(self, phases, number_of_iterations, switch_phase_every):
+        self.phases = phases
+        self.number_of_iterations = number_of_iterations
+        self.switch_phase_every = switch_phase_every
+        self._phases_last_iterations = [None, None]
+
+    @property
+    def iteration(self):
+        if None in self._phases_last_iterations:
+            return 0
+        return min(self._phases_last_iterations)
+
+    def run(self, n_iterations=None):
+        # Handle default argument.
+        if n_iterations is None:
+            n_iterations = self.number_of_iterations
+
+        # Handle case in which we don't alternate between phases.
+        if self.switch_phase_every <= 0:
+            switch_phase_every = self.number_of_iterations
+
+        # Count down the iterations to run.
+        iterations_left = [None, None]
+        while iterations_left != [0, 0]:
+
+            # Alternate phases every switch_phase_every iterations.
+            for phase_id, phase in enumerate(self.phases):
+                # Phases may get out of sync if the user delete the storage
+                # file of only one phase and restart. Here we check that the
+                # phase still has iterations to run before creating it.
+                if self._phases_last_iterations[phase_id] == self.number_of_iterations:
+                    iterations_left[phase_id] = 0
+                    continue
+
+                # If this is a new simulation, initialize alchemical phase.
+                if isinstance(phase, YamlPhaseFactory):
+                    alchemical_phase = phase.initialize_alchemical_phase()
+                    self.phases[phase_id] = phase.storage
+                else:  # Resume previous simulation.
+                    alchemical_phase = AlchemicalPhase.from_storage(phase)
+
+                # Update total number of iterations. This may write the new number
+                # of iterations in the storage file so we do it only if necessary.
+                if alchemical_phase.number_of_iterations != self.number_of_iterations:
+                    alchemical_phase.number_of_iterations = self.number_of_iterations
+
+                # Determine number of iterations to run in this function call.
+                if iterations_left[phase_id] is None:
+                    total_iterations_left = self.number_of_iterations - alchemical_phase.iteration
+                    iterations_left[phase_id] = min(n_iterations, total_iterations_left)
+
+                # Run simulation for iterations_left or until we have to switch phase.
+                iterations_to_run = min(iterations_left[phase_id], switch_phase_every)
+                alchemical_phase.run(n_iterations=iterations_to_run)
+
+                # Update phase iteration info.
+                iterations_left[phase_id] -= iterations_to_run
+                self._phases_last_iterations[phase_id] = alchemical_phase.iteration
+
+                # Delete alchemical phase and prepare switching.
+                del alchemical_phase
+
+
+class YamlBuilder(object):
     """Parse YAML configuration file and build the experiment.
 
     The relative paths indicated in the script are assumed to be relative to
@@ -1114,23 +1249,16 @@ class YamlBuilder:
     some files and raises an exception if it finds already existing output folders
     unless the options resume_setup or resume_simulation are True.
 
-    Properties
-    ----------
-    yank_options : dict
-        The options specified in the parsed YAML file that will be passed to Yank.
-        These are not the full range of options specified in the script since some
-        of them are used to configure YamlBuilder and not the Yank object.
-
     Examples
     --------
     >>> import textwrap
-    >>> import openmoltools as omt
-    >>> import utils
-    >>> setup_dir = utils.get_data_filename(os.path.join('..', 'examples',
-    ...                                     'p-xylene-implicit', 'input'))
+    >>> import openmmtools as mmtools
+    >>> import yank.utils
+    >>> setup_dir = yank.utils.get_data_filename(os.path.join('..', 'examples',
+    ...                                          'p-xylene-implicit', 'input'))
     >>> pxylene_path = os.path.join(setup_dir, 'p-xylene.mol2')
     >>> lysozyme_path = os.path.join(setup_dir, '181L-pdbfixer.pdb')
-    >>> with omt.utils.temporary_directory() as tmp_dir:
+    >>> with mmtools.utils.temporary_directory() as tmp_dir:
     ...     yaml_content = '''
     ...     ---
     ...     options:
@@ -1168,7 +1296,7 @@ class YamlBuilder:
     ...       protocol: absolute-binding
     ...     '''.format(tmp_dir, lysozyme_path, pxylene_path)
     >>> yaml_builder = YamlBuilder(textwrap.dedent(yaml_content))
-    >>> yaml_builder.build_experiments()
+    >>> yaml_builder.run_experiments()
 
     """
 
@@ -1176,7 +1304,8 @@ class YamlBuilder:
     # Public API
     # --------------------------------------------------------------------------
 
-    DEFAULT_OPTIONS = {
+    # These are options that can be specified only in the main "options" section.
+    GENERAL_DEFAULT_OPTIONS = {
         'verbose': False,
         'resume_setup': False,
         'resume_simulation': False,
@@ -1185,15 +1314,22 @@ class YamlBuilder:
         'experiments_dir': 'experiments',
         'platform': 'fastest',
         'precision': 'auto',
+        'switch_experiment_every': 0,
+    }
+
+    # These options can be overwritten also in the "experiment"
+    # section and they can be thus combinatorially expanded.
+    EXPERIMENT_DEFAULT_OPTIONS = {
+        'switch_phase_every': 0,
         'temperature': 298 * unit.kelvin,
         'pressure': 1 * unit.atmosphere,
         'constraints': openmm.app.HBonds,
         'hydrogen_mass': 1 * unit.amu,
+        'nsteps_per_iteration': 500,
+        'timestep': 2.0 * unit.femtosecond,
+        'collision_rate': 1.0 / unit.picosecond,
+        'mc_displacement_sigma': 10.0 * unit.angstroms
     }
-
-    @property
-    def yank_options(self):
-        return self._isolate_yank_options(self.options)
 
     def __init__(self, yaml_source=None):
         """Constructor.
@@ -1205,14 +1341,14 @@ class YamlBuilder:
             can load it later by using parse() (default is None).
 
         """
-        self.options = self.DEFAULT_OPTIONS.copy()  # General options (not experiment-specific)
+        self.options = self.GENERAL_DEFAULT_OPTIONS.copy()
+        self.options.update(self.EXPERIMENT_DEFAULT_OPTIONS.copy())
 
         self._version = None
         self._script_dir = os.getcwd()  # basic dir for relative paths
         self._db = None  # Database containing molecules created in parse()
-        self._mpicomm = None  # MPI communicator
         self._raw_yaml = {}  # Unconverted input YAML script, helpful for
-        self._categorized_raw_yaml = {}  # Raw YAML with selective keys chosen and blank dictionaries for missing keys
+        self._expanded_raw_yaml = {}  # Raw YAML with selective keys chosen and blank dictionaries for missing keys
         self._protocols = {}  # Alchemical protocols description
         self._experiments = {}  # Experiments description
 
@@ -1291,24 +1427,28 @@ class YamlBuilder:
         yaml_content = self._expand_systems(yaml_content)
 
         # Save raw YAML content that will be needed when generating the YAML files
-        self._categorized_raw_yaml = copy.deepcopy({key: yaml_content.get(key, {})
-                                        for key in ['options', 'molecules', 'solvents',
-                                                    'systems', 'protocols']})
+        self._expanded_raw_yaml = copy.deepcopy({key: yaml_content.get(key, {})
+                                                 for key in ['options', 'molecules', 'solvents',
+                                                             'systems', 'protocols']})
 
         # Validate options and overwrite defaults
-        self.options.update(self._validate_options(utils.merge_dict(yaml_content.get('options', {}),
-                                                                    yaml_content.get('metadata', {}))))
+        self.options.update(self._validate_options(yaml_content.get('options', {}),
+                                                   validate_general_options=True))
 
-        # Setup MPI and general logging
-        self._mpicomm = utils.initialize_mpi()
-        utils.config_root_logger(self.options['verbose'], log_file_path=None, mpicomm=self._mpicomm)
-        if self._mpicomm is None:
-            logger.debug('MPI disabled.')
-        else:
-            logger.debug('MPI enabled.')
+        # Setup general logging
+        utils.config_root_logger(self.options['verbose'], log_file_path=None)
+
+        # Configure ContextCache, platform and precision. A Yank simulation
+        # currently needs 3 contexts: 1 for the alchemical states and 2 for
+        # the states with expanded cutoff.
+        platform = self._configure_platform(self.options['platform'],
+                                            self.options['precision'])
+        mmtools.cache.global_context_cache.platform = platform
+        mmtools.cache.global_context_cache.capacity = 3
 
         # Initialize and configure database with molecules, solvents and systems
-        self._db = SetupDatabase(setup_dir=self._get_setup_dir(self.options))
+        setup_dir = os.path.join(self.options['output_dir'], self.options['setup_dir'])
+        self._db = SetupDatabase(setup_dir=setup_dir)
         self._db.molecules = self._validate_molecules(yaml_content.get('molecules', {}))
         self._db.solvents = self._validate_solvents(yaml_content.get('solvents', {}))
         self._db.systems = self._validate_systems(yaml_content.get('systems', {}))
@@ -1319,18 +1459,52 @@ class YamlBuilder:
         # Validate experiments
         self._parse_experiments(yaml_content)
 
-    def build_experiments(self):
+    def run_experiments(self):
         """Set up and run all the Yank experiments."""
         # Throw exception if there are no experiments
         if len(self._experiments) == 0:
             raise YamlParseError('No experiments specified!')
 
+        # Handle case where we don't have to switch between experiments.
+        if self.options['switch_experiment_every'] <= 0:
+            # Run YamlExperiment for number_of_iterations.
+            switch_experiment_every = None
+        else:
+            switch_experiment_every = self.options['switch_experiment_every']
+
         # Setup and run all experiments with paths relative to the script directory
         with omt.utils.temporary_cd(self._script_dir):
             self._check_resume()
             self._setup_experiments()
-            for output_dir, combination in self._expand_experiments():
-                self._run_experiment(combination, output_dir)
+
+            # Cycle between experiments every switch_experiment_every iterations
+            # until all of them are done. We don't know how many experiments
+            # there are until after the end of first for-loop.
+            completed = [False]  # There always be at least one experiment.
+            while not all(completed):
+                for experiment_index, experiment in enumerate(self._build_experiments()):
+
+                    experiment.run(n_iterations=switch_experiment_every)
+
+                    # Check if this experiment is done.
+                    is_completed = experiment.iteration == experiment.number_of_iterations
+                    try:
+                        completed[experiment_index] = is_completed
+                    except IndexError:
+                        completed.append(is_completed)
+
+    def build_experiments(self):
+        """Set up, build and iterate over all the Yank experiments."""
+        # Throw exception if there are no experiments
+        if len(self._experiments) == 0:
+            raise YamlParseError('No experiments specified!')
+
+        # Setup and iterate over all experiments with paths relative to the script directory
+        with omt.utils.temporary_cd(self._script_dir):
+            self._check_resume()
+            self._setup_experiments()
+            for experiment in self._build_experiments():
+                yield experiment
 
     def setup_experiments(self):
         """Set up all Yank experiments without running them."""
@@ -1347,16 +1521,12 @@ class YamlBuilder:
     # Options handling
     # --------------------------------------------------------------------------
 
-    def _isolate_yank_options(self, options):
-        """Return the options that do not belong to YamlBuilder."""
-        return {opt: val for opt, val in utils.listitems(options)
-                if opt not in self.DEFAULT_OPTIONS}
-
     def _determine_experiment_options(self, experiment):
-        """Merge the options specified in the experiment section with the general ones.
+        """Determine all the options required to build the experiment.
 
-        Options in the general section have priority. Options in the experiment section
-        are validated.
+        Merge the options specified in the experiment section with the ones
+        in the options section, and divide them into several dictionaries to
+        feed to different main classes necessary to create an AlchemicalPhase.
 
         Parameters
         ----------
@@ -1365,13 +1535,35 @@ class YamlBuilder:
 
         Returns
         -------
-        exp_options : dict
-            A new dictionary containing the all the options that apply for the experiment.
+        experiment_options : dict
+            The YamlBuilder experiment options. This does not contain
+            the general YamlBuilder options that are accessible through
+            self.options.
+        phase_options : dict
+            The options to pass to the YamlPhaseFactory constructor.
+        sampler_options : dict
+            The options to pass to the ReplicaExchange constructor.
+        alchemical_region_options : dict
+            The options to pass to AlchemicalRegion.
 
         """
-        exp_options = self.options.copy()
-        exp_options.update(self._validate_options(experiment.get('options', {})))
-        return exp_options
+        # First discard general options.
+        options = {name: value for name, value in self.options.items()
+                   if name not in self.GENERAL_DEFAULT_OPTIONS}
+
+        # Then update with specific experiment options.
+        options.update(experiment.get('options', {}))
+
+        def _filter_options(reference_options):
+            return {name: value for name, value in options.items()
+                    if name in reference_options}
+
+        experiment_options = _filter_options(self.EXPERIMENT_DEFAULT_OPTIONS)
+        phase_options = _filter_options(YamlPhaseFactory.DEFAULT_OPTIONS)
+        sampler_options = _filter_options(utils.get_keyword_args(repex.ReplicaExchange.__init__))
+        alchemical_region_options = _filter_options(mmtools.alchemy._ALCHEMICAL_REGION_ARGS)
+
+        return experiment_options, phase_options, sampler_options, alchemical_region_options
 
     # --------------------------------------------------------------------------
     # Combinatorial expansion
@@ -1505,13 +1697,16 @@ class YamlBuilder:
     # --------------------------------------------------------------------------
 
     @classmethod
-    def _validate_options(cls, options):
+    def _validate_options(cls, options, validate_general_options):
         """Validate molecules syntax.
 
         Parameters
         ----------
         options : dict
             A dictionary with the options to validate.
+        validate_general_options : bool
+            If False only the options that can be specified in the
+            experiment section are validated.
 
         Returns
         -------
@@ -1524,15 +1719,26 @@ class YamlBuilder:
             If the syntax for any option is not valid.
 
         """
-        template_options = cls.DEFAULT_OPTIONS.copy()
-        template_options.update(Yank.default_parameters)
-        template_options.update(ReplicaExchange.default_parameters)
-        template_options.update(utils.get_keyword_args(AbsoluteAlchemicalFactory.__init__))
-        openmm_app_type = {'constraints': to_openmm_app}
+        template_options = cls.EXPERIMENT_DEFAULT_OPTIONS.copy()
+        template_options.update(YamlPhaseFactory.DEFAULT_OPTIONS)
+        template_options.update(mmtools.alchemy._ALCHEMICAL_REGION_ARGS)
+        template_options.update(utils.get_keyword_args(repex.ReplicaExchange.__init__))
+
+        if validate_general_options is True:
+            template_options.update(cls.GENERAL_DEFAULT_OPTIONS.copy())
+
+        # Remove options that are not supported.
+        template_options.pop('mcmc_moves')  # ReplicaExchange
+        template_options.pop('alchemical_atoms')  # AlchemicalRegion
+        template_options.pop('alchemical_bonds')
+        template_options.pop('alchemical_angles')
+        template_options.pop('alchemical_torsions')
+
+        special_conversions = {'constraints': to_openmm_app}
         try:
             validated_options = utils.validate_parameters(options, template_options, check_unknown=True,
                                                           process_units_str=True, float_to_int=True,
-                                                          special_conversions=openmm_app_type)
+                                                          special_conversions=special_conversions)
         except (TypeError, ValueError) as e:
             raise YamlParseError(str(e))
         return validated_options
@@ -1808,15 +2014,21 @@ class YamlBuilder:
                     print('Correctly recognized files %s as %s' % (files, expected_extensions))
                 for filepath in files:
                     if not os.path.isfile(filepath):
-                        pritn('os.path.isfile(%s) is False' % filepath)
+                        print('os.path.isfile(%s) is False' % filepath)
                         raise YamlParseError('File path {} does not exist.'.format(filepath))
                 return [filepath for (ext, filepath) in sorted(zip(provided_extensions, files))]
             return _system_files
 
         # Define experiment Schema
         validated_systems = systems_description.copy()
-        parameters_schema = {  # simple strings are converted to list of strings
-            'parameters': And(Use(lambda p: [p] if isinstance(p, str) else p), [str])}
+
+        # Schema for leap parameters. Simple strings are converted to list of strings.
+        parameters_schema = {'parameters': And(Use(lambda p: [p] if isinstance(p, str) else p), [str])}
+
+        # Schema for DSL specification with system files.
+        dsl_schema = {Optional('ligand_dsl'): str, Optional('solvent_dsl'): str}
+
+        # System schema.
         system_schema = Schema(Or(
             {'receptor': is_known_molecule, 'ligand': is_known_molecule,
              'solvent': is_pipeline_solvent, Optional('pack', default=False): bool,
@@ -1825,28 +2037,28 @@ class YamlBuilder:
             {'solute': is_known_molecule, 'solvent1': is_pipeline_solvent,
              'solvent2': is_pipeline_solvent, Optional('leap'): parameters_schema},
 
-            {'phase1_path': Use(system_files('amber')), 'phase2_path': Use(system_files('amber')),
-             'ligand_dsl': str, Optional('solvent_dsl'): str, 'solvent': is_known_solvent},
+            utils.merge_dict(dsl_schema, {'phase1_path': Use(system_files('amber')),
+                                          'phase2_path': Use(system_files('amber')),
+                                          'solvent': is_known_solvent}),
 
-            {'phase1_path': Use(system_files('amber')), 'phase2_path': Use(system_files('amber')),
-             'ligand_dsl': str, Optional('solvent_dsl'): str,
-             'solvent1': is_known_solvent, 'solvent2': is_known_solvent},
+            utils.merge_dict(dsl_schema, {'phase1_path': Use(system_files('amber')),
+                                          'phase2_path': Use(system_files('amber')),
+                                          'solvent1': is_known_solvent,
+                                          'solvent2': is_known_solvent}),
 
-            {'phase1_path': Use(system_files('gromacs')), 'phase2_path': Use(system_files('gromacs')),
-             'ligand_dsl': str, Optional('solvent_dsl'): str,
-             'solvent': is_known_solvent, Optional('gromacs_include_dir'): os.path.isdir},
+            utils.merge_dict(dsl_schema, {'phase1_path': Use(system_files('gromacs')),
+                                          'phase2_path': Use(system_files('gromacs')),
+                                          'solvent': is_known_solvent,
+                                          Optional('gromacs_include_dir'): os.path.isdir}),
 
-            {'phase1_path': Use(system_files('gromacs')), 'phase2_path': Use(system_files('gromacs')),
-             'ligand_dsl': str, Optional('solvent_dsl'): str,
-             'solvent1': is_known_solvent, 'solvent2': is_known_solvent, Optional('gromacs_include_dir'): os.path.isdir},
+            utils.merge_dict(dsl_schema, {'phase1_path': Use(system_files('gromacs')),
+                                          'phase2_path': Use(system_files('gromacs')),
+                                          'solvent1': is_known_solvent,
+                                          'solvent2': is_known_solvent,
+                                          Optional('gromacs_include_dir'): os.path.isdir}),
 
-            {'phase1_path': Use(system_files('gromacs')), 'phase2_path': Use(system_files('gromacs')),
-             'ligand_dsl': str, Optional('solvent_dsl'): str,
-             'solvent1': is_known_solvent, 'solvent2': is_known_solvent,
-             Optional('gromacs_include_dir'): os.path.isdir},
-
-            {'phase1_path': Use(system_files('openmm')), 'phase2_path': Use(system_files('openmm')),
-             'ligand_dsl': str, Optional('solvent_dsl'): str}
+            utils.merge_dict(dsl_schema, {'phase1_path': Use(system_files('openmm')),
+                                          'phase2_path': Use(system_files('openmm'))})
         ))
 
         # Schema validation
@@ -1891,6 +2103,9 @@ class YamlBuilder:
                 return True
             raise YamlParseError('Protocol ' + protocol_id + ' is unknown')
 
+        def validate_experiment_options(options):
+            return YamlBuilder._validate_options(options, validate_general_options=False)
+
         # Check if there is a sequence of experiments or a single one
         try:
             if isinstance(yaml_content['experiments'], list):
@@ -1907,7 +2122,7 @@ class YamlBuilder:
 
         # Define experiment Schema
         experiment_schema = Schema({'system': is_known_system, 'protocol': is_known_protocol,
-                                    Optional('options'): Use(YamlBuilder._validate_options),
+                                    Optional('options'): Use(validate_experiment_options),
                                     Optional('restraint'): restraint_schema})
 
         # Schema validation
@@ -1921,37 +2136,19 @@ class YamlBuilder:
     # File paths utilities
     # --------------------------------------------------------------------------
 
-    @staticmethod
-    def _get_setup_dir(experiment_options):
-        """Return the path to the directory where the setup output files
-        should be stored.
-
-        Parameters
-        ----------
-        experiment_options : dict
-            A dictionary containing the validated options that apply to the
-            experiment as obtained by _determine_experiment_options().
-
-        """
-        return os.path.join(experiment_options['output_dir'], experiment_options['setup_dir'])
-
-    @staticmethod
-    def _get_experiment_dir(experiment_options, experiment_subdir):
+    def _get_experiment_dir(self, experiment_subdir):
         """Return the path to the directory where the experiment output files
         should be stored.
 
         Parameters
         ----------
-        experiment_options : dict
-            A dictionary containing the validated options that apply to the
-            experiment as obtained by _determine_experiment_options().
         experiment_subdir : str
             The relative path w.r.t. the main experiments directory (determined
             through the options) of the experiment-specific subfolder.
 
         """
-        return os.path.join(experiment_options['output_dir'],
-                            experiment_options['experiments_dir'], experiment_subdir)
+        return os.path.join(self.options['output_dir'], self.options['experiments_dir'],
+                            experiment_subdir)
 
     # --------------------------------------------------------------------------
     # Resuming
@@ -1983,6 +2180,7 @@ class YamlBuilder:
                 return False
         return True
 
+    @mpi.on_single_node(0, sync_nodes=True)
     def _check_resume(self, check_setup=True, check_experiments=True):
         """Perform dry run to check if we are going to overwrite files.
 
@@ -2007,31 +2205,23 @@ class YamlBuilder:
             If files to write already exist and we resuming options are not set.
 
         """
-        # This is hard disk intensive, only process 0 should do it
-        if self._mpicomm is not None and self._mpicomm.rank != 0:
-            self._mpicomm.barrier()  # Wait for root node to check
-            return
-
         err_msg = ''
 
         for exp_sub_dir, combination in self._expand_experiments():
-            # Determine and validate options
-            exp_options = self._determine_experiment_options(combination)
 
             if check_experiments:
-                resume_sim = exp_options['resume_simulation']
-                experiment_dir = self._get_experiment_dir(exp_options, exp_sub_dir)
+                resume_sim = self.options['resume_simulation']
+                experiment_dir = self._get_experiment_dir(exp_sub_dir)
                 if not resume_sim and self._check_resume_experiment(experiment_dir,
                                                                     combination['protocol']):
                     err_msg = 'experiment files in directory {}'.format(experiment_dir)
                     solving_option = 'resume_simulation'
 
             if check_setup and err_msg == '':
-                resume_setup = exp_options['resume_setup']
+                resume_setup = self.options['resume_setup']
                 system_id = combination['system']
 
                 # Check system and molecule setup dirs
-                self._db.setup_dir = self._get_setup_dir(exp_options)
                 is_sys_setup, is_sys_processed = self._db.is_system_setup(system_id)
                 if is_sys_processed and not resume_setup:
                     system_dir = os.path.dirname(
@@ -2059,67 +2249,9 @@ class YamlBuilder:
                             'directory or set {} options').format(solving_option)
                 raise YamlParseError(err_msg)
 
-        # Signal resume to non-root other nodes
-        if self._mpicomm is not None:
-            self._mpicomm.barrier()
-
     # --------------------------------------------------------------------------
-    # Experiment setup and execution
+    # OpenMM Platform configuration
     # --------------------------------------------------------------------------
-
-    def _setup_experiments(self):
-        """Set up all experiments without running them.
-
-        IMPORTANT: This does not check if we are about to overwrite files, nor it
-        cd into the script directory! Use setup_experiments() for that.
-
-        """
-        # TODO parallelize setup
-        # Only root node performs setup
-        if self._mpicomm is not None and self._mpicomm.rank != 0:
-            debug_msg = 'Node {}/{}: MPI barrier'.format(self._mpicomm.rank,
-                                                         self._mpicomm.size)
-            logger.debug(debug_msg + ' - waiting for the setup to be completed.')
-            self._mpicomm.barrier()
-            return
-
-        for _, experiment in self._expand_experiments():
-            # Set database path
-            exp_opts = self._determine_experiment_options(experiment)
-            self._db.setup_dir = self._get_setup_dir(exp_opts)
-
-            # Force system and molecules setup
-            system_id = experiment['system']
-            sys_descr = self._db.systems[system_id]  # system description
-            try:
-                try:  # binding free energy system
-                    components = (sys_descr['receptor'], sys_descr['ligand'], sys_descr['solvent'])
-                except KeyError:  # partition/solvation free energy system
-                    components = (sys_descr['solute'], sys_descr['solvent1'], sys_descr['solvent2'])
-                logger.info('Setting up the systems for {}, {} and {}'.format(*components))
-                self._db.get_system(system_id)
-            except KeyError:  # system files are given directly by the user
-                pass
-
-        # Signal resume to child nodes
-        if self._mpicomm is not None:
-            debug_msg = 'Node {}/{}: MPI barrier'.format(self._mpicomm.rank,
-                                                         self._mpicomm.size)
-            logger.debug(debug_msg + ' - signal completed setup.')
-            # Proceed through barrier where other MPI processes are blocking.
-            self._mpicomm.barrier()
-
-    @staticmethod
-    def _set_gpu_precision(platform, precision_model):
-        """Temporary work-around for OpenMM7.1 issue #1676."""
-        try:  # TODO we could remove this when openmm#1676 gets fixed
-            platform.setPropertyDefaultValue('Precision', precision_model)
-        except Exception:  # TODO we can remove this when we stop support for OpenMM 7.0
-            platform_name = platform.getName()
-            if platform_name == 'CUDA':
-                platform_name = 'Cuda'
-            property_name = platform_name + 'Precision'
-            platform.setPropertyDefaultValue(property_name, precision_model)
 
     @staticmethod
     def _opencl_device_support_precision(precision_model):
@@ -2143,7 +2275,7 @@ class YamlBuilder:
         old_precision = opencl_platform.getPropertyDefaultValue('OpenCLPrecision')
 
         # Test support by creating a toy context
-        YamlBuilder._set_gpu_precision(opencl_platform, precision_model)
+        opencl_platform.setPropertyDefaultValue('Precision', precision_model)
         system = openmm.System()
         system.addParticle(1.0 * unit.amu)  # system needs at least 1 particle
         integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
@@ -2157,26 +2289,9 @@ class YamlBuilder:
         del integrator
 
         # Restore old precision
-        YamlBuilder._set_gpu_precision(opencl_platform, old_precision)
+        opencl_platform.setPropertyDefaultValue('Precision', old_precision)
 
         return is_supported
-
-    @staticmethod
-    def _determine_fastest_platform():
-        """
-        Return the fastest available platform.
-
-        Returns
-        -------
-        platform : simtk.openmm.Platform
-           The fastest available platform.
-
-        """
-        platform_speeds = np.array([openmm.Platform.getPlatform(i).getSpeed()
-                                    for i in range(openmm.Platform.getNumPlatforms())])
-        fastest_platform_id = int(np.argmax(platform_speeds))
-        platform = openmm.Platform.getPlatform(fastest_platform_id)
-        return platform
 
     def _configure_platform(self, platform_name, platform_precision):
         """
@@ -2209,7 +2324,7 @@ class YamlBuilder:
         """
         # Determine the platform to configure
         if platform_name == 'fastest':
-            platform = self._determine_fastest_platform()
+            platform = mmtools.utils.get_fastest_platform()
             platform_name = platform.getName()
         else:
             platform = openmm.Platform.getPlatformByName(platform_name)
@@ -2217,7 +2332,8 @@ class YamlBuilder:
         # Use only a single CPU thread if we are using the CPU platform.
         # TODO: Since there is an environment variable that can control this,
         # TODO: we may want to avoid doing this.
-        if platform_name == 'CPU' and self._mpicomm is not None:
+        mpicomm = mpi.get_mpicomm()
+        if platform_name == 'CPU' and mpicomm is not None:
             logger.debug("Setting 'CpuThreads' to 1 because MPI is active.")
             platform.setPropertyDefaultValue('CpuThreads', '1')
 
@@ -2240,11 +2356,11 @@ class YamlBuilder:
             logger.info("Setting {} platform to use precision model "
                         "'{}'.".format(platform_name, platform_precision))
             if platform_name == 'CUDA':
-                YamlBuilder._set_gpu_precision(platform, platform_precision)
+                platform.setPropertyDefaultValue('Precision', platform_precision)
             elif platform_name == 'OpenCL':
                 # Some OpenCL devices do not support double precision so we need to test it
                 if self._opencl_device_support_precision(platform_precision):
-                    YamlBuilder._set_gpu_precision(platform, platform_precision)
+                    platform.setPropertyDefaultValue('Precision', platform_precision)
                 else:
                     raise RuntimeError('This device does not support double precision for OpenCL.')
             elif platform_name == 'Reference':
@@ -2259,6 +2375,44 @@ class YamlBuilder:
                 raise RuntimeError("Found unknown platform '{}'.".format(platform_name))
 
         return platform
+
+    # --------------------------------------------------------------------------
+    # Experiment setup and execution
+    # --------------------------------------------------------------------------
+
+    def _build_experiments(self):
+        """Set up and build all the Yank experiments.
+
+        IMPORTANT: This does not check if we are about to overwrite files, neither
+        it creates the setup files nor it cds into the script directory! Use
+        build_experiments() for that.
+
+        """
+        for output_dir, combination in self._expand_experiments():
+            yield self._build_experiment(combination, output_dir)
+
+    @mpi.on_single_node(rank=0, sync_nodes=True)
+    def _setup_experiments(self):
+        """Set up all experiments without running them.
+
+        IMPORTANT: This does not check if we are about to overwrite files, nor it
+        cd into the script directory! Use setup_experiments() for that.
+
+        """
+        # TODO parallelize setup
+        for _, experiment in self._expand_experiments():
+            # Force system and molecules setup
+            system_id = experiment['system']
+            sys_descr = self._db.systems[system_id]  # system description
+            try:
+                try:  # binding free energy system
+                    components = (sys_descr['receptor'], sys_descr['ligand'], sys_descr['solvent'])
+                except KeyError:  # partition/solvation free energy system
+                    components = (sys_descr['solute'], sys_descr['solvent1'], sys_descr['solvent2'])
+                logger.info('Setting up the systems for {}, {} and {}'.format(*components))
+                self._db.get_system(system_id)
+            except KeyError:  # system files are given directly by the user
+                pass
 
     def _generate_yaml(self, experiment, file_path):
         """Generate the minimum YAML file needed to reproduce the experiment.
@@ -2280,10 +2434,10 @@ class YamlBuilder:
                 molecule_ids = [sys_descr['receptor'], sys_descr['ligand']]
             except KeyError:  # partition/solvation free energy
                 molecule_ids = [sys_descr['solute']]
-            mol_section = {mol_id: self._categorized_raw_yaml['molecules'][mol_id]
+            mol_section = {mol_id: self._expanded_raw_yaml['molecules'][mol_id]
                            for mol_id in molecule_ids}
 
-            # Copy to avoid modifying _categorized_raw_yaml when updating paths
+            # Copy to avoid modifying _expanded_raw_yaml when updating paths
             mol_section = copy.deepcopy(mol_section)
         except KeyError:  # user provided directly system files
             mol_section = {}
@@ -2297,20 +2451,20 @@ class YamlBuilder:
             except KeyError:  # from xml/pdb system files
                 assert 'phase1_path' in sys_descr
                 solvent_ids = []
-        sol_section = {sol_id: self._categorized_raw_yaml['solvents'][sol_id]
+        sol_section = {sol_id: self._expanded_raw_yaml['solvents'][sol_id]
                        for sol_id in solvent_ids}
 
         # Systems section data
         system_id = experiment['system']
-        sys_section = {system_id: copy.deepcopy(self._categorized_raw_yaml['systems'][system_id])}
+        sys_section = {system_id: copy.deepcopy(self._expanded_raw_yaml['systems'][system_id])}
 
         # Protocols section data
         protocol_id = experiment['protocol']
-        prot_section = {protocol_id: self._categorized_raw_yaml['protocols'][protocol_id]}
+        prot_section = {protocol_id: self._expanded_raw_yaml['protocols'][protocol_id]}
 
         # We pop the options section in experiment and merge it to the general one
         exp_section = experiment.copy()
-        opt_section = self._categorized_raw_yaml['options'].copy()
+        opt_section = self._expanded_raw_yaml['options'].copy()
         opt_section.update(exp_section.pop('options', {}))
 
         # Convert relative paths to new script directory
@@ -2328,14 +2482,14 @@ class YamlBuilder:
         try:  # output directory
             output_dir = opt_section['output_dir']
         except KeyError:
-            output_dir = self.DEFAULT_OPTIONS['output_dir']
+            output_dir = self.GENERAL_DEFAULT_OPTIONS['output_dir']
         if not os.path.isabs(output_dir):
             opt_section['output_dir'] = os.path.relpath(output_dir, yaml_dir)
 
         # If we are converting a combinatorial experiment into a
         # single one we must set the correct experiment directory
         experiment_dir = os.path.relpath(yaml_dir, output_dir)
-        if experiment_dir != self.DEFAULT_OPTIONS['experiments_dir']:
+        if experiment_dir != self.GENERAL_DEFAULT_OPTIONS['experiments_dir']:
             opt_section['experiments_dir'] = experiment_dir
 
         # Create YAML with the sections in order
@@ -2354,35 +2508,15 @@ class YamlBuilder:
         with open(file_path, 'w') as f:
             f.write(yaml_content)
 
-    def _get_alchemical_paths(self, protocol_id):
-        """Return the list of AlchemicalStates specified in the protocol.
+    @staticmethod
+    def _save_analysis_script(results_dir, phase_names):
+        """Store the analysis information about phase signs for analyze."""
+        analysis = [[phase_names[0], 1], [phase_names[1], -1]]
+        analysis_script_path = os.path.join(results_dir, 'analysis.yaml')
+        with open(analysis_script_path, 'w') as f:
+            yaml.dump(analysis, f)
 
-        Parameters
-        ----------
-        protocol_id : str
-            The protocol ID specified in the YAML script.
-
-        Returns
-        -------
-        alchemical_paths : dict of list of AlchemicalState
-            alchemical_paths[phase] is the list of AlchemicalStates specified in the
-            YAML script for protocol 'protocol_id' and phase 'phase'.
-
-        """
-        alchemical_protocol = {}
-        for phase_name, phase in utils.listitems(self._protocols[protocol_id]):
-            # Separate lambda variables names from their associated lists
-            lambdas, values = zip(*utils.listitems(phase['alchemical_path']))
-
-            # Transpose so that each row contains single alchemical state values
-            values = zip(*values)
-
-            alchemical_protocol[phase_name] = [AlchemicalState(
-                                               **{var: val for var, val in zip(lambdas, state_values)}
-                                               ) for state_values in values]
-        return alchemical_protocol
-
-    def _run_experiment(self, experiment, experiment_dir):
+    def _build_experiment(self, experiment, experiment_dir):
         """Prepare and run a single experiment.
 
         Parameters
@@ -2393,139 +2527,173 @@ class YamlBuilder:
             The directory where to store the output files relative to the main
             output directory as specified by the user in the YAML script
 
+        Returns
+        -------
+        yaml_experiment : YamlExperiment
+            A YamlExperiment object.
+
         """
+        system_id = experiment['system']
         protocol_id = experiment['protocol']
         exp_name = 'experiments' if experiment_dir == '' else os.path.basename(experiment_dir)
 
-        # Get and validate experiment sub-options
+        # Get and validate experiment sub-options and divide them by class.
         exp_opts = self._determine_experiment_options(experiment)
-        yank_opts = self._isolate_yank_options(exp_opts)
+        exp_opts, phase_opts, sampler_opts, alchemical_region_opts = exp_opts
 
-        # Set database path
-        self._db.setup_dir = self._get_setup_dir(exp_opts)
+        # Determine output directory and create it if it doesn't exist.
+        results_dir = self._get_experiment_dir(experiment_dir)
+        if not os.path.isdir(results_dir):
+            os.makedirs(results_dir)
 
-        # Create directory and determine if we need to resume the simulation
-        results_dir = self._get_experiment_dir(exp_opts, experiment_dir)
-        resume = os.path.isdir(results_dir)
-        if self._mpicomm is None or self._mpicomm.rank == 0:
-            if not resume:
-                os.makedirs(results_dir)
-            else:
-                resume = self._check_resume_experiment(results_dir, protocol_id)
-        if self._mpicomm:  # process 0 send result to other processes
-            resume = self._mpicomm.bcast(resume, root=0)
+        # Configure logger file for this experiment.
+        utils.config_root_logger(self.options['verbose'],
+                                 os.path.join(results_dir, exp_name + '.log'))
 
-        # Configure logger for this experiment
-        utils.config_root_logger(exp_opts['verbose'], os.path.join(results_dir, exp_name + '.log'),
-                                 self._mpicomm)
+        # Export YAML file for reproducibility
+        mpi.run_single_node(0, self._generate_yaml, experiment,
+                            os.path.join(results_dir, exp_name + '.yaml'))
 
-        # Configure platform and precision
-        platform = self._configure_platform(exp_opts['platform'], exp_opts['precision'])
-
-        # Initialize simulation
-        yank = Yank(results_dir, mpicomm=self._mpicomm, platform=platform, **yank_opts)
-
-        if resume:
-            yank.resume()
+        # Get ligand resname for alchemical atom selection. If we can't
+        # find it, this is a solvation free energy calculation.
+        ligand_dsl = None
+        try:
+            # First try for systems that went through pipeline.
+            ligand_molecule_id = self._db.systems[system_id]['ligand']
+        except KeyError:
+            # Try with system from system files.
+            try:
+                ligand_dsl = self._db.systems[system_id]['ligand_dsl']
+            except KeyError:
+                # This is a solvation free energy.
+                pass
         else:
-            if self._mpicomm is None or self._mpicomm.rank == 0:
-                system_id = experiment['system']
+            # Make sure that molecule filepath points to the mol2 file
+            self._db.is_molecule_setup(ligand_molecule_id)
+            ligand_descr = self._db.molecules[ligand_molecule_id]
+            ligand_resname = utils.Mol2File(ligand_descr['filepath']).resname
+            ligand_dsl = 'resname ' + ligand_resname
 
-                # Export YAML file for reproducibility
-                self._generate_yaml(experiment, os.path.join(results_dir, exp_name + '.yaml'))
+        if ligand_dsl is None:
+            logger.debug('Cannot find ligand specification. '
+                         'Alchemically modifying the whole solute.')
+        else:
+            logger.debug('DSL string for the ligand: "{}"'.format(ligand_dsl))
 
-                # Get molecule resname for alchemical atom selection
-                if self._db.is_system_setup(system_id)[1]:  # system went through pipeline
-                    try:  # binding free energy calculation
-                        alchemical_molecule_id = self._db.systems[system_id]['ligand']
-                    except KeyError:  # partition/solvation free energy calculation
-                        alchemical_molecule_id = self._db.systems[system_id]['solute']
+        # Determine solvent DSL.
+        try:
+            solvent_dsl = self._db.systems[system_id]['solvent_dsl']
+        except KeyError:
+            solvent_dsl = 'auto'  # Topography uses common solvent resnames.
+        logger.debug('DSL string for the solvent: "{}"'.format(solvent_dsl))
 
-                    # Make sure that molecule filepath points to the mol2 file
-                    self._db.is_molecule_setup(alchemical_molecule_id)
-                    ligand_descr = self._db.molecules[alchemical_molecule_id]
-                    ligand_dsl = utils.Mol2File(ligand_descr['filepath']).resname
-                    if ligand_dsl is None:
-                        ligand_dsl = 'MOL'
-                    ligand_dsl = 'resname ' + ligand_dsl
-                else:  # system files given directly by user
-                    ligand_dsl = self._db.systems[system_id]['ligand_dsl']
-                logger.debug('DSL string for the ligand: "{}"'.format(ligand_dsl))
+        # Determine complex and solvent phase solvents
+        try:  # binding free energy calculations
+            solvent_ids = [self._db.systems[system_id]['solvent'],
+                           self._db.systems[system_id]['solvent']]
+        except KeyError:  # partition/solvation free energy calculations
+            try:
+                solvent_ids = [self._db.systems[system_id]['solvent1'],
+                               self._db.systems[system_id]['solvent2']]
+            except KeyError:  # from xml/pdb system files
+                assert 'phase1_path' in self._db.systems[system_id]
+                solvent_ids = [None, None]
 
-                # Determine complex and solvent phase solvents
-                try:  # binding free energy calculations
-                    solvent_ids = [self._db.systems[system_id]['solvent'],
-                                   self._db.systems[system_id]['solvent']]
-                except KeyError:  # partition/solvation free energy calculations
-                    try:
-                        solvent_ids = [self._db.systems[system_id]['solvent1'],
-                                       self._db.systems[system_id]['solvent2']]
-                    except KeyError:  # from xml/pdb system files
-                        assert 'phase1_path' in self._db.systems[system_id]
-                        solvent_ids = [None, None]
+        # Determine restraint
+        try:
+            restraint_type = experiment['restraint']['type']
+        except (KeyError, TypeError):  # restraint unspecified or None
+            restraint_type = None
 
-                # Determine solvent DSL.
-                try:
-                    solvent_dsl = self._db.systems[system_id]['solvent_dsl']
-                except KeyError:
-                    solvent_dsl = None
+        # Get system files.
+        system_files_paths = self._db.get_system(system_id)
+        gromacs_include_dir = self._db.systems[system_id].get('gromacs_include_dir', None)
 
-                # Get protocols as list of AlchemicalStates
-                alchemical_paths = self._get_alchemical_paths(protocol_id)
-                system_files_paths = self._db.get_system(system_id)
-                gromacs_include_dir = self._db.systems[system_id].get('gromacs_include_dir', None)
+        # Prepare Yank arguments
+        phases = [None, None]
+        # self._protocols[protocol_id] is an OrderedDict so phases are in the
+        # correct order (e.g. [complex, solvent] or [solvent1, solvent2])
+        phase_names = list(self._protocols[protocol_id].keys())
+        for i, phase_name in enumerate(phase_names):
+            # Check if we need to resume a phase. If the phase has been
+            # already created, YamlExperiment will resume from the storage.
+            phase_path = os.path.join(results_dir, phase_name + '.nc')
+            if os.path.isfile(phase_path):
+                phases[i] = phase_path
+                continue
 
-                # Prepare Yank arguments
-                phases = [None, None]
-                for i, phase_name in enumerate(self._protocols[protocol_id]):
-                    # self._protocols[protocol_id] is an OrderedDict so phases are in the
-                    # correct order (e.g. [complex, solvent] or [solvent1, solvent2])
-                    solvent_id = solvent_ids[i]
-                    positions_file_path = system_files_paths[i].position_path
-                    parameters_file_path = system_files_paths[i].parameters_path
-                    if solvent_id is None:
-                        system_options = None
-                    else:
-                        system_options = utils.merge_dict(self._db.solvents[solvent_id], exp_opts)
-                    logger.info("Reading phase {}".format(phase_name))
-                    phases[i] = pipeline.prepare_phase(positions_file_path, parameters_file_path, ligand_dsl,
-                                                       system_options, solvent_dsl=solvent_dsl,
-                                                       gromacs_include_dir=gromacs_include_dir)
-                    phases[i].name = phase_name
-                    phases[i].protocol = alchemical_paths[phase_name]
+            # Create system, topology and sampler state from system files.
+            solvent_id = solvent_ids[i]
+            positions_file_path = system_files_paths[i].position_path
+            parameters_file_path = system_files_paths[i].parameters_path
+            if solvent_id is None:
+                system_options = None
+            else:
+                system_options = utils.merge_dict(self._db.solvents[solvent_id], exp_opts)
+            logger.info("Reading phase {}".format(phase_name))
+            system, topology, sampler_state = pipeline.read_system_files(
+                positions_file_path, parameters_file_path, system_options,
+                gromacs_include_dir=gromacs_include_dir)
 
-                for phase in phases:
-                    if len(phase.atom_indices['ligand']) == 0:
-                        raise RuntimeError('DSL string "{}" did not select any atom for '
-                                           'the ligand in phase {}.'.format(ligand_dsl, phase.name))
+            # Identify system components. There is a ligand only in the complex phase.
+            if i == 0:
+                ligand_atoms = ligand_dsl
+            else:
+                ligand_atoms = None
+            topography = Topography(topology, ligand_atoms=ligand_atoms,
+                                    solvent_atoms=solvent_dsl)
 
-                # Dump analysis script
-                analysis = [[phases[0].name, 1], [phases[1].name, -1]]
-                analysis_script_path = os.path.join(results_dir, 'analysis.yaml')
-                with open(analysis_script_path, 'w') as f:
-                    yaml.dump(analysis, f)
+            # Create reference thermodynamic state.
+            if system.usesPeriodicBoundaryConditions():
+                pressure = exp_opts['pressure']
+            else:
+                pressure = None
+            thermodynamic_state = mmtools.states.ThermodynamicState(system, exp_opts['temperature'],
+                                                                    pressure=pressure)
 
-                # Create thermodynamic state
-                thermodynamic_state = ThermodynamicState(temperature=exp_opts['temperature'],
-                                                         pressure=exp_opts['pressure'])
+            # Start from AlchemicalPhase default alchemical region
+            # and modified it according to the user options.
+            phase_protocol = self._protocols[protocol_id][phase_name]['alchemical_path']
+            alchemical_region = AlchemicalPhase._build_default_alchemical_region(system, topography,
+                                                                                 phase_protocol)
+            alchemical_region = alchemical_region._replace(**alchemical_region_opts)
 
-                # Determine restraint
-                try:
-                    restraint_type = experiment['restraint']['type']
-                except (KeyError, TypeError):  # restraint unspecified or None
-                    restraint_type = None
+            # Apply restraint only if this is the first phase. AlchemicalPhase
+            # will take care of raising an error if the phase type does not support it.
+            if i == 0 and restraint_type is not None:
+                restraint = restraints.create_restraint(restraint_type)
+            else:
+                restraint = None
 
-                # Create new simulation
-                yank.create(thermodynamic_state, *phases, restraint_type=restraint_type)
+            # Create MCMC moves and sampler. Apply MC rotation displacement to ligand.
+            if len(topography.ligand_atoms) > 0:
+                move_list = [
+                    mmtools.mcmc.MCDisplacementMove(displacement_sigma=exp_opts['mc_displacement_sigma'],
+                                                    atom_subset=topography.ligand_atoms),
+                    mmtools.mcmc.MCRotationMove(atom_subset=topography.ligand_atoms)
+                ]
+            else:
+                move_list = []
+            move_list.append(mmtools.mcmc.LangevinDynamicsMove(timestep=exp_opts['timestep'],
+                                                               collision_rate=exp_opts['collision_rate'],
+                                                               n_steps=exp_opts['nsteps_per_iteration'],
+                                                               reassign_velocities=True,
+                                                               n_restart_attempts=6))
+            mcmc_move = mmtools.mcmc.SequenceMove(move_list=move_list)
+            sampler = repex.ReplicaExchange(mcmc_moves=mcmc_move, **sampler_opts)
 
-            # Run the simulation
-            if self._mpicomm:  # wait for the simulation to be prepared
-                debug_msg = 'Node {}/{}: MPI barrier'.format(self._mpicomm.rank, self._mpicomm.size)
-                logger.debug(debug_msg + ' - waiting for the simulation to be created.')
-                self._mpicomm.barrier()
-                if self._mpicomm.rank != 0:
-                    yank.resume()  # resume from netcdf file created by root node
-        yank.run()
+            # Create phases.
+            phases[i] = YamlPhaseFactory(sampler, thermodynamic_state, sampler_state,
+                                         topography, phase_protocol, storage=phase_path,
+                                         restraint=restraint, alchemical_regions=alchemical_region,
+                                         **phase_opts)
+
+        # Dump analysis script
+        mpi.run_single_node(0, self._save_analysis_script, results_dir, phase_names)
+
+        # Return new YamlExperiment object.
+        return YamlExperiment(phases, sampler_opts['number_of_iterations'],
+                              exp_opts['switch_phase_every'])
 
 
 if __name__ == "__main__":

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -43,103 +43,6 @@ HIGHEST_VERSION = '1.2'  # highest version of YAML syntax
 # UTILITY FUNCTIONS
 # =============================================================================
 
-def compute_min_dist(mol_positions, *args):
-    """Compute the minimum distance between a molecule and a set of other molecules.
-
-    All the positions must be expressed in the same unit of measure.
-
-    Parameters
-    ----------
-    mol_positions : numpy.ndarray
-        An Nx3 array where, N is the number of atoms, containing the positions of
-        the atoms of the molecule for which we want to compute the minimum distance
-        from the others
-
-    Other parameters
-    ----------------
-    args
-        A series of numpy.ndarrays containing the positions of the atoms of the other
-        molecules
-
-    Returns
-    -------
-    min_dist : float
-        The minimum distance between mol_positions and the other set of positions
-
-    """
-    for pos1 in args:
-        # Compute squared distances
-        # Each row is an array of distances from a mol2 atom to all mol1 atoms
-        distances2 = np.array([((pos1 - pos2)**2).sum(1) for pos2 in mol_positions])
-
-        # Find closest atoms and their distance
-        min_idx = np.unravel_index(distances2.argmin(), distances2.shape)
-        try:
-            min_dist = min(min_dist, np.sqrt(distances2[min_idx]))
-        except UnboundLocalError:
-            min_dist = np.sqrt(distances2[min_idx])
-    return min_dist
-
-
-def compute_min_max_dist(mol_positions, *args):
-    """Compute minimum and maximum distances between a molecule and a set of
-    other molecules.
-
-    All the positions must be expressed in the same unit of measure.
-
-    Parameters
-    ----------
-    mol_positions : numpy.ndarray
-        An Nx3 array where, N is the number of atoms, containing the positions of
-        the atoms of the molecule for which we want to compute the minimum distance
-        from the others
-
-    Other parameters
-    ----------------
-    args
-        A series of numpy.ndarrays containing the positions of the atoms of the other
-        molecules
-
-    Returns
-    -------
-    min_dist : float
-        The minimum distance between mol_positions and the atoms of the other positions
-    max_dist : float
-        The maximum distance between mol_positions and the atoms of the other positions
-
-    Examples
-    --------
-    >>> mol1_pos = np.array([[-1, -1, -1], [1, 1, 1]], np.float)
-    >>> mol2_pos = np.array([[2, 2, 2], [2, 4, 5]], np.float)  # determine min dist
-    >>> mol3_pos = np.array([[3, 3, 3], [3, 4, 5]], np.float)  # determine max dist
-    >>> min_dist, max_dist = compute_min_max_dist(mol1_pos, mol2_pos, mol3_pos)
-    >>> min_dist == np.linalg.norm(mol1_pos[1] - mol2_pos[0])
-    True
-    >>> max_dist == np.linalg.norm(mol1_pos[1] - mol3_pos[1])
-    True
-
-    """
-    min_dist = None
-
-    for arg_pos in args:
-        # Compute squared distances of all atoms. Each row is an array
-        # of distances from an atom in arg_pos to all the atoms in arg_pos
-        distances2 = np.array([((mol_positions - atom)**2).sum(1) for atom in arg_pos])
-
-        # Find distances of each arg_pos atom to mol_positions
-        distances2 = np.amin(distances2, axis=1)
-
-        # Find closest and distant atom
-        if min_dist is None:
-            min_dist = np.sqrt(distances2.min())
-            max_dist = np.sqrt(distances2.max())
-        else:
-            min_dist = min(min_dist, np.sqrt(distances2.min()))
-            max_dist = max(max_dist, np.sqrt(distances2.max()))
-
-    return min_dist, max_dist
-
-
 def remove_overlap(mol_positions, *args, **kwargs):
     """Remove any eventual overlap between a molecule and a set of others.
 
@@ -178,7 +81,7 @@ def remove_overlap(mol_positions, *args, **kwargs):
     min_distance = kwargs.get('min_distance', 1.0)
 
     # Try until we have a non-overlapping conformation w.r.t. all fixed molecules
-    while compute_min_dist(x, *args) <= min_distance:
+    while pipeline.compute_min_dist(x, *args) <= min_distance:
         # Compute center of geometry
         x0 = x.mean(0)
 
@@ -232,7 +135,7 @@ def pack_transformation(mol1_pos, mol2_pos, min_distance, max_distance):
 
     # Try until we have a non-overlapping conformation w.r.t. all fixed molecules
     i = 0
-    min_dist, max_dist = compute_min_max_dist(mol1_pos, mol2_pos)
+    min_dist, max_dist = pipeline.compute_min_max_dist(mol1_pos, mol2_pos)
     while min_dist < min_distance or max_distance <= max_dist:
         # Select random atom of fixed molecule and use it to propose new x0 position
         mol1_atom_idx = np.random.random_integers(0, len(mol1_pos) - 1)
@@ -243,7 +146,7 @@ def pack_transformation(mol1_pos, mol2_pos, min_distance, max_distance):
 
         # Apply random transformation and test
         x = ((Rq * np.matrix(mol2_pos - x0).T).T + x0).A + translation
-        min_dist, max_dist = compute_min_max_dist(mol1_pos, x)
+        min_dist, max_dist = pipeline.compute_min_max_dist(mol1_pos, x)
 
         # Check n iterations
         i += 1

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -231,6 +231,16 @@ class IMultiStateSampler(mmtools.utils.SubhookedABCMeta):
 
     """
 
+    @property
+    def number_of_iterations(self):
+        """int: the total number of iterations to run."""
+        pass
+
+    @abc.abstractproperty
+    def iteration(self):
+        """int: the current iteration."""
+        pass
+
     @abc.abstractproperty
     def metadata(self):
         """dict: a copy of the metadata dictionary passed on creation."""
@@ -381,6 +391,20 @@ class AlchemicalPhase(object):
         # Resume sampler and return new AlchemicalPhase.
         sampler = cls.from_storage(storage)
         return AlchemicalPhase(sampler)
+
+    @property
+    def iteration(self):
+        """int: the current iteration (read-only)."""
+        return self._sampler.iteration
+
+    @property
+    def number_of_iterations(self):
+        """int: the total number of iterations to run."""
+        return self._sampler.number_of_iterations
+
+    @number_of_iterations.setter
+    def number_of_iterations(self, value):
+        self._sampler.number_of_iterations = value
 
     def create(self, thermodynamic_state, sampler_states, topography, protocol, storage,
                restraint=None, anisotropic_dispersion_cutoff=None,


### PR DESCRIPTION
This is the last big chunk of modifications! Tests are not supposed to pass until this is merged with the changes in the `new-repex` branch. I'll start running validation simulations as soon as we have gathered all the pieces into the branch `development`. Here's a list of changes in this PR:

**Bugfixes**
- Ions of any charge (instead of just single charge) are supported when figuring out which counterions to alchemically modify to keep the periodic solvation box neutral with charged ligands.

**New features**
- Implemented `AlchemicalPhase` that wraps around a generic sampler. The preliminary minimization of the positions in the reference state discussed in #643 is implemented in `AlchemicalPhase.minimize`.
- `YamlBuilder` now offer two methods `build_experiments` and `run_experiments`. The former sets up and iterates over all the possible experiments, which are provided as `YamlExperiment` objects. These can be further tweaked through the API to set things like the propagator, custom restraints, and others that is not possible to set through the YAML script. `run_experiments` does what `builds_experiments` was doing before.

**Changes**
- Removed options `show_mixing_statistics`, `show_energies`, `online_analysis`, `online_analysis_min_iterations` from YAML syntax which are not supported by `ReplicaExchange` anymore.
- Divided the `YamlBuilder` options in general options (e.g. output directory, verbose) from experiment options (e.g. temperature/pressure, timestep), where the former cannot be specified in the experiment section (and thus they cannot be combinatorially expanded). This came with a lot of code simplification and we drop support for use cases that don't actually make much sense.
- `ligand_dsl` in system files section is now used only for ligand-receptor systems and it has thus become an optional attribute. If a ligand is specified but receptor atoms are not found, an error is raised.
- Updated default values of `collision_rate`: set to 1/ps for production and 90/ps for equilibration.
- Two new options `switch_phase_every` (experiment option), and `switch_experiment_every` that allow to make progress on multiple phases/experiments together (name to be discussed).
