### PR TITLE
Fix #705: Disable analytical dispersion correction for alchemical atoms

### DIFF
--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -548,7 +548,7 @@ class AlchemicalPhase(object):
         # Create alchemically-modified system using alchemical factory.
         logger.debug("Creating alchemically-modified states...")
         if alchemical_factory is None:
-            alchemical_factory = mmtools.alchemy.AbsoluteAlchemicalFactory()
+            alchemical_factory = mmtools.alchemy.AbsoluteAlchemicalFactory(disable_alchemical_dispersion_correction=True)
         alchemical_system = alchemical_factory.create_alchemical_system(thermodynamic_state.system,
                                                                         alchemical_regions)
 


### PR DESCRIPTION
As described in #705, disabling the analytical dispersion correction for the `CustomNonbondedForce` used to model the sterics for the alchemical atoms results in massive speedups for the computation of the energy matrix at almost no cost in overlap with the expanded-cutoff states.