### PR TITLE
Checkpointing Feature

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -64,13 +64,13 @@ def generate_phase_name(current_name, name_list):
     return name
 
 
-def get_analyzer(file_path):
+def get_analyzer(file_base_path):
     """
     Utility function to convert storage file to a Reporter and Analyzer by reading the data on file
 
     For now this is mostly placeholder functions, but creates the API for the user to work with.
     """
-    reporter = Reporter(file_path)  # Eventually extend this to get more reporters, but for now simple placeholder\
+    reporter = Reporter(file_base_path)  # Eventually extend this to get more reporters, but for now simple placeholder\
     """
     storage = infer_storage_format_from_extension('complex.nc')  # This is always going to be nc for now.
     metadata = storage.metadata
@@ -776,7 +776,7 @@ class RepexPhase(YankPhaseAnalyzer):
 
         """
         if self._computed_observables['standard_state_correction'] is None:
-            ssc = self._reporter.read_dict('metadata')['standard_state_correction']
+            ssc = self._reporter.read_dict('metadata', storage='checkpoint')['standard_state_correction']
             self._computed_observables['standard_state_correction'] = ssc
         return self._computed_observables['standard_state_correction']
 
@@ -1777,7 +1777,7 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
     # Import simulation data
     try:
         reporter = Reporter(nc_path, open_mode='r')
-        metadata = reporter.read_dict('metadata')
+        metadata = reporter.read_dict('metadata', storage='checkpoint')
         reference_system = mmtools.utils.deserialize(metadata['reference_state']).system
         topology = mmtools.utils.deserialize(metadata['topography']).topology
 
@@ -1786,8 +1786,8 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
         logger.info('Detected periodic boundary conditions: {}'.format(is_periodic))
 
         # Get dimensions
-        n_iterations = reporter._storage.variables['positions'].shape[0]
-        n_atoms = reporter._storage.variables['positions'].shape[2]
+        n_iterations = reporter._storage_checkpoint.variables['positions'].shape[0]
+        n_atoms = reporter._storage_checkpoint.variables['positions'].shape[2]
         logger.info('Number of iterations: {}, atoms: {}'.format(n_iterations, n_atoms))
 
         # Determine frames to extract
@@ -1805,39 +1805,43 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
 
         # Discard equilibration samples
         if discard_equilibration:
-            u_n = extract_u_n(reporter._storage)[frame_indices]
+            u_n = extract_u_n(reporter._storage_analysis)[frame_indices]
             n_equil, g, n_eff = timeseries.detectEquilibration(u_n)
             logger.info(("Discarding initial {} equilibration samples (leaving {} "
                          "effectively uncorrelated samples)...").format(n_equil, n_eff))
             frame_indices = frame_indices[n_equil:-1]
 
+        written_indices = []
+        for frame in frame_indices:
+            if reporter.get_previous_checkpoint(frame):
+                written_indices.append(frame)
         # Extract state positions and box vectors
-        positions = np.zeros((len(frame_indices), n_atoms, 3))
+        positions = np.zeros((len(written_indices), n_atoms, 3))
         if is_periodic:
-            box_vectors = np.zeros((len(frame_indices), 3, 3))
+            box_vectors = np.zeros((len(written_indices), 3, 3))
         if state_index is not None:
             logger.info('Extracting positions of state {}...'.format(state_index))
 
             # Deconvolute state indices
-            state_indices = np.zeros(len(frame_indices))
-            for i, iteration in enumerate(frame_indices):
-                replica_indices = reporter._storage.variables['states'][iteration, :]
+            state_indices = np.zeros(len(written_indices))
+            for i, iteration in enumerate(written_indices):
+                replica_indices = reporter._storage_analysis.variables['states'][iteration, :]
                 state_indices[i] = np.where(replica_indices == state_index)[0][0]
 
             # Extract state positions and box vectors
-            for i, iteration in enumerate(frame_indices):
+            for i, iteration in enumerate(written_indices):
                 replica_index = state_indices[i]
-                positions[i, :, :] = reporter._storage.variables['positions'][iteration, replica_index, :, :].astype(np.float32)
+                positions[i, :, :] = reporter._storage_checkpoint.variables['positions'][i, replica_index, :, :].astype(np.float32)
                 if is_periodic:
-                    box_vectors[i, :, :] = reporter._storage.variables['box_vectors'][iteration, replica_index, :, :].astype(np.float32)
+                    box_vectors[i, :, :] = reporter._storage_checkpoint.variables['box_vectors'][i, replica_index, :, :].astype(np.float32)
 
         else:  # Extract replica positions and box vectors
             logger.info('Extracting positions of replica {}...'.format(replica_index))
 
-            for i, iteration in enumerate(frame_indices):
-                positions[i, :, :] = reporter._storage.variables['positions'][iteration, replica_index, :, :].astype(np.float32)
+            for i, iteration in enumerate(written_indices):
+                positions[i, :, :] = reporter._storage_checkpoint.variables['positions'][i, replica_index, :, :].astype(np.float32)
                 if is_periodic:
-                    box_vectors[i, :, :] = reporter._storage.variables['box_vectors'][iteration, replica_index, :, :].astype(np.float32)
+                    box_vectors[i, :, :] = reporter._storage_checkpoint.variables['box_vectors'][i, replica_index, :, :].astype(np.float32)
     finally:
         reporter.close()
 

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -1733,7 +1733,7 @@ def analyze(source_directory):
 # Extract trajectory from NetCDF4 file
 # ==============================================================================
 
-def extract_trajectory(output_path, nc_base_path, state_index=None, replica_index=None,
+def extract_trajectory(output_path, nc_path, nc_checkpoint_file=None, state_index=None, replica_index=None,
                        start_frame=0, end_frame=-1, skip_frame=1, keep_solvent=True,
                        discard_equilibration=False, image_molecules=False):
     """Extract phase trajectory from the NetCDF4 file.
@@ -1743,8 +1743,12 @@ def extract_trajectory(output_path, nc_base_path, state_index=None, replica_inde
     output_path : str
         Path to the trajectory file to be created. The extension of the file
         determines the format.
-    nc_base_path : str
-        Path to the base name of the NetCDF4 files containing the trajectory.
+    nc_path : str
+        Path to the primary nc_file storing the analysis options
+    nc_checkpoint_file : str or None, Optional
+        File name of the checkpoint file housing the main trajectory
+        Used if the checkpoint file is differently named from the default one chosen by the nc_path file.
+        Default: None
     state_index : int, optional
         The index of the alchemical state for which to extract the trajectory.
         One and only one between state_index and replica_index must be not None
@@ -1771,12 +1775,12 @@ def extract_trajectory(output_path, nc_base_path, state_index=None, replica_inde
     if (state_index is None) == (replica_index is None):
         raise ValueError('One and only one between "state_index" and '
                          '"replica_index" must be specified.')
-    if not os.path.isfile(nc_base_path):
-        raise ValueError('Cannot find file {}'.format(nc_base_path))
+    if not os.path.isfile(nc_path):
+        raise ValueError('Cannot find file {}'.format(nc_path))
 
     # Import simulation data
     try:
-        reporter = Reporter(nc_base_path, open_mode='r')
+        reporter = Reporter(nc_path, open_mode='r', checkpoint_storage_file=nc_checkpoint_file)
         metadata = reporter.read_dict('metadata')
         reference_system = mmtools.utils.deserialize(metadata['reference_state']).system
         topology = mmtools.utils.deserialize(metadata['topography']).topology

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -1733,7 +1733,7 @@ def analyze(source_directory):
 # Extract trajectory from NetCDF4 file
 # ==============================================================================
 
-def extract_trajectory(output_path, nc_path, state_index=None, replica_index=None,
+def extract_trajectory(output_path, nc_base_path, state_index=None, replica_index=None,
                        start_frame=0, end_frame=-1, skip_frame=1, keep_solvent=True,
                        discard_equilibration=False, image_molecules=False):
     """Extract phase trajectory from the NetCDF4 file.
@@ -1743,8 +1743,8 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
     output_path : str
         Path to the trajectory file to be created. The extension of the file
         determines the format.
-    nc_path : str
-        Path to the NetCDF4 file containing the trajectory.
+    nc_base_path : str
+        Path to the base name of the NetCDF4 files containing the trajectory.
     state_index : int, optional
         The index of the alchemical state for which to extract the trajectory.
         One and only one between state_index and replica_index must be not None
@@ -1771,12 +1771,12 @@ def extract_trajectory(output_path, nc_path, state_index=None, replica_index=Non
     if (state_index is None) == (replica_index is None):
         raise ValueError('One and only one between "state_index" and '
                          '"replica_index" must be specified.')
-    if not os.path.isfile(nc_path):
-        raise ValueError('Cannot find file {}'.format(nc_path))
+    if not os.path.isfile(nc_base_path):
+        raise ValueError('Cannot find file {}'.format(nc_base_path))
 
     # Import simulation data
     try:
-        reporter = Reporter(nc_path, open_mode='r')
+        reporter = Reporter(nc_base_path, open_mode='r')
         metadata = reporter.read_dict('metadata', storage='checkpoint')
         reference_system = mmtools.utils.deserialize(metadata['reference_state']).system
         topology = mmtools.utils.deserialize(metadata['topography']).topology

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -776,7 +776,7 @@ class RepexPhase(YankPhaseAnalyzer):
 
         """
         if self._computed_observables['standard_state_correction'] is None:
-            ssc = self._reporter.read_dict('metadata', storage='checkpoint')['standard_state_correction']
+            ssc = self._reporter.read_dict('metadata')['standard_state_correction']
             self._computed_observables['standard_state_correction'] = ssc
         return self._computed_observables['standard_state_correction']
 
@@ -1777,7 +1777,7 @@ def extract_trajectory(output_path, nc_base_path, state_index=None, replica_inde
     # Import simulation data
     try:
         reporter = Reporter(nc_base_path, open_mode='r')
-        metadata = reporter.read_dict('metadata', storage='checkpoint')
+        metadata = reporter.read_dict('metadata')
         reference_system = mmtools.utils.deserialize(metadata['reference_state']).system
         topology = mmtools.utils.deserialize(metadata['topography']).topology
 

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -27,7 +27,7 @@ YANK analyze
 Usage:
   yank analyze (-s STORE | --store=STORE) [-v | --verbose]
   yank analyze report (-s STORE | --store=STORE) (-o REPORT | --output=REPORT)
-  yank analyze extract-trajectory --netcdf=FILEPATH (--state=STATE | --replica=REPLICA) --trajectory=FILEPATH [--start=START_FRAME] [--skip=SKIP_FRAME] [--end=END_FRAME] [--nosolvent] [--discardequil] [--imagemol] [-v | --verbose]
+  yank analyze extract-trajectory --netcdf=FILEPATH [--checkpoint=FILEPATH ] (--state=STATE | --replica=REPLICA) --trajectory=FILEPATH [--start=START_FRAME] [--skip=SKIP_FRAME] [--end=END_FRAME] [--nosolvent] [--discardequil] [--imagemol] [-v | --verbose]
 
 Description:
   Analyze the data to compute Free Energies OR extract the trajectory from the NetCDF file into a common fortmat.
@@ -41,6 +41,7 @@ YANK Health Report Arguments:
 
 Extract Trajectory Required Arguments:
   --netcdf=FILEPATH             Path to the NetCDF file.
+  --checkpoint=FILEPATH         Path to the NetCDF checkpoint file if not the default name inferned from "netcdf" option
   --state=STATE_IDX             Index of the alchemical state for which to extract the trajectory
   --replica=REPLICA_IDX         Index of the replica for which to extract the trajectory
   --trajectory=FILEPATH         Path to the trajectory file to create (extension determines the format)
@@ -102,6 +103,8 @@ def dispatch_extract_trajectory(args):
         kwargs['discard_equilibration'] = True
     if args['--imagemol']:
         kwargs['image_molecules'] = True
+    if args['--checkpoint']:
+        kwargs["nc_checkpoint_file"] = args['--checkpoint']
 
     # Extract trajectory
     analyze.extract_trajectory(output_path, nc_path, **kwargs)

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -917,7 +917,7 @@ class ReplicaExchange(object):
     class while the simulation is running. This reads the SamplerStates of every
     run iteration.
 
-    >>> reporter = Reporter(storage=storage_path, open_mode='r')
+    >>> reporter = Reporter(storage=storage_path, open_mode='r', checkpoint_interval=1)
     >>> sampler_states = reporter.read_sampler_states(iteration=range(1, 4))
     >>> len(sampler_states)
     3
@@ -1265,7 +1265,7 @@ class ReplicaExchange(object):
         self._display_citations()
 
         # Initialize reporter file.
-        self._reporter = Reporter(storage_base, open_mode=None)  # This is open only in node 0.
+        self._reporter = Reporter(storage_base, open_mode=None, checkpoint_interval=checkpoint_interval)  # This is open only in node 0.
         self._initialize_reporter()
 
     @mmtools.utils.with_timer('Minimizing all replicas')

--- a/Yank/reports/__init__.py
+++ b/Yank/reports/__init__.py
@@ -1,1 +1,8 @@
-from . import notebook
+try:
+    from . import notebook
+except ImportError:
+    print("Rendering this notebook requires the following packages:\n"
+          " - matplotlib\n"
+          "These are not required to generate the notebook through the `yank analyze report` command\n"
+          "The modules are not required to use the rest of YANK and no ImportError is raised,\n"
+          "but the reports module cannot be used.")

--- a/Yank/tests/test_cli.py
+++ b/Yank/tests/test_cli.py
@@ -102,12 +102,12 @@ def test_script_yaml():
             absolute-binding:
                 complex:
                     alchemical_path:
-                        lambda_electrostatics: [1.0, 0.9, 0.8, 0.6, 0.4, 0.2, 0.0]
-                        lambda_sterics: [1.0, 0.9, 0.8, 0.6, 0.4, 0.2, 0.0]
+                        lambda_electrostatics: [1.0, 0.5, 0.0]
+                        lambda_sterics: [1.0, 0.5, 0.0]
                 solvent:
                     alchemical_path:
-                        lambda_electrostatics: [1.0, 0.8, 0.6, 0.3, 0.0]
-                        lambda_sterics: [1.0, 0.8, 0.6, 0.3, 0.0]
+                        lambda_electrostatics: [1.0, 0.5, 0.0]
+                        lambda_sterics: [1.0, 0.5, 0.0]
         systems:
             system:
                 receptor: T4lysozyme

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -249,7 +249,7 @@ class TestReporter(object):
             reporter = Reporter(storage=storage_file, open_mode='w',
                                 checkpoint_interval=checkpoint_interval,
                                 checkpoint_storage_file=checkpoint_storage_file)
-            assert reporter.storage_exists()
+            assert reporter.storage_exists(skip_size=True)
             yield reporter
 
     def test_store_thermodynamic_states(self):
@@ -985,6 +985,7 @@ class TestReplicaExchange(object):
             cp_file = 'checkpoint_file.nc'
             cp_file_mod = 'checkpoint_mod.nc'
             reporter = Reporter(storage_path, checkpoint_storage_file=cp_file, open_mode='w')
+            reporter.close()
             del reporter
             Reporter(storage_path, checkpoint_storage_file=cp_file_mod, open_mode='r')
 

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1991,11 +1991,11 @@ def test_run_solvation_experiment():
         output_dir = yaml_builder._get_experiment_dir('')
 
         assert os.path.isdir(output_dir)
-        for extension in repex.Reporter.storage_extensions():
-            solvent1_path = os.path.join(output_dir, 'solven1' + extension)
-            solvent2_path = os.path.join(output_dir, 'solven2' + extension)
-            assert os.path.isfile(solvent1_path)
-            assert os.path.isfile(solvent2_path)
+        for solvent in ['solvent1.nc', 'solvent2.nc']:
+            solvent_path = os.path.join(output_dir, solvent)
+            reporter = repex.Reporter(solvent_path, open_mode=None)
+            assert reporter.storage_exists()
+            del reporter
         assert os.path.isfile(os.path.join(output_dir, 'experiments.yaml'))
         assert os.path.isfile(os.path.join(output_dir, 'experiments.log'))
 

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1989,9 +1989,13 @@ def test_run_solvation_experiment():
 
         # The experiments folders are correctly named and positioned
         output_dir = yaml_builder._get_experiment_dir('')
+
         assert os.path.isdir(output_dir)
-        assert os.path.isfile(os.path.join(output_dir, 'solvent1.nc'))
-        assert os.path.isfile(os.path.join(output_dir, 'solvent2.nc'))
+        for extension in repex.Reporter.storage_extensions():
+            solvent1_path = os.path.join(output_dir, 'solven1' + extension)
+            solvent2_path = os.path.join(output_dir, 'solven2' + extension)
+            assert os.path.isfile(solvent1_path)
+            assert os.path.isfile(solvent2_path)
         assert os.path.isfile(os.path.join(output_dir, 'experiments.yaml'))
         assert os.path.isfile(os.path.join(output_dir, 'experiments.log'))
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -2615,7 +2615,7 @@ class YamlBuilder(object):
 
             # Create phases.
             phases[i] = YamlPhaseFactory(sampler, thermodynamic_state, sampler_state,
-                                         topography, phase_protocol, storage=phase_path,
+                                         topography, phase_protocol, storage_base=phase_path,
                                          restraint=restraint, alchemical_regions=alchemical_region,
                                          **phase_opts)
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1047,6 +1047,14 @@ class YamlPhaseFactory(object):
         create_kwargs = self.__dict__.copy()
         create_kwargs.pop('options')
         create_kwargs.pop('sampler')
+        if not isinstance(self.storage, repex.Reporter):
+            # Build the Reporter
+            storage_path = create_kwargs.pop('storage')
+            checkpoint_interval = self.options['checkpoint_interval']
+            # We don't allow checkpoint file overwriting in YAML file
+            reporter = repex.Reporter(storage_path, checkpoint_interval=checkpoint_interval)
+            create_kwargs['storage'] = reporter
+            self.storage = reporter
         if self.options['anisotropic_dispersion_correction'] is True:
             dispersion_cutoff = self.options['anisotropic_dispersion_cutoff']
         else:
@@ -1122,7 +1130,7 @@ class YamlExperiment(object):
                 # If this is a new simulation, initialize alchemical phase.
                 if isinstance(phase, YamlPhaseFactory):
                     alchemical_phase = phase.initialize_alchemical_phase()
-                    self.phases[phase_id] = phase.storage
+                    self.phases[phase_id] = phase.storage  # Should automatically be a Reporter class
                 else:  # Resume previous simulation.
                     alchemical_phase = AlchemicalPhase.from_storage(phase)
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1027,14 +1027,14 @@ class YamlPhaseFactory(object):
     }
 
     def __init__(self, sampler, thermodynamic_state, sampler_states, topography,
-                 protocol, storage_base, restraint=None, alchemical_regions=None,
+                 protocol, storage, restraint=None, alchemical_regions=None,
                  alchemical_factory=None, metadata=None, **options):
         self.sampler = sampler
         self.thermodynamic_state = thermodynamic_state
         self.sampler_states = sampler_states
         self.topography = topography
         self.protocol = protocol
-        self.storage_base = storage_base
+        self.storage = storage
         self.restraint = restraint
         self.alchemical_regions = alchemical_regions
         self.alchemical_factory = alchemical_factory
@@ -1122,7 +1122,7 @@ class YamlExperiment(object):
                 # If this is a new simulation, initialize alchemical phase.
                 if isinstance(phase, YamlPhaseFactory):
                     alchemical_phase = phase.initialize_alchemical_phase()
-                    self.phases[phase_id] = phase.storage_base
+                    self.phases[phase_id] = phase.storage
                 else:  # Resume previous simulation.
                     alchemical_phase = AlchemicalPhase.from_storage(phase)
 
@@ -2615,7 +2615,7 @@ class YamlBuilder(object):
 
             # Create phases.
             phases[i] = YamlPhaseFactory(sampler, thermodynamic_state, sampler_state,
-                                         topography, phase_protocol, storage_base=phase_path,
+                                         topography, phase_protocol, storage=phase_path,
                                          restraint=restraint, alchemical_regions=alchemical_region,
                                          **phase_opts)
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1023,17 +1023,18 @@ class YamlPhaseFactory(object):
         'randomize_ligand_close_cutoff': 1.5 * unit.angstrom,
         'number_of_equilibration_iterations': 0,
         'equilibration_timestep': 1.0 * unit.femtosecond,
+        'checkpoint_interval': 10,
     }
 
     def __init__(self, sampler, thermodynamic_state, sampler_states, topography,
-                 protocol, storage, restraint=None, alchemical_regions=None,
+                 protocol, storage_base, restraint=None, alchemical_regions=None,
                  alchemical_factory=None, metadata=None, **options):
         self.sampler = sampler
         self.thermodynamic_state = thermodynamic_state
         self.sampler_states = sampler_states
         self.topography = topography
         self.protocol = protocol
-        self.storage = storage
+        self.storage_base = storage_base
         self.restraint = restraint
         self.alchemical_regions = alchemical_regions
         self.alchemical_factory = alchemical_factory
@@ -1121,7 +1122,7 @@ class YamlExperiment(object):
                 # If this is a new simulation, initialize alchemical phase.
                 if isinstance(phase, YamlPhaseFactory):
                     alchemical_phase = phase.initialize_alchemical_phase()
-                    self.phases[phase_id] = phase.storage
+                    self.phases[phase_id] = phase.storage_base
                 else:  # Resume previous simulation.
                     alchemical_phase = AlchemicalPhase.from_storage(phase)
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -379,7 +379,7 @@ class AlchemicalPhase(object):
         # TODO: this should skip the Reporter and use the Storage to read storage.metadata.
         # Open Reporter for reading and read metadata.
         reporter = repex.Reporter(storage_base, open_mode='r')
-        metadata = reporter.read_dict('metadata')
+        metadata = reporter.read_dict('metadata', storage='checkpoint')
         reporter.close()
 
         # Retrieve the sampler class.

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -383,7 +383,7 @@ class AlchemicalPhase(object):
 
         # TODO: this should skip the Reporter and use the Storage to read storage.metadata.
         # Open Reporter for reading and read metadata.
-        reporter = reporter.open(mode='r')
+        reporter.open(mode='r')
         metadata = reporter.read_dict('metadata')
         reporter.close()
 

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -66,6 +66,7 @@ Detailed Options List
     * :ref:`extend_simulation <yaml_options_extend_simulation>`
     * :ref:`nsteps_per_iteration <yaml_options_nsteps_per_iteration>`
     * :ref:`timestep <yaml_options_timestep>`
+    * :ref:`checkpoint_interval <yaml_options_checkpoint_interval>`
     * :ref:`replica_mixing_scheme <yaml_options_replica_mixing_scheme>`
     * :ref:`collision_rate <yaml_options_collision_rate>`
     * :ref:`constraint_tolerance <yaml_options_constraint_tolerance>`

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -497,6 +497,28 @@ Timestep of Langevin Dynamics production runs.
 Valid Options (2.0 * femtosecond): <Quantity Time> [1]_
 
 
+.. _yaml_options_checkpoint_interval:
+
+checkpoint_interval
+-------------------
+.. code-block:: yaml
+
+   options:
+     checkpoint_interval: 10
+
+Specify how frequently checkpoint information should be saved to file relative to iterations. YANK simulations can be
+resumed only from checkpoints, so if something crashes, up to ``checkpoint_interval`` worth of iterations will be lost
+and YANK will resume from the most recent checkpoint.
+
+This option helps control write-to-disk time and file sizes. The fewer times a checkpoint is written, the less of both
+you will get. If you want to write a checkpoint every iteration, set this to ``1``.
+
+Checkpoint information includes things like full coordinates and box vectors, as well as more static information such
+as metadata, simulation options, and serialized thermodynamic states.
+
+Valid Options (10): <Integer ``>= 1``>
+
+
 .. _yaml_options_replica_mixing_scheme:
 
 replica_mixing_scheme

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
     platforms=['Linux', 'Mac OS-X', 'Unix', 'Windows'],
     classifiers=CLASSIFIERS.splitlines(),
     package_dir={'yank': 'Yank'},
-    packages=['yank', "yank.tests", "yank.tests.data", "yank.commands", "yank.mixing"] + ['yank.{}'.format(package) for package in find_packages('yank')],
+    packages=['yank', "yank.tests", "yank.tests.data", "yank.commands", "yank.mixing", "yank.reports"], #+ ['yank.{}'.format(package) for package in find_packages('yank')],
     package_data={'yank': find_package_data('Yank/tests/data', 'yank') + ['reports/*.ipynb'],
                   },
     zip_safe=False,


### PR DESCRIPTION
This PR provides the ability for YANK to checkpoint simulations to save space and time when writing to file, at the cost of writing less frequently

This commit does the following:
* Splits all storage files into 2 files, one for checkpointing and one for analysis
* The two files are used for infrequent, and frequent writes respectively
* All file paths are now on a "base" and the individual files are derived from that base
* Most choices about which file gets which data is handled in the Reporter class
* Added `checkpoint_interval` option to specify how frequently writes occur on the checkpoint relative to the iterations
* Simulations are resumed only from the most recent checkpoint
* Data accessed from checkpoint file which is not on checkpoint_interval returns None objects
* Data cannot be written to checkpoint file at non-checkpoint_interval iterations (logger raises a warning, no action taken)
* Fixed an un-documented bug where the Health Reports were not being picked up correctly