### PR TITLE
Fix maximum allowed cutoff of expanded states.

### DIFF
--- a/Yank/tests/test_cli.py
+++ b/Yank/tests/test_cli.py
@@ -86,7 +86,7 @@ def test_script_yaml():
             number_of_iterations: 0
             output_dir: '.'
             resume_setup: yes
-            resume_simulation: yes
+            resume_simulation: no
             minimize: no
         molecules:
             T4lysozyme:
@@ -121,15 +121,12 @@ def test_script_yaml():
             restraint:
                 type: FlatBottom
         """.format(lysozyme_path, pxylene_path)
+
     with omt.utils.temporary_directory() as tmp_dir:
         yaml_file_path = os.path.join(tmp_dir, 'yank.yaml')
         with open(yaml_file_path, 'w') as f:
             f.write(textwrap.dedent(yaml_content))
         run_cli('script --yaml={}'.format(yaml_file_path))
-    # Test with override
-    with omt.utils.temporary_directory() as tmp_dir:
-        yaml_file_path = os.path.join(tmp_dir, 'yank.yaml')
-        with open(yaml_file_path, 'w') as f:
-            f.write(textwrap.dedent(yaml_content))
-        extension = "options:number_of_iterations:1"
-        run_cli('script --yaml={} -o {}'.format(yaml_file_path, extension))
+
+        # Test option overriding.
+        run_cli('script --yaml={} -o options:resume_simulation:yes'.format(yaml_file_path))

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -171,7 +171,7 @@ class TestAlchemicalPhase(object):
         # figure out the expected value.
         if expected_cutoff == 'auto':
             box_vectors = thermodynamic_state._standard_system.getDefaultPeriodicBoxVectors()
-            min_box_dimension = min([np.linalg.norm(vector) for vector in box_vectors])
+            min_box_dimension = min([vector[i] for i, vector in enumerate(box_vectors)])
             if thermodynamic_state.pressure is None:
                 min_box_half_size = min_box_dimension * 0.99 / 2.0
             else:

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -764,9 +764,11 @@ class AlchemicalPhase(object):
         thermodynamic_state = copy.deepcopy(thermodynamic_state)
         system = thermodynamic_state.system
 
-        # Determine minimum box side dimension.
+        # Determine minimum box side dimension. The theoretical maximal allowed cutoff
+        # is given by half the norm of the smallest vector, but OpenMM limits it to
+        # the minimum diagonal element of the box vector matrix for efficiency.
         box_vectors = system.getDefaultPeriodicBoxVectors()
-        min_box_dimension = min([np.linalg.norm(vector) for vector in box_vectors])
+        min_box_dimension = min([vector[i] for i, vector in enumerate(box_vectors)])
 
         # Determine cutoff automatically if requested.
         # We leave more space if the volume fluctuates.


### PR DESCRIPTION
Should be ready for review.

The theoretical maximal allowed cutoff is given by half the norm of the smallest vector, but OpenMM limits it to the minimum diagonal element of the box vector matrix for efficiency.

Related to PR #691 and issue #690. See also pandegroup/openmm#1831.