### PR TITLE
Use C-optimized YAML dumper and loader for Storage

### DIFF
--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -2257,7 +2257,7 @@ class ParallelTempering(ReplicaExchange):
 # MODULE INTERNAL USAGE UTILITIES
 # ==============================================================================
 
-class _DictYamlLoader(yaml.Loader):
+class _DictYamlLoader(yaml.CLoader):
     """PyYAML Loader that reads !Quantity tags."""
     def __init__(self, *args, **kwargs):
         super(_DictYamlLoader, self).__init__(*args, **kwargs)
@@ -2283,7 +2283,7 @@ class _DictYamlLoader(yaml.Loader):
         return data
 
 
-class _DictYamlDumper(yaml.Dumper):
+class _DictYamlDumper(yaml.CDumper):
     """PyYAML Dumper that handle simtk Quantities through !Quantity tags."""
 
     def __init__(self, *args, **kwargs):

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -324,7 +324,7 @@ class TestReporter(object):
                 unsampled_serialized.append(unsampled_dict)
 
             # Two of the three ThermodynamicStates are compatible.
-            assert isinstance(states_serialized[0]['standard_system'], str)
+            assert 'standard_system' in states_serialized[0]
             assert 'standard_system' not in states_serialized[1]
             state_compatible_to_1 = states_serialized[1]['_Reporter__compatible_state']
             assert state_compatible_to_1 == 'thermodynamic_states/0'

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -17,7 +17,7 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda update --yes conda
-conda install --yes conda-build jinja2 anaconda-client pip
+conda install --yes conda-build=2.1.17 jinja2 anaconda-client pip
 
 # Restore original directory
 popd


### PR DESCRIPTION
Closes #706 .

Using `CDumper` gives me a x15 speedup on my laptop when storing the serialization of `openmmtools.testsystems.SrcExplicit` with `Reporter.write_dict()`.

I'll wait for the new `openmmtools` to be released before merging to be sure that the recent changes in the two repos are compatible.