### PR TITLE
Update website docs

### DIFF
--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -251,8 +251,8 @@ def test_yaml_parsing():
         experiments_dir: /path/to/output/experiments/
         platform: CPU
         precision: mixed
-        switch_experiment_every: -2.0
-        switch_phase_every: 32
+        switch_experiment_interval: -2.0
+        switch_phase_interval: 32
         temperature: 300*kelvin
         pressure: null
         constraints: AllBonds

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -40,6 +40,7 @@ Detailed Options List
     * :ref:`experiments_dir <yaml_options_experiments_dir>`
     * :ref:`platform <yaml_options_platform>`
     * :ref:`precision <yaml_options_precision>`
+    * :ref:`switch_experiment_interval <yaml_options_switch_experiment_interval>`
 
   * :ref:`System and Simulation Prep <yaml_options_sys_and_sim_prep>`
 
@@ -53,17 +54,13 @@ Detailed Options List
 
   * :ref:`Simulation Parameters: <yaml_options_simulation_parameters>`
 
-    * :ref:`online_analysis <yaml_options_online_analysis>`
-    * :ref:`online_analysis_min_iterations <yaml_options_online_analysis_min_iterations>`
-    * :ref:`show_energies <yaml_options_show_energies>`
-    * :ref:`show_mixing_statistics <yaml_options_show_mixing_statistics>`
+    * :ref:`switch_phase_interval <yaml_options_switch_phase_interval>`
     * :ref:`minimize <yaml_options_minimize>`
     * :ref:`minimize_max_iterations <yaml_options_minimize_max_iterations>`
     * :ref:`minimize_tolerance <yaml_options_minimize_tolerance>`
     * :ref:`number_of_equilibration_iterations <yaml_options_number_of_equilibration_iterations>`
     * :ref:`equilibration_timestep <yaml_options_equilibration_timestep>`
     * :ref:`number_of_iterations <yaml_options_number_of_iterations>`
-    * :ref:`extend_simulation <yaml_options_extend_simulation>`
     * :ref:`nsteps_per_iteration <yaml_options_nsteps_per_iteration>`
     * :ref:`timestep <yaml_options_timestep>`
     * :ref:`checkpoint_interval <yaml_options_checkpoint_interval>`

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -136,6 +136,7 @@ value (``auto``) is equivalent to ``mixed`` when the device support this precisi
 
 Valid options: [auto]/double/mixed/single
 
+
 .. _yaml_options_switch_experiment_interval:
 
 switch_experiment_interval
@@ -150,12 +151,13 @@ When running multiple experiments using the ``!Combinatorial`` tag, this allows 
 completing the specified ``number_of_iterations``. If 0 or less, YANK will complete the combinatorial calculations
 sequentially.
 
-Valid options (0): <int>
+Valid options (0): <Integer>
+
 
 .. _yaml_options_sys_and_sim_prep:
 
-System and Simulation Prepartion:
-=================================
+System and Simulation Preparation:
+==================================
 
 .. _yaml_options_randomize_ligand:
 
@@ -308,10 +310,11 @@ Valid options (16 * angstrom): <Quantity Length> [1]_
 Simulation Parameters
 =====================
 
+
 .. _yaml_options_switch_phase_interval:
 
-switch_experiment_interval
---------------------------
+switch_phase_interval
+---------------------
 .. code-block:: yaml
 
    options:
@@ -321,7 +324,8 @@ This allows to switch the simulation between the two phases of the calculation e
 If 0 or less, YANK will exhaust the ``number_of_iterations`` iterations of the first phase before switching to the
 second one.
 
-Valid options (0): <int>
+Valid options (0): <Integer>
+
 
 .. _yaml_options_minimize:
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -6,10 +6,14 @@ Options for YAML files
 These are all the simulation, alchemy, and file I/O options controlled by the ``options`` header in the YAML files for
 YANK. We have subdivided the categories below, but all settings on this page go under the ``options`` header in the YAML file:
 
-* :ref:`General Options: <yaml_options_options>`
+* :ref:`General Options <yaml_options_options>`
 * :ref:`System and Simulation Prep <yaml_options_sys_and_sim_prep>`
-* :ref:`Simulation Parameters: <yaml_options_simulation_parameters>`
+* :ref:`Simulation Parameters <yaml_options_simulation_parameters>`
 * :ref:`Alchemy Parameters <yaml_options_alchemy_parameters>`
+
+Besides the options listed in :ref:`General Options <yaml_options_options>` that can be specified exclusively in the
+``options`` section of the YAML script, everything else can go either in ``options`` as a general setting, or in
+``experiments.options``. In the latter case, an option can be expanded combinatorially with the ``!Combinatorial`` tag.
 
 ----
 
@@ -132,7 +136,21 @@ value (``auto``) is equivalent to ``mixed`` when the device support this precisi
 
 Valid options: [auto]/double/mixed/single
 
-|
+.. _yaml_options_switch_experiment_interval:
+
+switch_experiment_interval
+--------------------------
+.. code-block:: yaml
+
+   options:
+     switch_experiments_interval: 0
+
+When running multiple experiments using the ``!Combinatorial`` tag, this allows to switch between experiments every
+``switch_experiments_interval`` iterations, and gather data about multiple molecules/conditions before
+completing the specified ``number_of_iterations``. If 0 or less, YANK will complete the combinatorial calculations
+sequentially.
+
+Valid options (0): <int>
 
 .. _yaml_options_sys_and_sim_prep:
 
@@ -290,62 +308,20 @@ Valid options (16 * angstrom): <Quantity Length> [1]_
 Simulation Parameters
 =====================
 
-.. _yaml_options_online_analysis:
+.. _yaml_options_switch_phase_interval:
 
-online_analysis
----------------
+switch_experiment_interval
+--------------------------
 .. code-block:: yaml
 
    options:
-     online_analysis: no
+     switch_phase_interval: 0
 
-Analysis will occur at each iteration of the simulations if set. **WARNING:** This can be a slow process!
+This allows to switch the simulation between the two phases of the calculation every ``switch_phase_interval`` iterations.
+If 0 or less, YANK will exhaust the ``number_of_iterations`` iterations of the first phase before switching to the
+second one.
 
-Valid options: [no]/yes
-
-
-.. _yaml_options_online_analysis_min_iterations:
-
-online_analysis_min_iterations
-------------------------------
-.. code-block:: yaml
-
-   options:
-     online_analysis_min_iterations: 20
-
-The minimum number of iterations that must pass before :ref:`online analysis <yaml_options_online_analysis>` begins.
-
-Valid options (20): <Integer>
-
-
-.. _yaml_options_show_energies:
-
-show_energies
--------------
-.. code-block:: yaml
-
-   options:
-     show_energies: yes
-
-If ``yes``, will print out the energies at each iteration.
-
-Valid options: [yes]/no
-
-
-.. _yaml_options_show_mixing_statistics:
-
-show_mixing_statistics
-----------------------
-.. code-block:: yaml
-
-   options:
-     show_mixing_statistics: yes
-
-If ``yes``, will print the Hamiltonian Replica Exchange swapping statistics at each iteration. This process adds a small
-amount of overhead to each iteration.
-
-Valid options: [yes]/no
-
+Valid options (0): <int>
 
 .. _yaml_options_minimize:
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -411,37 +411,38 @@ set, this option can be used to extend previous simulations past their original 
 Valid Options (1): <Integer>
 
 
-.. _yaml_options_extend_simulation:
+..
+   .. _yaml_options_extend_simulation:
 
-extend_simulation
---------------------
-.. code-block:: yaml
+   extend_simulation
+   --------------------
+   .. code-block:: yaml
 
-    options:
-      extend_simulation: False
+       options:
+         extend_simulation: False
 
-Special modification of :ref:`yaml_options_number_of_iterations` which allows **extending** a simulation by
-:ref:`yaml_options_number_of_iterations` instead of running for a maximum. If set to ``True``,
-the simulation will run the additional specified number of iterations, even if a simulation already has
-run for a length of time. For fresh simulations, the resulting simulation is identical to not setting this flag.
+   Special modification of :ref:`yaml_options_number_of_iterations` which allows **extending** a simulation by
+   :ref:`yaml_options_number_of_iterations` instead of running for a maximum. If set to ``True``,
+   the simulation will run the additional specified number of iterations, even if a simulation already has
+   run for a length of time. For fresh simulations, the resulting simulation is identical to not setting this flag.
 
-This is helpful for running consecutive batches of simulations for time lengths that are unknown.
+   This is helpful for running consecutive batches of simulations for time lengths that are unknown.
 
-*Recommended*: Also set :ref:`resume_setup <yaml_options_resume_setup>` and
-:ref:`resume_simulation <yaml_options_resume_simulation>` to allow resuming simulations.
+   *Recommended*: Also set :ref:`resume_setup <yaml_options_resume_setup>` and
+   :ref:`resume_simulation <yaml_options_resume_simulation>` to allow resuming simulations.
 
-*Example*: You have a simulation that ran for 500 iterations, you wish to add an additional 1000 iterations. You would
-set ``number_of_iterations: 1000`` and ``extend_simulation: True`` in your YAML file and rerun. The simulation would
-then resume at iteration 500, then continue to iteration 1500. The same behavior would be achieved if you set
-``number_of_iterations: 1500``, but the ``extend_simulation`` has the advantage that it can be run multiple times to
-keep extending the simulation without modifying the YAML file.
+   *Example*: You have a simulation that ran for 500 iterations, you wish to add an additional 1000 iterations. You would
+   set ``number_of_iterations: 1000`` and ``extend_simulation: True`` in your YAML file and rerun. The simulation would
+   then resume at iteration 500, then continue to iteration 1500. The same behavior would be achieved if you set
+   ``number_of_iterations: 1500``, but the ``extend_simulation`` has the advantage that it can be run multiple times to
+   keep extending the simulation without modifying the YAML file.
 
-**WARNING**: Extending simulations affects ALL simulations for :doc:`Combinatorial <combinatorial>`. You cannot extend
-a subset of simulations from a combinatorial setup; all simulations will be extended if this option is set.
+   **WARNING**: Extending simulations affects ALL simulations for :doc:`Combinatorial <combinatorial>`. You cannot extend
+   a subset of simulations from a combinatorial setup; all simulations will be extended if this option is set.
 
-**OPTIONAL** and **MODIFIES** :ref:`yaml_options_number_of_iterations`
+   **OPTIONAL** and **MODIFIES** :ref:`yaml_options_number_of_iterations`
 
-Valid Options: True/[False]
+   Valid Options: True/[False]
 
 
 .. _yaml_options_nsteps_per_iteration:

--- a/docs/yamlpages/protocols.rst
+++ b/docs/yamlpages/protocols.rst
@@ -53,7 +53,8 @@ Below is the *recommended* mappings of each ``{PhaseNameX}``:
   * ``{PhaseName2}`` -> ``phase2``
 
 More generally, the ``{PhaseNameX}`` only has to contain the keyword for the system you expect.
-For instance, in the Ligand/Receptor case, the following would also be a valid structure: 
+For instance, in the Ligand/Receptor case, the following would also be a valid structure:
+
 .. code-block:: yaml
 
    {UserDefinedProtocol}:
@@ -68,6 +69,7 @@ and ``my_complex_phase`` would correspond to the ``complex`` phase for the same 
 If you want to name them whatever you would like and instead rely on the which sign is used for the free energy evaluation,
 you can invoke ``{UserDefinedProtocol}: !Ordered`` to make the first entry the ``+`` sign and the second ``-`` sign in the free energy difference.
 Here is an example:
+
 .. code-block:: yaml
 
    absolute-binding: !Ordered
@@ -97,3 +99,28 @@ only applies if ``restraint`` :ref:`in experiments is specified <yaml_experiment
 * `The Boresh restraint in our YANK GitHub Examples <https://github.com/choderalab/yank-examples/tree/master/examples/binding/abl-imatinib>`_
 
 Valid Arguments: <Identical Sized List of Floats>
+
+
+.. _yaml_protocols_thermodynamic_variables:
+
+temperature and pressure
+------------------------
+
+It is possible to vary temperature and pressure along the alchemical path, but the end states must have the same values.
+The number of window must be identical to the other lambda variables. A short example:
+
+.. code-block::yaml
+
+   protocols:
+     {UserDefinedProtocol}:
+       {PhaseName1}:
+         alchemical_path:
+           lambda_electrostatics: [1.00, 0.50, 0.00, 0.00, 0.00]
+           lambda_sterics:        [1.00, 1.00, 1.00, 0.50, 0.00]
+           temperature:           [300*kelvin, 310*kelvin, 320*kelvin, 310*kelvin, 300*kelvin]
+       {PhaseName2}:
+         alchemical_path:
+           lambda_electrostatics: [1.00, 0.50, 0.00, 0.00, 0.00]
+           lambda_sterics:        [1.00, 1.00, 1.00, 0.50, 0.00]
+
+Valid Arguments: <List of Quantities>

--- a/docs/yamlpages/solvents.rst
+++ b/docs/yamlpages/solvents.rst
@@ -86,6 +86,24 @@ Nonbonded Methods: ``CutoffPeriodic``, ``Ewald``, ``PME``
 
 Valid Options (0 * nanometer) <Quantity Length> [1]_
 
+
+.. _yaml_solvents_solvent_model:
+
+solvent_model
+-------------
+.. code-block:: yaml
+
+   solvents:
+     {UserDefinedSolvent}:
+       solvent_model: tip4pew
+
+Specify the water model used to solvate the box.
+
+Nonbonded Methods: ``CuttoffNonPeriodic``, ``CuttoffPeriodic``, ``Ewald``, ``PME``
+
+Valid Options: [tip4pew] / tip3p / tip3pfb / tip5p / spce
+
+
 .. _yaml_solvents_rigid_water:
 
 rigid_water

--- a/docs/yamlpages/systems.rst
+++ b/docs/yamlpages/systems.rst
@@ -99,14 +99,17 @@ MDTraj is required to use this options since picking the ligand out of the files
 
 * ``phase1_path``: The set of files which fully describe the first phase of the free energy simulation you want to run.
 * ``phase2_path``: The set of files which fully describe the second phase of the free energy simulation you want to run.
-* ``ligand_dsl``: An MDTraj DSL string which identifies the ligand in the files provided by ``phase1_path`` and ``phase2_path``.
-* ``solvent_dsl``: An optional MDTraj DSL string which identifies the solvent atoms in the files provided by ``phase1_path``
-  and ``phase2_path``. If not specified, a list of common solvent residue names will be used to automatically detect
-  solvent atoms.
-* ``solvent``: A ``{UserDefinedSolvent}`` to put the two phases in. Only one solvent is allowed for this calculation.
-  This option must be omitted if using XML/PDB files, since the solvent options are inherently specified in the XML
-  definition of the system. Finally, if the two phases require two different solvents, it is possible to substitute the
-  ``solvent`` option with two ``solvent1`` and ``solvent2``, which are associated to phase 1 and phase 2 respectively.
+* ``ligand_dsl``: *Only for receptor-ligand systems*. An MDTraj DSL string which identifies the ligand in the files
+  provided by ``phase1_path`` and ``phase2_path``. This must be specified only in case of a ligand-receptor system. If
+  you are running a solvation free energy calculation, this will raise an error.
+* ``solvent_dsl``: *Optional*. An MDTraj DSL string which identifies the solvent atoms (including ions) in the files
+  provided by ``phase1_path`` and ``phase2_path``. If not specified, a list of common solvent residue names will be used
+  to automatically detect solvent atoms.
+* ``solvent``: *Only for Amber and GROMACS files*. A ``{UserDefinedSolvent}`` to put the two phases in. Only one solvent
+  is allowed for this calculation. This option must be omitted if using XML/PDB files, since the solvent options are
+  inherently specified in the XML definition of the system. Finally, if the two phases require two different solvents,
+  it is possible to substitute the ``solvent`` option with two ``solvent1`` and ``solvent2``, which are associated to
+  phase 1 and phase 2 respectively.
 * ``gromacs_include_dir``: *Optional*, Tells YANK where the GROMACS include directory is to pull files and parameters from.
   This is particularly helpful if your topology file does not contain all parameters.
   Path is relative to the YAML script.


### PR DESCRIPTION
This changes the name of `switch_experiment/phase_every` options to `switch_experiment/phase_interval` as we discussed few weeks ago, and updates the website docs with the recent changes to the YAML syntax.

I don't think I'll have time to find a solution for `extend_simulation` before the next release. Should I comment it out from the docs until it's reintroduced?