### PR TITLE
Support SMILES files with comments and compress dictionaries in NetCDF file

### DIFF
--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -907,7 +907,7 @@ class Reporter(object):
         try:
             nc_variable = self._resolve_variable_path(name, storage)
         except KeyError:
-            nc_variable = self._storage_dict[storage].createVariable(name, str, 'scalar')
+            nc_variable = self._storage_dict[storage].createVariable(name, str, 'scalar', zlib=True)
 
         # Activate flow style to save space.
         data_str = yaml.dump(data, Dumper=_DictYamlDumper)#, default_flow_style=True)

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -875,6 +875,7 @@ class TestMultiMoleculeFiles(object):
 
         # Create 2-molecule SMILES file
         with open(cls.smiles_path, 'w') as f:
+            f.write('# comment\n')
             f.write('benzene,c1ccccc1\n')
             f.write('toluene,Cc1ccccc1\n')
 
@@ -1116,7 +1117,7 @@ class TestMultiMoleculeFiles(object):
                 assert os.path.getsize(os.path.join(mol2_path)) > 0
 
                 # The mol2 represents the right molecule
-                csv_smiles_str = (open(self.smiles_path, 'r').readlines()[i]).strip().split(',')[1]
+                csv_smiles_str = read_csv_lines(self.smiles_path, lines=i).strip().split(',')[1]
                 mol2_smiles_str = OEMolToSmiles(utils.read_oe_molecule(mol2_path))
                 assert mol2_smiles_str == csv_smiles_str
 

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -274,7 +274,7 @@ def read_csv_lines(file_path, lines):
     # Read all lines ignoring blank lines and comments.
     with open(file_path, 'r') as f:
         all_records = [line for line in f
-                       if bool(line) and line.strip().startswith('#')]
+                       if bool(line) and not line.strip().startswith('#')]
 
     if lines == 'all':
         return all_records
@@ -1558,7 +1558,7 @@ class YamlBuilder(object):
                         n_models = PDBFile(comb_molecule['filepath']).getNumFrames()
 
                     elif extension == 'csv' or extension == 'smiles':
-                        n_models = len(read_csv_lines(comb_molecule['filepath']), lines='all')
+                        n_models = len(read_csv_lines(comb_molecule['filepath'], lines='all'))
 
                     elif extension == 'sdf' or extension == 'mol2':
                         if not utils.is_openeye_installed(oetools=('oechem',)):


### PR DESCRIPTION
As the title says.

The CSV standard doesn't have a definition of comment, but FreeSolv uses Python-style comments so I've added support for those.