### PR TITLE
Add support for non-TIP3P solvation

### DIFF
--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -281,20 +281,20 @@ def test_TLeap_script():
 
     tleap = TLeap()
     tleap.load_parameters('oldff/leaprc.ff99SBildn', 'leaprc.gaff')
-    tleap.load_group(name='receptor', file_path='receptor.pdbfixer.pdb')
+    tleap.load_unit(name='receptor', file_path='receptor.pdbfixer.pdb')
     tleap.load_parameters('ligand.gaff.frcmod')
     tleap.load_parameters('ligand.gaff.frcmod')  # tLeap should not load this twice
-    tleap.load_group(name='ligand', file_path='path/to/ligand.gaff.mol2')
+    tleap.load_unit(name='ligand', file_path='path/to/ligand.gaff.mol2')
     tleap.transform('ligand', np.array([[1, 0, 0, 6], [0, -1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]))
     tleap.combine('complex', 'receptor', 'ligand')
-    tleap.solvate(group='complex', water_model='TIP3PBOX', clearance=10.0)
+    tleap.solvate(unit='complex', solvent_model='TIP3PBOX', clearance=10.0)
     tleap.add_commands('check complex', 'charge complex')
     tleap.new_section('New section')
-    tleap.save_group(group='complex', output_path='complex.prmtop')
-    tleap.save_group(group='complex', output_path='complex.pdb')
-    tleap.solvate(group='ligand', water_model='TIP3PBOX', clearance=10.0)
-    tleap.save_group(group='ligand', output_path='solvent.inpcrd')
-    tleap.save_group(group='ligand', output_path='solvent.pdb')
+    tleap.save_unit(unit='complex', output_path='complex.prmtop')
+    tleap.save_unit(unit='complex', output_path='complex.pdb')
+    tleap.solvate(unit='ligand', solvent_model='TIP3PBOX', clearance=10.0)
+    tleap.save_unit(unit='ligand', output_path='solvent.inpcrd')
+    tleap.save_unit(unit='ligand', output_path='solvent.pdb')
 
     assert tleap.script == expected_script
 
@@ -307,12 +307,12 @@ def test_TLeap_export_run():
 
     tleap = TLeap()
     tleap.load_parameters('oldff/leaprc.ff99SB', 'leaprc.gaff')
-    tleap.load_group(name='benzene', file_path=benzene_gaff)
+    tleap.load_unit(name='benzene', file_path=benzene_gaff)
     tleap.load_parameters(benzene_frcmod)
 
     with omt.utils.temporary_directory() as tmp_dir:
         output_path = os.path.join(tmp_dir, 'benzene')
-        tleap.save_group(group='benzene', output_path=output_path + '.prmtop')
+        tleap.save_unit(unit='benzene', output_path=output_path + '.prmtop')
 
         export_path = os.path.join(tmp_dir, 'leap.in')
         tleap.export_script(export_path)

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -20,9 +20,10 @@ import unittest
 import tempfile
 import itertools
 
-from nose.tools import assert_raises
+import mdtraj
+
+from nose.tools import assert_raises, assert_equal
 from nose.plugins.attrib import attr
-from mdtraj.formats.mol2 import mol2_to_dataframes
 
 from yank.yamlbuild import *
 
@@ -362,6 +363,7 @@ def test_validation_correct_solvents():
     """Correct solvents YAML validation."""
     solvents = [
         {'nonbonded_method': 'NoCutoff', 'nonbonded_cutoff': '3*nanometers'},
+        {'nonbonded_method': 'PME', 'solvent_model': 'tip4pew'},
         {'nonbonded_method': 'PME', 'clearance': '3*angstroms'},
         {'nonbonded_method': 'PME'},
         {'nonbonded_method': 'NoCutoff', 'implicit_solvent': 'OBC2'},
@@ -378,6 +380,7 @@ def test_validation_wrong_solvents():
     """YAML validation raises exception with wrong solvents."""
     solvents = [
         {'nonbonded_cutoff: 3*nanometers'},
+        {'nonbonded_method': 'PME', 'solvent_model': 'unknown_solvent_model'},
         {'nonbonded_method': 'PME', 'clearance': '3*angstroms', 'implicit_solvent': 'OBC2'},
         {'nonbonded_method': 'NoCutoff', 'blabla': '3*nanometers'},
         {'nonbonded_method': 'NoCutoff', 'implicit_solvent': 'OBX2'},
@@ -721,9 +724,9 @@ def test_setup_name_smiles_openeye_charges():
             assert os.path.getsize(output_basepath + '.gaff.mol2') > 0
             assert os.path.getsize(output_basepath + '.frcmod') > 0
 
-            atoms_frame, _ = mol2_to_dataframes(output_basepath + '.mol2')
+            atoms_frame, _ = mdtraj.formats.mol2.mol2_to_dataframes(output_basepath + '.mol2')
             input_charges = atoms_frame['charge']
-            atoms_frame, _ = mol2_to_dataframes(output_basepath + '.gaff.mol2')
+            atoms_frame, _ = mdtraj.formats.mol2.mol2_to_dataframes(output_basepath + '.gaff.mol2')
             output_charges = atoms_frame['charge']
 
             # With openeye:am1bcc charges, the final charges should be unaltered
@@ -1485,6 +1488,35 @@ def test_setup_explicit_solvation_system():
             assert os.path.getsize(prmtop_path) > 0
             assert os.path.getsize(inpcrd_path) > 0
             assert found_resnames == expected_resnames[phase]
+
+
+def test_setup_solvent_models():
+    """Test the solvation with different solvent models works."""
+    with mmtools.utils.temporary_directory() as tmp_dir:
+        template_script = get_template_script(tmp_dir)
+
+        # Setup solvation system and reduce clearance to make test faster.
+        template_script['systems'] = {
+            'system1':
+                {'solute': 'toluene', 'solvent1': 'PME', 'solvent2': 'vacuum',
+                 'leap': {'parameters': ['leaprc.gaff', 'oldff/leaprc.ff14SB']}}}
+        template_script['solvents']['PME']['clearance'] = '3.0 * angstrom'
+        del template_script['experiments']
+
+        # Test solvent models.
+        for solvent_model in ['tip3p', 'tip3pfb', 'tip4pew', 'tip5p']:
+            yaml_script = copy.deepcopy(template_script)
+            yaml_script['solvents']['PME']['solvent_model'] = solvent_model
+            yaml_script['options']['setup_dir'] = solvent_model
+            yaml_builder = YamlBuilder(yaml_script)
+
+            # Infer number of expected atoms per water molecule from model.
+            expected_water_n_atoms = int(list(filter(str.isdigit, solvent_model))[0])
+
+            # Setup the system and check that water residues have expected number of particles.
+            prmtop_filepath = yaml_builder._db.get_system('system1')[0].parameters_path
+            topology = mdtraj.load_prmtop(prmtop_filepath)
+            yield assert_equal, topology.residue(1).n_atoms, expected_water_n_atoms
 
 
 def test_setup_multiple_parameters_system():

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1246,7 +1246,7 @@ class TLeap:
             # Update loaded parameters cache
             self._loaded_parameters.add(par_file)
 
-    def load_group(self, name, file_path):
+    def load_unit(self, name, file_path):
         extension = os.path.splitext(file_path)[1]
         if extension == '.mol2':
             load_command = 'loadMol2'
@@ -1260,18 +1260,18 @@ class TLeap:
         # Update list of input files to copy in temporary folder before run
         self._file_paths[local_name] = file_path
 
-    def combine(self, group, *args):
+    def combine(self, unit, *args):
         components = ' '.join(args)
-        self.add_commands('{} = combine {{{{ {} }}}}'.format(group, components))
+        self.add_commands('{} = combine {{{{ {} }}}}'.format(unit, components))
 
     def add_ions(self, unit, ion, num_ions=0):
         self.add_commands('addIons2 {} {} {}'.format(unit, ion, num_ions))
 
-    def solvate(self, group, water_model, clearance):
-        self.add_commands('solvateBox {} {} {} iso'.format(group, water_model,
+    def solvate(self, unit, solvent_model, clearance):
+        self.add_commands('solvateBox {} {} {} iso'.format(unit, solvent_model,
                                                            str(clearance)))
 
-    def save_group(self, group, output_path):
+    def save_unit(self, unit, output_path):
         file_name = os.path.basename(output_path)
         file_name, extension = os.path.splitext(file_name)
         local_name = 'molo{}'.format(len(self._file_paths))
@@ -1282,7 +1282,7 @@ class TLeap:
         # Add command
         if extension == '.prmtop' or extension == '.inpcrd':
             local_name2 = 'molo{}'.format(len(self._file_paths))
-            command = 'saveAmberParm ' + group + ' {{{}}} {{{}}}'
+            command = 'saveAmberParm ' + unit + ' {{{}}} {{{}}}'
 
             # Update list of output files with the one not explicit
             if extension == '.inpcrd':
@@ -1296,7 +1296,7 @@ class TLeap:
 
             self.add_commands(command)
         elif extension == '.pdb':
-            self.add_commands('savePDB {} {{{}}}'.format(group, local_name))
+            self.add_commands('savePDB {} {{{}}}'.format(unit, local_name))
         else:
             raise ValueError('cannot export format {} from tLeap'.format(extension[1:]))
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1316,6 +1316,14 @@ class TLeap:
 
     def run(self):
         """Run script and return warning messages in leap log file."""
+
+        def create_dirs_and_copy(path_to_copy, copied_path):
+            """Create directories before copying the file."""
+            output_dir_path = os.path.dirname(copied_path)
+            if not os.path.isdir(output_dir_path):
+                os.makedirs(output_dir_path)
+            shutil.copy(path_to_copy, copied_path)
+
         # Transform paths in absolute paths since we'll change the working directory
         input_files = {local + os.path.splitext(path)[1]: os.path.abspath(path)
                        for local, path in listitems(self._file_paths) if 'moli' in local}
@@ -1346,13 +1354,13 @@ class TLeap:
                 first_output_name = os.path.basename(first_output_path).split('.')[0]
                 first_output_dir = os.path.dirname(first_output_path)
                 log_path = os.path.join(first_output_dir, first_output_name + '.leap.log')
-                shutil.copy('leap.log', log_path)
+                create_dirs_and_copy('leap.log', log_path)
 
             # Copy back output files. If something goes wrong, some files may not exist
             error_msg = ''
             try:
                 for local_file, file_path in listitems(output_files):
-                    shutil.copy(local_file, file_path)
+                    create_dirs_and_copy(local_file, file_path)
             except IOError:
                 error_msg = "Could not create one of the system files."
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -914,7 +914,7 @@ class SetupDatabase:
         # ------------------------------------
         tleap.new_section('Load molecules')
         for mol_id in molecule_ids:
-            tleap.load_group(name=mol_id, file_path=self.molecules[mol_id]['filepath'])
+            tleap.load_unit(name=mol_id, file_path=self.molecules[mol_id]['filepath'])
 
         if len(molecule_ids) > 1:
             # Check that molecules don't have clashing atoms. Also, if the ligand
@@ -990,7 +990,7 @@ class SetupDatabase:
                 tleap.load_parameters('frcmod.' + solvent_model)
             leap_solvent_model = _OPENMM_LEAP_SOLVENT_MODELS_MAP[solvent_model]
             clearance = float(solvent['clearance'].value_in_unit(unit.angstroms))
-            tleap.solvate(group=unit_to_solvate, water_model=leap_solvent_model, clearance=clearance)
+            tleap.solvate(unit=unit_to_solvate, solvent_model=leap_solvent_model, clearance=clearance)
 
         # Check charge
         tleap.new_section('Check charge')
@@ -1008,8 +1008,8 @@ class SetupDatabase:
 
         # Save prmtop, inpcrd and reference pdb files
         tleap.new_section('Save prmtop and inpcrd files')
-        tleap.save_group(unit_to_solvate, system_file_path)
-        tleap.save_group(unit_to_solvate, base_file_path + '.pdb')
+        tleap.save_unit(unit_to_solvate, system_file_path)
+        tleap.save_unit(unit_to_solvate, base_file_path + '.pdb')
 
         # Save tleap script for reference
         tleap.export_script(base_file_path + '.leap.in')


### PR DESCRIPTION
Fix #378: Add support for non-TIP3P explicit solvent models.

Should be ready for review if tests pass.