### PR TITLE
Automatic expanded cutoff and restraint parameters in YAML

### DIFF
--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -637,7 +637,14 @@ def test_validation_correct_experiments():
     experiments = [
         {'system': 'sys', 'protocol': 'absolute-binding'},
         {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {'type': 'Harmonic'}},
-        {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {'type': None}}
+        {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {'type': None}},
+        {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {
+            'type': 'Harmonic', 'spring_constant': '8*kilojoule_per_mole/nanometers**2'}},
+        {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {
+            'type': 'FlatBottom', 'well_radius': '5.2*nanometers', 'restrained_receptor_atom': 1644}},
+        {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {
+            'type': 'Boresch', 'restrained_atoms': [1335, 1339, 1397, 2609, 2607, 2606],
+            'K_r': '20.0*kilocalories_per_mole/angstrom**2', 'r_aA0': '0.35*nanometer'}},
     ]
     for experiment in experiments:
         modified_script = basic_script.copy()
@@ -1930,6 +1937,10 @@ def test_run_experiment():
             protocol: absolute-binding
             restraint:
                 type: FlatBottom
+                spring_constant: 0.6*kilocalorie_per_mole/angstroms**2
+                well_radius: 5.2*nanometers
+                restrained_receptor_atom: 1644
+                restrained_ligand_atom: 2609
         """.format(tmp_dir, examples_paths()['lysozyme'], examples_paths()['p-xylene'],
                    indent(standard_protocol))
 

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -161,12 +161,23 @@ class TestAlchemicalPhase(object):
     @classmethod
     def check_expanded_states(cls, alchemical_phase, protocol, expected_cutoff):
         """The expanded states have been setup correctly."""
-        cutoff_unit = expected_cutoff.unit
         thermodynamic_state = alchemical_phase._sampler._thermodynamic_states[0]
         unsampled_states = alchemical_phase._sampler._unsampled_states
 
         is_periodic = thermodynamic_state.is_periodic
         is_restrained = hasattr(thermodynamic_state, 'lambda_restraints')
+
+        # If the expanded cutoff is determined automatically,
+        # figure out the expected value.
+        if expected_cutoff == 'auto':
+            box_vectors = thermodynamic_state._standard_system.getDefaultPeriodicBoxVectors()
+            min_box_dimension = min([np.linalg.norm(vector) for vector in box_vectors])
+            if thermodynamic_state.pressure is None:
+                min_box_half_size = min_box_dimension * 0.99 / 2.0
+            else:
+                min_box_half_size = min_box_dimension * 0.8 / 2.0
+            expected_cutoff = min(min_box_half_size, 16*unit.angstrom)
+        cutoff_unit = expected_cutoff.unit
 
         # Anisotropic correction is not applied to non-periodic systems.
         if not is_periodic:
@@ -199,9 +210,8 @@ class TestAlchemicalPhase(object):
     def test_create(self):
         """Alchemical state correctly creates the simulation object."""
         available_restraints = list(yank.restraints.available_restraint_classes().values())
-        correction_cutoff = 12 * unit.angstroms
 
-        for test_case in self.all_test_cases:
+        for test_index, test_case in enumerate(self.all_test_cases):
             test_name, thermodynamic_state, sampler_state, topography = test_case
 
             # Add random restraint if this is ligand-receptor system in implicit solvent.
@@ -213,6 +223,12 @@ class TestAlchemicalPhase(object):
             else:
                 restraint = None
                 protocol = self.protocol
+
+            # Add either automatic of fixed correction cutoff.
+            if test_index % 2 == 0:
+                correction_cutoff = 12 * unit.angstroms
+            else:
+                correction_cutoff = 'auto'
 
             alchemical_phase = AlchemicalPhase(sampler=ReplicaExchange())
             with self.temporary_storage_path() as storage_path:

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1058,7 +1058,7 @@ class YamlPhaseFactory(object):
 
     DEFAULT_OPTIONS = {
         'anisotropic_dispersion_correction': True,
-        'anisotropic_dispersion_cutoff': 16.0*unit.angstroms,
+        'anisotropic_dispersion_cutoff': 'auto',
         'minimize': True,
         'minimize_tolerance': 1.0 * unit.kilojoules_per_mole/unit.nanometers,
         'minimize_max_iterations': 0,
@@ -1703,7 +1703,16 @@ class YamlBuilder(object):
         template_options.pop('alchemical_angles')
         template_options.pop('alchemical_torsions')
 
-        special_conversions = {'constraints': to_openmm_app}
+        # Some options need to be treated differently.
+        def check_anisotropic_cutoff(cutoff):
+            if cutoff == 'auto':
+                return cutoff
+            else:
+                return utils.process_unit_bearing_str(cutoff, unit.angstroms)
+        special_conversions = {'constraints': to_openmm_app,
+                               'anisotropic_dispersion_cutoff': check_anisotropic_cutoff}
+
+        # Validate parameters
         try:
             validated_options = utils.validate_parameters(options, template_options, check_unknown=True,
                                                           process_units_str=True, float_to_int=True,

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -797,12 +797,14 @@ class AlchemicalPhase(object):
             else:
                 # We don't want to reduce the cutoff if it's already large.
                 if force_cutoff < expanded_cutoff_distance:
-                    force.setCutoffDistance(expanded_cutoff_distance)
+                    cutoff_diff = expanded_cutoff_distance - force_cutoff
+                    switching_distance = force.getSwitchingDistance()
 
-                    # Set switch distance. We don't need to check if we are
-                    # using a switch since there is a setting for that.
-                    switching_distance = expanded_cutoff_distance - 1.0*unit.angstrom
-                    force.setSwitchingDistance(switching_distance)
+                    # Expand cutoff preserving the original switch width.
+                    # We don't need to check if we are using a switch since
+                    # there is a setting for that.
+                    force.setCutoffDistance(expanded_cutoff_distance)
+                    force.setSwitchingDistance(switching_distance + cutoff_diff)
 
         # Return the new thermodynamic state with the expanded cutoff.
         thermodynamic_state.system = system

--- a/docs/yamlpages/experiments.rst
+++ b/docs/yamlpages/experiments.rst
@@ -21,6 +21,8 @@ Experiments Syntax
      protocol: {UserDefinedProtocol}
      restraint:
        type: FlatBottom
+       {Restraint Parameter}
+       ...
      options:
        {Any Valid Option}
        {Any Valid Option}
@@ -32,7 +34,9 @@ It takes a ``{UserDefinedSystem}`` (see :doc:`systems <systems>`) and a ``{UserD
 to create the experiment and are the only required arguments.
 
 The ``restraint`` is an **optional** keyword that applies a restraint to the ligand to keep it close to the receptor.
-Valid types are: ``FlatBottom``/``Harmonic``/`` Boresch``/``null``. If not specified, assumes ``null``.
+The only required keyword is ``type``. Valid types are: ``FlatBottom``/``Harmonic``/``Boresch``/``null``. If not
+specified, assumes ``null``. Every restraint has his own set of optional parameters that are passed directly to the
+Python constructor of the restraint. See the API documentation in ``yank.restraints`` for the available parameters.
 
 The ``options`` directive lets you overwrite :doc:`any global setting <options>` specified in the header ``options`` for
 this specific experiment.

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -297,7 +297,9 @@ anisotropic_dispersion_cutoff
      anisotropic_dispersion_cutoff: auto
 
 Specify the expanded cutoff distance for YANK's :ref:`yaml_options_anisotropic_dispersion_correction` setting. If
-``auto`` the cutoff will be set to a little smaller than the minimum box size. Please see the main
+``auto`` the cutoff will be set to ``0.99*min_box_size/2`` if no barostat is in use or ``0.8*min_box_size/2`` if
+one is in use (to account for box size fluctuations), with ``min_box_size`` denoting the norm of the smallest OpenMM
+box vector defining the initial triclinic cell volume. Please see the main
 :ref:`yaml_options_anisotropic_dispersion_correction` option for details.
 
 Valid options: [auto]/<Quantity Length> [1]_

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -294,12 +294,13 @@ anisotropic_dispersion_cutoff
 .. code-block:: yaml
 
    options:
-     anisotropic_dispersion_cutoff: 16.0 * angstrom
+     anisotropic_dispersion_cutoff: auto
 
-Specify the expanded cutoff distance for YANK's :ref:`yaml_options_anisotropic_dispersion_correction` setting.
-Please see the main :ref:`yaml_options_anisotropic_dispersion_correction` option for details/
+Specify the expanded cutoff distance for YANK's :ref:`yaml_options_anisotropic_dispersion_correction` setting. If
+``auto`` the cutoff will be set to a little smaller than the minimum box size. Please see the main
+:ref:`yaml_options_anisotropic_dispersion_correction` option for details.
 
-Valid options (16 * angstrom): <Quantity Length> [1]_
+Valid options: [auto]/<Quantity Length> [1]_
 
 .. note:: This will be combined with :ref:`yaml_options_anisotropic_dispersion_correction` in our version 2.0 of our YAML code.
 


### PR DESCRIPTION
This is ready for review.

- Fix #690: Automatic determination of the expanded cutoff. Support for triclinic box.
- Fix #507: Support passing restraint parameters through YAML script.
- Updated main documentation.