### PR TITLE
Online analysis feature

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -227,9 +227,9 @@ class YankPhaseAnalyzer(ABC):
         self.reference_states = reference_states
         self._mbar = None
         self._kT = None
-        if analysis_kwargs is not None and type(analysis_kwargs) is not dict:
+        if type(analysis_kwargs) not in [type(None), dict]:
             raise ValueError('analysis_kwargs must be either None or a dictionary')
-        self._extra_analysis_kwargs = analysis_kwargs
+        self._extra_analysis_kwargs = analysis_kwargs if (analysis_kwargs is not None) else dict()
 
     @property
     def name(self):
@@ -479,10 +479,7 @@ class YankPhaseAnalyzer(ABC):
 
         # Initialize MBAR (computing free energy estimates, which may take a while)
         logger.info("Computing free energy differences...")
-        if self._extra_analysis_kwargs is not None:
-            mbar = MBAR(energy_matrix, samples_per_state, **self._extra_analysis_kwargs)
-        else:
-            mbar = MBAR(energy_matrix, samples_per_state)
+        mbar = MBAR(energy_matrix, samples_per_state, **self._extra_analysis_kwargs)
         self._mbar = mbar
 
     def _combine_phases(self, other, operator='+'):

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -201,7 +201,8 @@ class YankPhaseAnalyzer(ABC):
                 O[i,j] = O[j] - O[i]
         analysis_kwargs : None or dict, optional
             Dictionary of extra keyword arguments to pass into the analysis tool, typically MBAR.
-            For instance, the initial guess of weights to give to MBAR would be something like {'f_k':[0,1,2,3]}
+            For instance, the initial guess of relative free energies to give to MBAR would be something like:
+                {'f_k':[0,1,2,3]}
         """
         if not reporter.is_open():
             reporter.open(mode='r')

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -970,7 +970,7 @@ class Reporter(object):
         """
         online_group = self._storage_analysis.groups['online_analysis']
         f_k = online_group.variables['f_k'][iteration]
-        free_energy = online_group.variables['D_f'][iteration, :]
+        free_energy = online_group.variables['free_energy'][iteration, :]
         return f_k, free_energy
 
     def write_mbar_free_energies(self, iteration, f_k, free_energy):
@@ -1002,12 +1002,12 @@ class Reporter(object):
             online_group = analysis_nc.createGroup('online_analysis')
             # larger chunks, faster operations, small matrix anyways
             online_group.createVariable('f_k', float, dimensions=('iteration', 'f_k_length'),
-                                       zlib=True, chunksizes=(10, len(f_k)), fill_value=0)
+                                       zlib=True, chunksizes=(1, len(f_k)), fill_value=0)
             online_group.createVariable('free_energy', float, dimensions=('iteration', 'Df'),
-                                        zlib=True, chunksizes=(10, 2), fill_value=np.inf)
+                                        zlib=True, chunksizes=(1, 2), fill_value=np.inf)
         online_group = analysis_nc.groups['online_analysis']
         online_group.variables['f_k'][iteration] = f_k
-        online_group.variables['D_f'][iteration, :] = free_energy
+        online_group.variables['free_energy'][iteration, :] = free_energy
 
     def get_previous_checkpoint(self, iteration):
         """
@@ -1327,6 +1327,7 @@ class ReplicaExchange(object):
         self._n_proposed_matrix = None
         self._reporter = None
         self._metadata = None
+        self._have_displayed_citations_before = False
 
     @classmethod
     def from_storage(cls, storage):
@@ -1522,8 +1523,8 @@ class ReplicaExchange(object):
 
         @staticmethod
         def _oa_min_iter_check(instance, online_analysis_minimum_iterations):
-            if instance.online_analysis_target_error is not None:
-                if type(online_analysis_minimum_iterations) is not int or online_analysis_minimum_iterations < 0:
+            if (instance.online_analysis_target_error is not None and
+                    (type(online_analysis_minimum_iterations) is not int or online_analysis_minimum_iterations < 0)):
                     raise ValueError("online_analysis_minimum_iterations must be an integer >= 0")
 
     number_of_iterations = _StoredProperty('number_of_iterations')
@@ -1542,7 +1543,7 @@ class ReplicaExchange(object):
 
     @property
     def is_completed(self):
-        """"Have we reached any of the stop target criterias?" (read-only)"""
+        """"Have we reached any of the stop target criteria?" (read-only)"""
         return self._is_completed
 
     # -------------------------------------------------------------------------
@@ -1921,8 +1922,13 @@ class ReplicaExchange(object):
             logger.error(err_msg)
             raise RuntimeError(err_msg)
 
-    def _display_citations(self):
-        """Display papers to be cited."""
+    @mpi.on_single_node(rank=0, broadcast_result=False, sync_nodes=False)
+    def _display_citations(self, overwrite_global=False):
+        """
+        Display papers to be cited.
+        The overwrite_golbal command will force the citation to display even if the "have_citations_been_shown" variable
+            is True
+        """
         # TODO Add original citations for various replica-exchange schemes.
         # TODO Show subset of OpenMM citations based on what features are being used.
         openmm_citations = """\
@@ -1937,11 +1943,13 @@ class ReplicaExchange(object):
         mbar_citations = """\
         Shirts MR and Chodera JD. Statistically optimal analysis of samples from multiple equilibrium states. J. Chem. Phys. 129:124105, 2008. DOI: 10.1063/1.2978177"""
 
-        print("Please cite the following:")
-        print("")
-        print(openmm_citations)
-        if self._replica_mixing_scheme == 'swap-all':
-            print(gibbs_citations)
+        if overwrite_global or (not self._have_displayed_citations_before and not self._global_citation_silence):
+            print("Please cite the following:")
+            print("")
+            print(openmm_citations)
+            if self._replica_mixing_scheme == 'swap-all':
+                print(gibbs_citations)
+            self._have_displayed_citations_before = True
 
     # -------------------------------------------------------------------------
     # Internal-usage: Initialization and storage utilities.
@@ -2323,6 +2331,7 @@ class ReplicaExchange(object):
         return output_dfe
 
     def _get_last_written_free_energy(self):
+        """Get the last free energy computed from online analysis"""
         last_f_k = None
         last_free_energy = None
         try:
@@ -2344,12 +2353,17 @@ class ReplicaExchange(object):
         # Case where we are running the online free energy and feed in nothing for the error
         if self._online_analysis_interval is not None and free_energy_error is None:
                 _, last_free_energy = self._get_last_written_free_energy()
-                _, free_energy_error = last_free_energy
+                _, free_energy_error = last_free_energy if last_free_energy is not None else (None, None)
         if free_energy_error is not None and free_energy_error <= self._online_analysis_target_error:
             completed = True
         elif self._iteration >= iteration_limit:  # Stop at iteration limit regardless
             completed = True
         return completed
+
+    # -------------------------------------------------------------------------
+    # Internal-usage: Test globals
+    # -------------------------------------------------------------------------
+    _global_citation_silence = False
 
 
 # ==============================================================================

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -2228,12 +2228,15 @@ class ReplicaExchange(object):
         self._reporter.open('r')
         if self._last_mbar_f_k is None:
             # Backwards search for last weights, don't need the 0th iteration because the weights are 0
-            for index in range(self._iteration, 0, -1):
-                f_k = self._reporter.read_mbar_weights(index)
-                # Find an f_k that is not all zeros
-                if not np.all(f_k == 0):
-                    self._last_mbar_f_k = f_k
-                    break  # Don't need to continue the loop if we already found one
+            try:
+                for index in range(self._iteration, 0, -1):
+                    f_k = self._reporter.read_mbar_weights(index)
+                    # Find an f_k that is not all zeros
+                    if not np.all(f_k == 0):
+                        self._last_mbar_f_k = f_k
+                        break  # Don't need to continue the loop if we already found one
+            except (IndexError, KeyError):  # No such f_k written yet (or variable created), no need to do anything
+                pass
         # Start the analysis
         bump_error_counter = False
         analysis = RepexPhase(self._reporter, analysis_kwargs={'initial_f_k': self._last_mbar_f_k})

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -45,7 +45,6 @@ import yaml
 import inspect
 import logging
 import datetime
-import operator
 import collections
 
 import numpy as np
@@ -1816,7 +1815,7 @@ class ReplicaExchange(object):
                 time_per_iteration = partial_total_time / (self._iteration - run_initial_iteration)
                 estimated_time_remaining = time_per_iteration * (iteration_limit - self._iteration)
                 estimated_total_time = time_per_iteration * iteration_limit
-                estimated_finish_time = partial_total_time + estimated_time_remaining
+                estimated_finish_time = time.time() + estimated_time_remaining
                 logger.debug("Iteration took {:.3f}s.".format(iteration_time))
                 logger.debug("Estimated completion in {}, at {} (consuming total wall clock time {}).".format(
                     str(datetime.timedelta(seconds=estimated_time_remaining)), time.ctime(estimated_finish_time),

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -14,6 +14,7 @@ TODO
 # =============================================================================================
 
 import os
+import sys
 import math
 import copy
 import pickle
@@ -32,6 +33,14 @@ from openmmtools import testsystems
 
 from yank import mpi, utils, analyze
 from yank.repex import Reporter, ReplicaExchange, _DictYamlLoader
+
+if sys.version_info[0] == 2:
+    from io import BytesIO as StringIO
+else:
+    from io import StringIO
+
+# quiet down some citation spam
+ReplicaExchange._global_citation_silence = True
 
 # ==============================================================================
 # MODULE CONSTANTS
@@ -601,6 +610,60 @@ class TestReplicaExchange(object):
             assert len(metadata) == 1
             assert repex.metadata['title'] == metadata['title']
 
+    @staticmethod
+    @contextlib.contextmanager
+    def captured_output():
+        new_out, new_err = StringIO(), StringIO()
+        old_out, old_err = sys.stdout, sys.stderr
+        try:
+            sys.stdout, sys.stderr = new_out, new_err
+            yield sys.stdout, sys.stderr
+        finally:
+            sys.stdout, sys.stderr = old_out, old_err
+
+    def test_citations(self):
+        thermodynamic_states, sampler_states, unsampled_states = copy.deepcopy(self.alanine_test)
+
+        # Remove one sampler state to verify distribution over states.
+        sampler_states = sampler_states[:-1]
+
+        with self.temporary_storage_path() as storage_path:
+            repex = ReplicaExchange()
+            # Ensure global mute is on
+            repex._global_citation_silence = True
+
+            # Create simulation and storage file.
+            reporter = Reporter(storage_path, checkpoint_interval=1)
+            # Trap expected output
+            with self.captured_output() as (out, _):
+                repex._display_citations(overwrite_global=True)
+                cite_string = out.getvalue().strip()
+                repex.create(thermodynamic_states, sampler_states, storage=reporter,
+                             unsampled_thermodynamic_states=unsampled_states)
+                # Reset internal flag
+                repex._have_displayed_citations_before = False
+                # Test that the overwrite flag worked
+                assert cite_string != ''
+            # Test that the output is not generate when the global is set
+            with self.captured_output() as (out, _):
+                repex._global_citation_silence = True
+                repex._display_citations()
+                output = out.getvalue().strip()
+                assert cite_string not in output
+            # Test that the output is generated with the global is not set and previously un shown
+            with self.captured_output() as (out, _):
+                repex._global_citation_silence = False
+                repex._have_displayed_citations_before = False
+                repex._display_citations()
+                output = out.getvalue().strip()
+                assert cite_string in output
+            # Repeat to ensure the citations are not generated a second time
+            with self.captured_output() as (out, _):
+                repex._global_citation_silence = False
+                repex._display_citations()
+                output = out.getvalue().strip()
+                assert cite_string not in output
+
     def test_from_storage(self):
         """Test that from_storage completely restore ReplicaExchange.
 
@@ -1089,6 +1152,44 @@ class TestReplicaExchange(object):
             repex = ReplicaExchange.from_storage(reporter)
             energies_rep, _ = repex._reporter.read_energies()
             assert np.all(energies_str == energies_rep)
+
+    def test_online_analysis_works(self):
+        """Test online analysis runs"""
+        thermodynamic_states, sampler_states, unsampled_states = copy.deepcopy(self.alanine_test)
+        with self.temporary_storage_path() as storage_path:
+            n_iterations = 5
+            online_interval = 2
+            move = mmtools.mcmc.IntegratorMove(openmm.VerletIntegrator(1.0 * unit.femtosecond), n_steps=1)
+            repex = ReplicaExchange(mcmc_moves=move, number_of_iterations=n_iterations,
+                                    online_analysis_interval=online_interval,
+                                    online_analysis_minimum_iterations=0)
+            repex.create(thermodynamic_states, sampler_states, storage=storage_path,
+                         unsampled_thermodynamic_states=unsampled_states)
+            # Run
+            repex.run()
+            last_mbar_f_k, free_energy = repex._get_last_written_free_energy()
+            assert len(last_mbar_f_k) == len(thermodynamic_states)
+            assert len(free_energy) == 2
+            assert not np.all(last_mbar_f_k == 0)
+            # Error should not be 0 yet
+            assert not free_energy[-1] == 0
+
+    def test_online_analysis_stops(self):
+        """Test online analysis will stop the simulation"""
+        thermodynamic_states, sampler_states, unsampled_states = copy.deepcopy(self.alanine_test)
+        with self.temporary_storage_path() as storage_path:
+            n_iterations = 5
+            online_interval = 1
+            move = mmtools.mcmc.IntegratorMove(openmm.VerletIntegrator(1.0 * unit.femtosecond), n_steps=1)
+            repex = ReplicaExchange(mcmc_moves=move, number_of_iterations=n_iterations,
+                                    online_analysis_interval=online_interval,
+                                    online_analysis_minimum_iterations=0,
+                                    online_analysis_target_error=np.inf)  # use infinite error to stop right away
+            repex.create(thermodynamic_states, sampler_states, storage=storage_path,
+                         unsampled_thermodynamic_states=unsampled_states)
+            # Run
+            repex.run()
+            assert repex._iteration < n_iterations
 
 # ==============================================================================
 # MAIN AND TESTS

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -691,6 +691,17 @@ class TestReplicaExchange(object):
                 original_dict.pop('_cached_transition_counts', None)
                 original_dict.pop('_cached_last_replica_thermodynamic_states', None)
 
+                # Check that the original completed,
+                # No need to check restored since _is_completed is not cached, just computed on the fly
+                original_completed = original_dict.pop('_is_completed')
+                if iteration == 0:
+                    # Should not be completed on first pass
+                    assert not original_completed
+                else:
+                    # Is completed after going through all iterations (see end of this loop)
+                    assert original_completed
+                _ = restored_dict.pop('_is_completed')
+
                 # Check all other arrays. Instantiate list so that we can pop from original_dict.
                 for attr, original_value in list(original_dict.items()):
                     if isinstance(original_value, np.ndarray):

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -1077,8 +1077,6 @@ class YamlPhaseFactory(object):
         'number_of_equilibration_iterations': 0,
         'equilibration_timestep': 1.0 * unit.femtosecond,
         'checkpoint_interval': 10,
-        'online_analysis_interval': None,
-        'online_analysis_target_error': 1.0,
     }
 
     def __init__(self, sampler, thermodynamic_state, sampler_states, topography,
@@ -1206,6 +1204,10 @@ class YamlExperiment(object):
                 # Update phase iteration info.
                 iterations_left[phase_id] -= iterations_to_run
                 self._phases_last_iterations[phase_id] = alchemical_phase.iteration
+
+                # Do one last check to see if the phase has converged by other means (e.g. online analysis)
+                if alchemical_phase.is_complete:
+                    self._phases_last_iterations[phase_id] = 0
 
                 # Delete alchemical phase and prepare switching.
                 del alchemical_phase

--- a/Yank/yamlbuild.py
+++ b/Yank/yamlbuild.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # CONSTANTS
 # =============================================================================
 
-HIGHEST_VERSION = '1.2'  # highest version of YAML syntax
+HIGHEST_VERSION = '1.3'  # highest version of YAML syntax
 
 # Map the OpenMM-style name for a solvent to the tleap
 # name compatible with the solvateBox command.
@@ -1077,6 +1077,8 @@ class YamlPhaseFactory(object):
         'number_of_equilibration_iterations': 0,
         'equilibration_timestep': 1.0 * unit.femtosecond,
         'checkpoint_interval': 10,
+        'online_analysis_interval': None,
+        'online_analysis_target_error': 1.0,
     }
 
     def __init__(self, sampler, thermodynamic_state, sampler_states, topography,

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -411,6 +411,14 @@ class AlchemicalPhase(object):
     def number_of_iterations(self, value):
         self._sampler.number_of_iterations = value
 
+    @property
+    def is_complete(self):
+        """bool: is the sampler complete by some other mechanism. If no method is present in sampler, returns False"""
+        try:
+            return self._sampler.is_complete
+        except AttributeError:
+            return False
+
     def create(self, thermodynamic_state, sampler_states, topography, protocol,
                storage, restraint=None, anisotropic_dispersion_cutoff=None,
                alchemical_regions=None, alchemical_factory=None, metadata=None):

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -413,11 +413,14 @@ class AlchemicalPhase(object):
 
     @property
     def is_complete(self):
-        """bool: is the sampler complete by some other mechanism. If no method is present in sampler, returns False"""
+        """
+        bool: is the sampler complete by some other mechanism.
+        If no method is present in sampler, check if sampler's current iteration is number of iterations
+        """
         try:
             return self._sampler.is_complete
         except AttributeError:
-            return False
+            return self._sampler.iteration >= self._sampler.number_of_iterations
 
     def create(self, thermodynamic_state, sampler_states, topography, protocol,
                storage, restraint=None, anisotropic_dispersion_cutoff=None,

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,13 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the github yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.16.2 Startup Speed and Reduced File Sizes
+-------------------------------------------
+- Automatic Expanded Cutoff Distance Selection
+- Compressed stored systems drastically reduce initial file sizes
+- Use C Yaml Dumper and Loaders to speed up YAML object processing
+- Requires OpenMMTools 0.11.2 at minimum
+
 0.16.1 Auto Expanded Cutoffs and bug fixes for Transition Matrix and Reporter
 -----------------------------------------------------------------------------
 - Expanded cutoff now able to be chosen automatically instead of just hard coded number

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -84,6 +84,12 @@ Detailed Options List
     * :ref:`softcore_e <yaml_options_alchemical_electrostatics>`
     * :ref:`softcore_f <yaml_options_alchemical_electrostatics>`
 
+  * :ref:`Online Analysis Parameters <yaml_options_online_analysis_parameters>`
+
+    * :ref:`online_analysis_interval <yaml_options_online_analysis_interval>`
+    * :ref:`online_analysis_target_error <yaml_options_online_analysis_target_error>`
+    * :ref:`online_analysis_minimum_iterations <yaml_options_online_analysis_minimum_iterations>`
+
 * :doc:`molecules <molecules>`
 
   * :ref:`Specifying Molecule Names <yaml_molecules_specifiy_names>`

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -646,3 +646,75 @@ Valid Options for ``softcore_[d,e,f]`` (1,1,2): <Integer preferred, Float accept
 .. [1] Quantity strings are of the format: ``<float> * <unit>`` where ``<unit>`` is any valid unit specified in the "Valid Options" for an option. e.g. "<Quantity Length>" indicates any measure of length may be used for <unit> such as nanometer or angstrom.
    Compound units are also parsed such as ``kilogram / meter**3`` for density.
    Only full unit names as they appear in the simtk.unit package (part of OpenMM) are allowed; so "nm" and "A" will be rejected.
+
+|
+
+
+
+.. _yaml_options_online_analysis_parameters:
+
+Online Analysis Parameters
+==========================
+
+YANK also supports an online free energy analysis framework which allows running simulations up to some target error
+in the free energy. Note that this will pause the simulation to run this analysis. The longer the simulation gets,
+the slower this process becomes.
+
+
+.. _yaml_options_online_analysis_interval:
+
+online_analysis_interval
+------------------------
+.. code-block:: yaml
+
+   options:
+      online_analysis_interval: 100
+
+Both the toggle and iteration count between online analysis operations. Every interval, the Multistate Bennet Acceptance
+Ratio estimate for the free energy is calculated and the error is computed. Some data is preserved each iteration to
+speed up future calculations, but this operation will still slow down as more iterations are added. We recommend
+choosing an interval of *at least* 100, if not more.
+
+If set to ``null`` (default), then online analysis is not run.
+
+Valid Options (``null``): ``null`` or <Int >= 1>
+
+
+.. _yaml_options_online_analysis_target_error:
+
+online_analysis_target_error
+----------------------------
+.. code-block:: yaml
+
+   options:
+      online_analysis_target_error: 1.0
+
+The target error for the online analysis measured in kT. Once the free energy is at or below this value, the phase will be considered complete.
+This value should be a number greater than 0, even though 0 is a valid option. The error free energy estimate between states
+is never zero except in very rare cases
+
+If :ref:`yaml_options_online_analysis_interval` is ``null``, this option does nothing.
+
+Valid Options (1.0): <Float >= 0>
+
+
+.. _yaml_options_online_analysis_minimum_iterations:
+
+online_analysis_minimum_iterations
+----------------------------------
+.. code-block:: yaml
+
+   options:
+      online_analysis_minimum_iterations: 50
+
+Number of iterations that are skipped at the beginning of the simulation before online analysis is attempted. This is
+a speed option since most of the initial iterations will be either equilibration or under sampled. We recommend choosing
+an initial number that is at least one or two ref:`yaml_options_online_analysis_interval`'s for speed's sake.
+
+The first iteration at which online analysis is performed is not affected by this number and always tracked as the
+modulo of the current iteration. E.g. if you have ``online_analysis_interval: 100` and
+`online_analysis_minimum_iterations: 150`, online analysis would happen at iteration 200 first, not iteration 250.
+
+If :ref:`yaml_options_online_analysis_interval` is ``null``, this option does nothing.
+
+Valid Options (50)

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -414,7 +414,16 @@ number_of_iterations
 Number of iterations for production simulation. Note: If :ref:`resume_simulation <yaml_options_resume_simulation>` is
 set, this option can be used to extend previous simulations past their original number of iterations.
 
-Valid Options (1): <Integer>
+Specifying ``0`` will run through the setup, create all the simulation files, store all options, and minimize the
+initial configurations (if specified), but will not run any production simulations.
+
+Set this to ``null`` to run an unlimited number of iterations. The simulation will not stop unless
+some other criteria is stops it. We **strongly** recommend specifying either
+:ref:`online free energy analysis <yaml_options_online_analysis_parameters>` and/or
+:ref:`a phase switching interval <switch_phase_interval>` to ensure there is at least some stop criteria, and all
+phases yield some samples.
+
+Valid Options (1): <Integer> or ``null``
 
 
 ..
@@ -689,13 +698,14 @@ online_analysis_target_error
    options:
       online_analysis_target_error: 1.0
 
-The target error for the online analysis measured in kT. Once the free energy is at or below this value, the phase will be considered complete.
+The target error for the online analysis measured in kT per phase. Once the free energy is at or below this value,
+the phase will be considered complete.
 This value should be a number greater than 0, even though 0 is a valid option. The error free energy estimate between states
-is never zero except in very rare cases
+is never zero except in very rare cases, so your simulation may never converge if you set this to 0.
 
 If :ref:`yaml_options_online_analysis_interval` is ``null``, this option does nothing.
 
-Valid Options (1.0): <Float >= 0>
+Valid Options (0.2): <Float >= 0>
 
 
 .. _yaml_options_online_analysis_minimum_iterations:
@@ -709,7 +719,7 @@ online_analysis_minimum_iterations
 
 Number of iterations that are skipped at the beginning of the simulation before online analysis is attempted. This is
 a speed option since most of the initial iterations will be either equilibration or under sampled. We recommend choosing
-an initial number that is at least one or two ref:`yaml_options_online_analysis_interval`'s for speed's sake.
+an initial number that is *at least* one or two :ref:`yaml_options_online_analysis_interval`'s for speed's sake.
 
 The first iteration at which online analysis is performed is not affected by this number and always tracked as the
 modulo of the current iteration. E.g. if you have ``online_analysis_interval: 100` and
@@ -717,4 +727,4 @@ modulo of the current iteration. E.g. if you have ``online_analysis_interval: 10
 
 If :ref:`yaml_options_online_analysis_interval` is ``null``, this option does nothing.
 
-Valid Options (50)
+Valid Options (50): <Int >=1>

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.16.3"  # Primary base version of the build
+VERSION = "0.17.0"  # Primary base version of the build
 DEVBUILD = "0"      # Dev build status, Either None or Integer as string
 ISRELEASED = False  # Are we releasing this as a full cut?
 __version__ = VERSION


### PR DESCRIPTION
This PR adds online analysis to the YANK simulations, handled primarily at the sampler level.

* Adds 3 options to the Repex API (and YAML options)
* Includes error and sanity checks common to MBAR without crashing the simulation.
* Stores the last online analysis attempt's MBAR f_k to use as the first guess of the new online analysis computations
* Should be backwards compatible?
