### PR TITLE
Renamed AlchemicalFactory to AbsoluteAlchemicalFactory

### DIFF
--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -266,7 +266,7 @@ class TestReporter(object):
                                                                     temperature, 1.0*unit.atmosphere)
 
         # Compound states.
-        factory = mmtools.alchemy.AlchemicalFactory()
+        factory = mmtools.alchemy.AbsoluteAlchemicalFactory()
         alchemical_region = mmtools.alchemy.AlchemicalRegion(alchemical_atoms=range(22))
         alanine_alchemical = factory.create_alchemical_system(alanine_system, alchemical_region)
         alchemical_state_interacting = mmtools.alchemy.AlchemicalState.from_system(alanine_alchemical)
@@ -466,7 +466,7 @@ class TestReplicaExchange(object):
         # Test case with host guest in implicit at 3 different positions and alchemical parameters.
         # -----------------------------------------------------------------------------------------
         hostguest_test = testsystems.HostGuestVacuum()
-        factory = mmtools.alchemy.AlchemicalFactory()
+        factory = mmtools.alchemy.AbsoluteAlchemicalFactory()
         alchemical_region = mmtools.alchemy.AlchemicalRegion(alchemical_atoms=range(126, 156))
         hostguest_alchemical = factory.create_alchemical_system(hostguest_test.system, alchemical_region)
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -453,10 +453,10 @@ class AlchemicalPhase(object):
             is None).
         alchemical_regions : openmmtools.alchemy.AlchemicalRegion, optional
             If specified, this is the AlchemicalRegion that will be passed
-            to the AlchemicalFactory, otherwise the ligand will be alchemically
-            modified according to the given protocol.
-        alchemical_factory : openmmtools.alchemy.AlchemicalFactory, optional
-            If specified, this AlchemicalFactory will be used instead of
+            to the AbsoluteAlchemicalFactory, otherwise the ligand will be
+            alchemically modified according to the given protocol.
+        alchemical_factory : openmmtools.alchemy.AbsoluteAlchemicalFactory, optional
+            If specified, this AbsoluteAlchemicalFactory will be used instead of
             the one created with default options.
         metadata : dict, optional
             Simulation metadata to be stored in the file.
@@ -548,9 +548,9 @@ class AlchemicalPhase(object):
         # Create alchemically-modified system using alchemical factory.
         logger.debug("Creating alchemically-modified states...")
         if alchemical_factory is None:
-            factory = mmtools.alchemy.AlchemicalFactory()
-        alchemical_system = factory.create_alchemical_system(thermodynamic_state.system,
-                                                             alchemical_regions)
+            alchemical_factory = mmtools.alchemy.AbsoluteAlchemicalFactory()
+        alchemical_system = alchemical_factory.create_alchemical_system(thermodynamic_state.system,
+                                                                        alchemical_regions)
 
         # Create compound alchemically modified state to pass to sampler.
         thermodynamic_state.system = alchemical_system


### PR DESCRIPTION
Tests won't pass with the old `openmmtools` and #684 already bumped the requirements, so I wouldn't do it here.

All the tests I run pass locally, so I'd merge anyway and fix eventual failures in a separate PR if you agree.