### PR TITLE
Fix extract_trajectory from nc file

### DIFF
--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1114,8 +1114,7 @@ def is_openeye_installed(oetools=('oechem', 'oequacpac', 'oeiupac', 'oeomega')):
                 try:
                     module = importlib.import_module('openeye', tool)
                 except SystemError: # Python 3.4 relative import fix
-                    import openeye
-                    module = importlib.import_module('openeye', tool)
+                    module = importlib.import_module('openeye.' + tool)
                 # Check that we have the license
                 if not getattr(module, tools_license[tool])():
                     raise ImportError

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1111,7 +1111,11 @@ def is_openeye_installed(oetools=('oechem', 'oequacpac', 'oeiupac', 'oeomega')):
         for tool in oetools:
             if tool in tool_keys:
                 # Try loading the module
-                module = importlib.import_module('openeye', tool)
+                try:
+                    module = importlib.import_module('openeye', tool)
+                except SystemError: # Python 3.4 relative import fix
+                    import openeye
+                    module = importlib.import_module('openeye', tool)
                 # Check that we have the license
                 if not getattr(module, tools_license[tool])():
                     raise ImportError


### PR DESCRIPTION
The function was broken when we broke backwards compatibility of ReplicaExchange storage format.

This is only a quick and dirty solution since we have other priorities. We should rewrite this after the analysis API will be stable.