### PR TITLE
Speed up write Thermodynamic States

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pymbar
     - ambermini >=16.16.0
     - docopt
-    - openmoltools >=0.9.5
+    - openmoltools
     - sphinxcontrib-bibtex
     - schema >=0.6.2
     #- gcc 4.8.2 # [linux]
@@ -38,11 +38,11 @@ requirements:
     - netcdf4
     - openmm >=7.1
     - mdtraj >=1.7.2
-    - openmmtools
+    - openmmtools >=0.10.0
     - pymbar
     - ambermini >=16.16.0
     - docopt
-    - openmoltools >=0.10.0
+    - openmoltools
     - mpi4py
     - pyyaml
     - clusterutils

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pymbar
     - ambermini >=16.16.0
     - docopt
-    - openmoltools
+    - openmoltools >=0.9.5
     - sphinxcontrib-bibtex
     - schema >=0.6.2
     #- gcc 4.8.2 # [linux]
@@ -42,7 +42,7 @@ requirements:
     - pymbar
     - ambermini >=16.16.0
     - docopt
-    - openmoltools
+    - openmoltools >=0.9.5
     - mpi4py
     - pyyaml
     - clusterutils

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - netcdf4
     - openmm >=7.1
     - mdtraj >=1.7.2
-    - openmmtools
+    - openmmtools >=0.10.0
     - pymbar
     - ambermini >=16.16.0
     - docopt
@@ -42,7 +42,7 @@ requirements:
     - pymbar
     - ambermini >=16.16.0
     - docopt
-    - openmoltools >=0.9.5
+    - openmoltools >=0.10.0
     - mpi4py
     - pyyaml
     - clusterutils

--- a/setup.py
+++ b/setup.py
@@ -146,11 +146,11 @@ setup(
         'cython',
         'openmm',
         'pymbar',
-        'openmmtools',
+        'openmmtools>=0.10.0',
         'docopt>=0.6.1',
         'netcdf4',
         'schema',
-        'openmoltools>=0.10.0',
+        'openmoltools',
         'mdtraj',
         'pyyaml'
         ],

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
         'docopt>=0.6.1',
         'netcdf4',
         'schema',
-        'openmoltools>=0.9.5',
+        'openmoltools>=0.10.0',
         'mdtraj',
         'pyyaml'
         ],

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
         'docopt>=0.6.1',
         'netcdf4',
         'schema',
-        'openmoltools',
+        'openmoltools>=0.9.5',
         'mdtraj',
         'pyyaml'
         ],


### PR DESCRIPTION
This is an optimization to the `Reporter.write_thermodynamic_states` function to only serialize the `openmmtools.ThermodynamicState._standard_state` object if we have a new, incompatible `ThermodynamicState` with the states we already serialized. 

This results in about a 20% speedup to start time as a lower bound. The speed improvement is a function of both system size and number of states, although there does not appear to be a direct correlation as the `write_dict` and `serialize` functions become the rate-limiting steps.

This will also not pass tests until OpenMMTools 0.9.5 goes live

cc @andrrizzi for review