### PR TITLE
Add Analyze Tests, Fix MultiPhaseAnalyze

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -1142,7 +1142,7 @@ class MultiPhaseAnalyzer(object):
                 if observable_name in _ObservablesRegistry.observables_with_error_adding_linear():
                     passed_output['error'] += payload['error']
                 elif observable_name in _ObservablesRegistry.observables_with_error_adding_quadrature():
-                    passed_output['error'] += (passed_output['error']**2 + payload['error']**2)**0.5
+                    passed_output['error'] = (passed_output['error']**2 + payload['error']**2)**0.5
             else:
                 if sign == '+':
                     passed_output += payload

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -4,34 +4,22 @@
 # Analyze datafiles produced by YANK.
 # =============================================================================================
 
-# =============================================================================================
-# REQUIREMENTS
-#
-# The netcdf4-python module is now used to provide netCDF v4 support:
-# http://code.google.com/p/netcdf4-python/
-#
-# This requires NetCDF with version 4 and multithreading support, as well as HDF5.
-# =============================================================================================
-
 import os
 import os.path
 
-import yaml
 import abc
 import copy
+import yaml
 import numpy as np
 
 import openmmtools as mmtools
 from .repex import Reporter
-import netCDF4 as netcdf  # netcdf4-python
 
 from pymbar import MBAR  # multi-state Bennett acceptance ratio
 from pymbar import timeseries  # for statistical inefficiency analysis
 
 import mdtraj
 import simtk.unit as units
-
-from . import utils
 
 import logging
 logger = logging.getLogger(__name__)
@@ -44,6 +32,10 @@ ABC = abc.ABCMeta('ABC', (object,), {})  # compatible with Python 2 *and* 3
 
 kB = units.BOLTZMANN_CONSTANT_kB * units.AVOGADRO_CONSTANT_NA
 
+
+# =============================================================================================
+# MODULE FUNCTIONS
+# =============================================================================================
 
 def generate_phase_name(current_name, name_list):
     """Provide a regular way to generate unique names"""
@@ -88,6 +80,10 @@ def get_analyzer(file_base_path):
         raise RuntimeError("Cannot automatically determine analyzer for Reporter: {}".format(reporter))
     return analyzer
 
+
+# =============================================================================================
+# MODULE CLASSES
+# =============================================================================================
 
 class _ObservablesRegistry(object):
     """
@@ -161,6 +157,7 @@ class _ObservablesRegistry(object):
     ##########################################
     @staticmethod
     def observables_with_error():
+        """Determine which observables have error by inspecting the the error subsets"""
         observables = set()
         for subset in (_ObservablesRegistry.observables_with_error_adding_quadrature(),
                        _ObservablesRegistry.observables_with_error_adding_linear()):
@@ -173,12 +170,18 @@ class _ObservablesRegistry(object):
     # ------------------------------------------------
     @staticmethod
     def observables_with_error_adding_quadrature():
+        """Observable C = A + B, Error eC = sqrt(eA**2 + eB**2)"""
         return 'entropy', 'enthalpy', 'free_energy'
 
     @staticmethod
     def observables_with_error_adding_linear():
+        """Observable C = A + B, Error eC = eA + eB"""
         return tuple()
 
+
+# ---------------------------------------------------------------------------------------------
+# Phase Analyzers
+# ---------------------------------------------------------------------------------------------
 
 class YankPhaseAnalyzer(ABC):
     """
@@ -364,10 +367,12 @@ class YankPhaseAnalyzer(ABC):
     # Static methods
     @staticmethod
     def get_decorrelation_time(timeseries_to_analyze):
+        """Compute the decorrelation times given a timeseries"""
         return timeseries.statisticalInefficiency(timeseries_to_analyze)
 
     @staticmethod
     def get_equilibration_data(timeseries_to_analyze):
+        """Compute equilibration method given a timeseries"""
         [n_equilibration, g_t, n_effective_max] = timeseries.detectEquilibration(timeseries_to_analyze)
         return n_equilibration, g_t, n_effective_max
 
@@ -500,6 +505,7 @@ class YankPhaseAnalyzer(ABC):
         self._mbar = mbar
 
     def _combine_phases(self, other, operator='+'):
+        """Workhorse function when creating a MultiPhaseAnalyzer object by combining single YankPhaseAnalyzers"""
         phases = [self]
         names = []
         signs = [self._sign]
@@ -698,6 +704,7 @@ class RepexPhase(YankPhaseAnalyzer):
         return u_n
 
     def _prepare_mbar_input_data(self, sampled_energy_matrix, unsampled_energy_matrix):
+        """Convert the sampled and unsampled energy matrices into MBAR ready data"""
         nstates, _, niterations = sampled_energy_matrix.shape
         _, nunsampled, _ = unsampled_energy_matrix.shape
         # Subsample data to obtain uncorrelated samples
@@ -1224,331 +1231,9 @@ def analyze_directory(source_directory):
         dDeltaH * kT / units.kilocalories_per_mole))
 
 
-"""
-Everything below here is the old code. Currently left in for comparison
-"""
-
-
-
-
-
-
-
-
-
-# =============================================================================================
-# SUBROUTINES
-# =============================================================================================
-
-
-def generate_mixing_statistics(ncfile, number_equilibrated=0):
-    """
-    Generate the mixing statistics
-
-    Parameters
-    ----------
-    ncfile : netCDF4.Dataset
-       NetCDF file
-    number_equilibrated : int, optional, default=0
-       If specified, only samples number_equilibrated:end will be used in analysis
-
-    Returns
-    -------
-    mixing_stats : np.array of shape [nstates, nstates]
-        Transition matrix estimate
-    mu : np.array
-        Eigenvalues of the Transition matrix sorted in descending order
-    """
-
-    # Get dimensions.
-    niterations = ncfile.variables['states'].shape[0]
-    nstates = ncfile.variables['states'].shape[1]
-
-    # Compute empirical transition count matrix.
-    Nij = np.zeros([nstates, nstates], np.float64)
-    for iteration in range(number_equilibrated, niterations-1):
-        for ireplica in range(nstates):
-            istate = ncfile.variables['states'][iteration, ireplica]
-            jstate = ncfile.variables['states'][iteration+1, ireplica]
-            Nij[istate, jstate] += 1
-
-    # Compute transition matrix estimate.
-    # TODO: Replace with maximum likelihood reversible count estimator from msmbuilder or pyemma.
-    Tij = np.zeros([nstates,nstates], np.float64)
-    for istate in range(nstates):
-        denom = (Nij[istate,:].sum() + Nij[:,istate].sum())
-        if denom > 0:
-            for jstate in range(nstates):
-                Tij[istate, jstate] = (Nij[istate, jstate] + Nij[jstate, istate]) / denom
-        else:
-            Tij[istate, istate] = 1.0
-
-    # Estimate eigenvalues
-    mu = np.linalg.eigvals(Tij)
-    mu = -np.sort(-mu)  # Sort in descending order
-
-    return Tij, mu
-
-
-def show_mixing_statistics(ncfile, cutoff=0.05, number_equilibrated=0):
-    """
-    Print summary of mixing statistics. Passes information off to generate_mixing_statistics then prints it out to
-    the logger
-
-    Parameters
-    ----------
-
-    ncfile : netCDF4.Dataset
-       NetCDF file
-    cutoff : float, optional, default=0.05
-       Only transition probabilities above 'cutoff' will be printed
-    number_equilibrated : int, optional, default=0
-       If specified, only samples number_equilibrated:end will be used in analysis
-
-    """
-
-    Tij, mu = generate_mixing_statistics(ncfile, number_equilibrated=number_equilibrated)
-
-    # Print observed transition probabilities.
-    nstates = ncfile.variables['states'].shape[1]
-    logger.info("Cumulative symmetrized state mixing transition matrix:")
-    str_row = "%6s" % ""
-    for jstate in range(nstates):
-        str_row += "%6d" % jstate
-    logger.info(str_row)
-
-    for istate in range(nstates):
-        str_row = ""
-        str_row += "%-6d" % istate
-        for jstate in range(nstates):
-            P = Tij[istate,jstate]
-            if P >= cutoff:
-                str_row += "%6.3f" % P
-            else:
-                str_row += "%6s" % ""
-        logger.info(str_row)
-
-    # Estimate second eigenvalue and equilibration time.
-    if mu[1] >= 1:
-        logger.info("Perron eigenvalue is unity; Markov chain is decomposable.")
-    else:
-        logger.info("Perron eigenvalue is {0:9.5f}; state equilibration timescale is ~ {1:.1f} iterations".format(
-            mu[1], 1.0 / (1.0 - mu[1]))
-        )
-
-    return
-
-
-def extract_ncfile_energies(ncfile, ndiscard=0, nuse=None, g=None):
-    """
-    Extract and decorelate energies from the ncfile to gather common data for other functions
-
-    Parameters
-    ----------
-    ncfile : NetCDF
-       Input YANK netcdf file
-    ndiscard : int, optional, default=0
-       Number of iterations to discard to equilibration
-    nuse : int, optional, default=None
-       Maximum number of iterations to use (after discarding)
-    g : int, optional, default=None
-       Statistical inefficiency to use if desired; if None, will be computed.
-
-    TODO
-    ----
-    * Automatically determine 'ndiscard'.
-
-    """
-    # Get current dimensions.
-    niterations = ncfile.variables['energies'].shape[0]
-    nstates = ncfile.variables['energies'].shape[1]
-    natoms = ncfile.variables['energies'].shape[2]
-
-    # Extract energies.
-    logger.info("Reading energies...")
-    energies = ncfile.variables['energies']
-    u_kln_replica = np.zeros([nstates, nstates, niterations], np.float64)
-    for n in range(niterations):
-        u_kln_replica[:,:,n] = energies[n,:,:]
-    logger.info("Done.")
-
-    # Deconvolute replicas
-    logger.info("Deconvoluting replicas...")
-    u_kln = np.zeros([nstates, nstates, niterations], np.float64)
-    for iteration in range(niterations):
-        state_indices = ncfile.variables['states'][iteration,:]
-        u_kln[state_indices,:,iteration] = energies[iteration,:,:]
-    logger.info("Done.")
-
-    # Compute total negative log probability over all iterations.
-    u_n = np.zeros([niterations], np.float64)
-    for iteration in range(niterations):
-        u_n[iteration] = np.sum(np.diagonal(u_kln[:,:,iteration]))
-
-    # Discard initial data to equilibration.
-    u_kln_replica = u_kln_replica[:,:,ndiscard:]
-    u_kln = u_kln[:,:,ndiscard:]
-    u_n = u_n[ndiscard:]
-
-    # Truncate to number of specified conforamtions to use
-    if (nuse):
-        u_kln_replica = u_kln_replica[:,:,0:nuse]
-        u_kln = u_kln[:,:,0:nuse]
-        u_n = u_n[0:nuse]
-
-    # Subsample data to obtain uncorrelated samples
-    N_k = np.zeros(nstates, np.int32)
-    indices = timeseries.subsampleCorrelatedData(u_n, g=g) # indices of uncorrelated samples
-    #print(u_n) # DEBUG
-    #indices = range(0,u_n.size) # DEBUG - assume samples are uncorrelated
-    N = len(indices) # number of uncorrelated samples
-    N_k[:] = N
-    u_kln = u_kln[:,:,indices]
-    logger.info("number of uncorrelated samples:")
-    logger.info(N_k)
-    logger.info("")
-
-    # Check for the expanded cutoff states, and subsamble as needed
-    try:
-        u_ln_full_raw = ncfile.variables['fully_interacting_expanded_cutoff_energies'][:].T #Its stored as nl, need in ln
-        u_ln_non_raw = ncfile.variables['noninteracting_expanded_cutoff_energies'][:].T 
-        fully_interacting_u_ln = np.zeros(u_ln_full_raw.shape)
-        noninteracting_u_ln = np.zeros(u_ln_non_raw.shape)
-        # Deconvolute the fully interacting state
-        for iteration in range(niterations):
-            state_indices = ncfile.variables['states'][iteration,:]
-            fully_interacting_u_ln[state_indices,iteration] = u_ln_full_raw[:,iteration]
-            noninteracting_u_ln[state_indices,iteration] = u_ln_non_raw[:,iteration]
-        # Discard non-equilibrated samples
-        fully_interacting_u_ln = fully_interacting_u_ln[:,ndiscard:]
-        fully_interacting_u_ln = fully_interacting_u_ln[:,indices]
-        noninteracting_u_ln = noninteracting_u_ln[:,ndiscard:]
-        noninteracting_u_ln = noninteracting_u_ln[:,indices]
-        # Augment u_kln to accept the new state
-        u_kln_new = np.zeros([nstates + 2, nstates + 2, N], np.float64)
-        N_k_new = np.zeros(nstates + 2, np.int32)
-        # Insert energies
-        u_kln_new[1:-1,0,:] = fully_interacting_u_ln
-        u_kln_new[1:-1,-1,:] = noninteracting_u_ln
-        # Fill in other energies
-        u_kln_new[1:-1,1:-1,:] = u_kln 
-        N_k_new[1:-1] = N_k
-        # Notify users
-        logger.info("Found expanded cutoff states in the energies!")
-        logger.info("Free energies will be reported relative to them instead!")
-        # Reset values, last step in case something went wrong so we dont overwrite u_kln on accident
-        u_kln = u_kln_new
-        N_k = N_k_new
-    except:
-        pass
-
-    return u_kln, N_k, u_n
-
-
-def initialize_MBAR(ncfile, u_kln=None, N_k=None):
-    """
-    Initialize MBAR for Free Energy and Enthalpy estimates, this may take a while.
-
-    ncfile : NetCDF
-       Input YANK netcdf file
-    u_kln : array of numpy.float64, optional, default=None
-       Reduced potential energies of the replicas; if None, will be extracted from the ncfile
-    N_k : array of ints, optional, default=None
-       Number of samples drawn from each kth replica; if None, will be extracted from the ncfile
-
-    TODO
-    ----
-    * Ensure that the u_kln and N_k are decorrelated if not provided in this function
-
-    """
-
-    if u_kln is None or N_k is None:
-        (u_kln, N_k, u_n) = extract_ncfile_energies(ncfile)
-
-    # Initialize MBAR (computing free energy estimates, which may take a while)
-    logger.info("Computing free energy differences...")
-    mbar = MBAR(u_kln, N_k)
-    
-    return mbar
-    
-
-def estimate_free_energies(ncfile, mbar=None):
-    """
-    Estimate free energies of all alchemical states.
-
-    Parameters
-    ----------
-    ncfile : NetCDF
-       Input YANK netcdf file
-    mbar : pymbar MBAR object, optional, default=None
-       Initilized MBAR object from simulations; if None, it will be generated from the ncfile
-    
-    """
-
-    # Create MBAR object if not provided
-    if mbar is None:
-        mbar = initialize_MBAR(ncfile)
-
-    nstates = mbar.N_k.size
-
-    # Get matrix of dimensionless free energy differences and uncertainty estimate.
-    logger.info("Computing covariance matrix...")
-
-    try:
-        # pymbar 2
-        (Deltaf_ij, dDeltaf_ij) = mbar.getFreeEnergyDifferences()
-    except ValueError:
-        # pymbar 3
-        (Deltaf_ij, dDeltaf_ij, theta_ij) = mbar.getFreeEnergyDifferences()
-
-    # Matrix of free energy differences
-    logger.info("Deltaf_ij:")
-    for i in range(nstates):
-        str_row = ""
-        for j in range(nstates):
-            str_row += "%8.3f" % Deltaf_ij[i, j]
-        logger.info(str_row)
-
-    # Matrix of uncertainties in free energy difference (expectations standard
-    # deviations of the estimator about the true free energy)
-    logger.info("dDeltaf_ij:")
-    for i in range(nstates):
-        str_row = ""
-        for j in range(nstates):
-            str_row += "%8.3f" % dDeltaf_ij[i, j]
-        logger.info(str_row)
-
-    # Return free energy differences and an estimate of the covariance.
-    return Deltaf_ij, dDeltaf_ij
-
-
-def estimate_enthalpies(ncfile, mbar=None):
-    """
-    Estimate enthalpies of all alchemical states.
-
-    Parameters
-    ----------
-    ncfile : NetCDF
-       Input YANK netcdf file
-    mbar : pymbar MBAR object, optional, default=None
-       Initilized MBAR object from simulations; if None, it will be generated from the ncfile
-
-    TODO
-    ----
-    * Check if there is an output/function name difference between pymbar 2 and 3
-    """
-
-    # Create MBAR object if not provided
-    if mbar is None:
-        mbar = initialize_MBAR(ncfile)
-
-    nstates = mbar.N_k.size
-
-    # Compute average enthalpies
-    (f_k, df_k, H_k, dH_k, S_k, dS_k) = mbar.computeEntropyAndEnthalpy()
-
-    return H_k, dH_k
-
+# ==========================================
+# HELPER FUNCTIONS FOR TRAJECTORY EXTRACTION
+# ==========================================
 
 def extract_u_n(ncfile):
     """
@@ -1562,8 +1247,8 @@ def extract_u_n(ncfile):
 
     Parameters
     ----------
-    ncfile : str
-       The filename of the repex NetCDF file.
+    ncfile : netCDF4.Dataset
+       Open NetCDF file to analyze
 
     Returns
     -------
@@ -1572,7 +1257,7 @@ def extract_u_n(ncfile):
 
     TODO
     ----
-    Move this to repex.
+    Figure out a way to remove this function
 
     """
 
@@ -1593,8 +1278,8 @@ def extract_u_n(ncfile):
     logger.info("Deconvoluting replicas...")
     u_kln = np.zeros([nstates, nstates, niterations], np.float64)
     for iteration in range(niterations):
-        state_indices = ncfile.variables['states'][iteration,:]
-        u_kln[state_indices,:,iteration] = energies[iteration,:,:]
+        state_indices = ncfile.variables['states'][iteration, :]
+        u_kln[state_indices,:,iteration] = energies[iteration, :, :]
     logger.info("Done.")
 
     # Compute total negative log probability over all iterations.
@@ -1603,197 +1288,6 @@ def extract_u_n(ncfile):
         u_n[iteration] = np.sum(np.diagonal(u_kln[:,:,iteration]))
 
     return u_n
-
-# =============================================================================================
-# SHOW STATUS OF STORE FILES
-# =============================================================================================
-
-
-def print_status(store_directory):
-    """
-    Print a quick summary of simulation progress.
-
-    Parameters
-    ----------
-    store_directory : string
-       The location of the NetCDF simulation output files.
-
-    Returns
-    -------
-    success : bool
-       True is returned on success; False if some files could not be read.
-
-    """
-    # Get NetCDF files
-    phases = utils.find_phases_in_store_directory(store_directory)
-
-    # Process each netcdf file.
-    for phase, fullpath in phases.items():
-
-        # Check that the file exists.
-        if not os.path.exists(fullpath):
-            # Report failure.
-            logger.info("File %s not found." % fullpath)
-            logger.info("Check to make sure the right directory was specified, and 'yank setup' has been run.")
-            return False
-
-        # Open NetCDF file for reading.
-        logger.debug("Opening NetCDF trajectory file '%(fullpath)s' for reading..." % vars())
-        ncfile = netcdf.Dataset(fullpath, 'r')
-
-        # Read dimensions.
-        niterations = ncfile.variables['positions'].shape[0]
-        nstates = ncfile.variables['positions'].shape[1]
-        natoms = ncfile.variables['positions'].shape[2]
-
-        # Print summary.
-        logger.info("%s" % phase)
-        logger.info("  %8d iterations completed" % niterations)
-        logger.info("  %8d alchemical states" % nstates)
-        logger.info("  %8d atoms" % natoms)
-
-        # TODO: Print average ns/day and estimated completion time.
-
-        # Close file.
-        ncfile.close()
-
-    return True
-
-# =============================================================================================
-# ANALYZE STORE FILES
-# =============================================================================================
-
-
-def analyze(source_directory):
-    """
-    Analyze contents of store files to compute free energy differences.
-
-    Parameters
-    ----------
-    source_directory : string
-       The location of the NetCDF simulation storage files.
-
-    """
-    analysis_script_path = os.path.join(source_directory, 'analysis.yaml')
-    if not os.path.isfile(analysis_script_path):
-        err_msg = 'Cannot find analysis.yaml script in {}'.format(source_directory)
-        logger.error(err_msg)
-        raise RuntimeError(err_msg)
-    with open(analysis_script_path, 'r') as f:
-        analysis = yaml.load(f)
-    phases = [phase_name for phase_name, sign in analysis]
-
-    # Storage for different phases.
-    data = dict()
-
-    # Process each netcdf file.
-    for phase in phases:
-        ncfile_path = os.path.join(source_directory, phase + '.nc')
-
-        # Open NetCDF file for reading.
-        logger.info("Opening NetCDF trajectory file %(ncfile_path)s for reading..." % vars())
-        try:
-            ncfile = netcdf.Dataset(ncfile_path, 'r')
-
-            logger.debug("dimensions:")
-            for dimension_name in ncfile.dimensions.keys():
-                logger.debug("%16s %8d" % (dimension_name, len(ncfile.dimensions[dimension_name])))
-
-            # Read dimensions.
-            niterations = ncfile.variables['positions'].shape[0]
-            nstates = ncfile.variables['positions'].shape[1]
-            logger.info("Read %(niterations)d iterations, %(nstates)d states" % vars())
-
-            DeltaF_standard_state_correction = 0.0
-            if 'metadata' in ncfile.groups:
-                # Read phase direction and standard state correction free energy.
-                # Yank sets correction to 0 if there are no standard_state_correction
-                DeltaF_standard_state_correction = ncfile.groups['metadata'].variables['standard_state_correction'][0]
-
-            # Choose number of samples to discard to equilibration
-            MIN_ITERATIONS = 10 # minimum number of iterations to use automatic detection
-            if niterations > MIN_ITERATIONS:
-                from pymbar import timeseries
-                u_n = extract_u_n(ncfile)
-                u_n = u_n[1:] # discard initial frame of zero energies TODO: Get rid of initial frame of zero energies
-                [number_equilibrated, g_t, Neff_max] = timeseries.detectEquilibration(u_n)
-                number_equilibrated += 1 # account for initial frame of zero energies
-                logger.info([number_equilibrated, Neff_max])
-            else:
-                number_equilibrated = 1  # discard first frame
-                g_t = 1
-                Neff_max = niterations
-
-            # Examine acceptance probabilities.
-            show_mixing_statistics(ncfile, cutoff=0.05, number_equilibrated=number_equilibrated)
-
-            # Extract equilibrated, decorrelated energies, check for fully interacting state
-            (u_kln, N_k, u_n) = extract_ncfile_energies(ncfile, ndiscard=number_equilibrated, g=g_t)
-
-            # Create MBAR object to use for free energy and entropy states
-            mbar = initialize_MBAR(ncfile, u_kln=u_kln, N_k=N_k)
-
-            # Estimate free energies, use fully interacting state if present
-            (Deltaf_ij, dDeltaf_ij) = estimate_free_energies(ncfile, mbar=mbar)
-
-            # Estimate average enthalpies
-            (DeltaH_i, dDeltaH_i) = estimate_enthalpies(ncfile, mbar=mbar)
-
-            # Accumulate free energy differences
-            entry = dict()
-            entry['DeltaF'] = Deltaf_ij[0, -1]
-            entry['dDeltaF'] = dDeltaf_ij[0, -1]
-            entry['DeltaH'] = DeltaH_i[0, -1]
-            entry['dDeltaH'] = dDeltaH_i[0, -1]
-            entry['DeltaF_standard_state_correction'] = DeltaF_standard_state_correction
-            data[phase] = entry
-
-            # Get temperatures.
-            ncvar = ncfile.groups['thermodynamic_states'].variables['temperatures']
-            temperature = ncvar[0] * units.kelvin
-            kT = kB * temperature
-
-        finally:
-            ncfile.close()
-
-    # Compute free energy and enthalpy
-    DeltaF = 0.0
-    dDeltaF = 0.0
-    DeltaH = 0.0
-    dDeltaH = 0.0
-    for phase, sign in analysis:
-        DeltaF -= sign * (data[phase]['DeltaF'] + data[phase]['DeltaF_standard_state_correction'])
-        dDeltaF += data[phase]['dDeltaF']**2
-        DeltaH -= sign * (data[phase]['DeltaH'] + data[phase]['DeltaF_standard_state_correction'])
-        dDeltaH += data[phase]['dDeltaH']**2
-    dDeltaF = np.sqrt(dDeltaF)
-    dDeltaH = np.sqrt(dDeltaH)
-
-    # Attempt to guess type of calculation
-    calculation_type = ''
-    for phase in phases:
-        if 'complex' in phase:
-            calculation_type = ' of binding'
-        elif 'solvent1' in phase:
-            calculation_type = ' of solvation'
-
-    # Print energies
-    logger.info("")
-    logger.info("Free energy{}: {:16.3f} +- {:.3f} kT ({:16.3f} +- {:.3f} kcal/mol)".format(
-        calculation_type, DeltaF, dDeltaF, DeltaF * kT / units.kilocalories_per_mole,
-        dDeltaF * kT / units.kilocalories_per_mole))
-    logger.info("")
-
-    for phase in phases:
-        logger.info("DeltaG {:<25} : {:16.3f} +- {:.3f} kT".format(phase, data[phase]['DeltaF'],
-                                                                   data[phase]['dDeltaF']))
-        if data[phase]['DeltaF_standard_state_correction'] != 0.0:
-            logger.info("DeltaG {:<25} : {:25.3f} kT".format('restraint',
-                                                             data[phase]['DeltaF_standard_state_correction']))
-    logger.info("")
-    logger.info("Enthalpy{}: {:16.3f} +- {:.3f} kT ({:16.3f} +- {:.3f} kcal/mol)".format(
-        calculation_type, DeltaH, dDeltaH, DeltaH * kT / units.kilocalories_per_mole,
-        dDeltaH * kT / units.kilocalories_per_mole))
 
 
 # ==============================================================================

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -45,7 +45,6 @@ import yaml
 import inspect
 import logging
 import datetime
-import operator
 import collections
 
 import numpy as np
@@ -1816,7 +1815,7 @@ class ReplicaExchange(object):
                 time_per_iteration = partial_total_time / (self._iteration - run_initial_iteration)
                 estimated_time_remaining = time_per_iteration * (iteration_limit - self._iteration)
                 estimated_total_time = time_per_iteration * iteration_limit
-                estimated_finish_time = partial_total_time + estimated_time_remaining
+                estimated_finish_time = time.time() + estimated_time_remaining
                 logger.debug("Iteration took {:.3f}s.".format(iteration_time))
                 logger.debug("Estimated completion in {}, at {} (consuming total wall clock time {}).".format(
                     str(datetime.timedelta(seconds=estimated_time_remaining)), time.ctime(estimated_finish_time),

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -58,6 +58,7 @@ from . import utils, mpi, version
 from pymbar.utils import ParameterError
 
 logger = logging.getLogger(__name__)
+_global_citation_silence = False
 
 
 # ==============================================================================
@@ -1943,7 +1944,7 @@ class ReplicaExchange(object):
         mbar_citations = """\
         Shirts MR and Chodera JD. Statistically optimal analysis of samples from multiple equilibrium states. J. Chem. Phys. 129:124105, 2008. DOI: 10.1063/1.2978177"""
 
-        if not self._have_displayed_citations_before or overwrite_global:
+        if (not self._have_displayed_citations_before and not _global_citation_silence) or overwrite_global:
             print("Please cite the following:")
             print("")
             print(openmm_citations)

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -1,0 +1,295 @@
+#!/usr/local/bin/env python
+
+"""
+Test analyze.py facility.
+
+"""
+
+# =============================================================================================
+# GLOBAL IMPORTS
+# =============================================================================================
+
+import os
+import math
+import copy
+import shutil
+import tempfile
+import contextlib
+
+import yaml
+import pymbar
+import numpy as np
+import scipy.integrate
+from simtk import openmm, unit
+from nose.plugins.attrib import attr
+from nose.tools import assert_raises
+
+import openmmtools as mmtools
+from openmmtools import testsystems
+
+from yank import mpi, utils, analyze
+from yank.repex import Reporter, ReplicaExchange, _DictYamlLoader
+
+# ==============================================================================
+# MODULE CONSTANTS
+# ==============================================================================
+
+kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA  # Boltzmann constant
+
+
+# ==============================================================================
+# TEMPLATE PHASE CLASS WITH NO OBSERVABLES
+# ==============================================================================
+
+class BlankPhase(analyze.YankPhaseAnalyzer):
+    """Create a blank phase class with no get_X (observable) methods for testing the MultiPhaseAnalyzer"""
+    def analyze_phase(self, *args, **kwargs):
+        pass
+
+    def _create_mbar_from_scratch(self):
+        pass
+
+    def extract_energies(self):
+        pass
+
+    @staticmethod
+    def get_timeseries(passed_timeseries):
+        pass
+
+    def _prepare_mbar_input_data(self):
+        pass
+
+
+class FreeEnergyPhase(BlankPhase):
+    """
+    Create a phase which can return a free energy estimate
+
+    Tests the Observables depending on 2 phases and has an error
+    """
+    # Static constants test can access
+    fev = 1
+    dfev = 0.5
+
+    def get_free_energy(self):
+        value = np.ones([2, 2]) * self.fev
+        error = np.ones([2, 2]) * self.dfev
+        self._computed_observables['free_energy'] = {'value': value, 'error': error}
+        return value, error
+
+
+class FEStandardStatePhase(FreeEnergyPhase):
+    """
+    Class which also defines a standard state
+    Tests Observable with no error depending only on phase
+    """
+    # Static constant the test can access
+    ssc = -1
+
+    def get_standard_state_correction(self):
+        self._computed_observables['standard_state_correction'] = self.ssc
+        return self._computed_observables['standard_state_correction']
+
+
+# ==============================================================================
+# TEST ANALYZER
+# ==============================================================================
+
+class TestPhaseAnalyzer(object):
+    """Test suite for YankPhaseAnalyzer class."""
+
+    @classmethod
+    def setup_class(cls):
+        """Shared test cases and variables."""
+        n_states = 3
+        n_steps = 5
+
+        # Test case with host guest in vacuum at 3 different positions and alchemical parameters.
+        # -----------------------------------------------------------------------------------------
+        hostguest_test = testsystems.HostGuestVacuum()
+        factory = mmtools.alchemy.AbsoluteAlchemicalFactory()
+        alchemical_region = mmtools.alchemy.AlchemicalRegion(alchemical_atoms=range(126, 156))
+        hostguest_alchemical = factory.create_alchemical_system(hostguest_test.system, alchemical_region)
+
+        # Translate the sampler states to be different one from each other.
+        hostguest_sampler_states = [mmtools.states.SamplerState(hostguest_test.positions + 10*i*unit.nanometers)
+                                    for i in range(n_states)]
+
+        # Create the three basic thermodynamic states.
+        hostguest_thermodynamic_states = [mmtools.states.ThermodynamicState(hostguest_alchemical, 300*unit.kelvin)
+                                          for i in range(n_states)]
+
+        # Create alchemical states at different parameter values.
+        alchemical_states = [mmtools.alchemy.AlchemicalState.from_system(hostguest_alchemical)
+                             for _ in range(n_states)]
+        for i, alchemical_state in enumerate(alchemical_states):
+            alchemical_state.set_alchemical_parameters(float(i) / (n_states - 1))
+
+        # Create compound states.
+        hostguest_compound_states = list()
+        for i in range(n_states):
+            hostguest_compound_states.append(
+                mmtools.states.CompoundThermodynamicState(thermodynamic_state=hostguest_thermodynamic_states[i],
+                                                          composable_states=[alchemical_states[i]])
+            )
+
+        # Unsampled states.
+        nonalchemical_state = mmtools.states.ThermodynamicState(hostguest_test.system, 300*unit.kelvin)
+        hostguest_unsampled_states = [copy.deepcopy(nonalchemical_state), copy.deepcopy(nonalchemical_state)]
+
+        cls.hostguest_test = (hostguest_compound_states, hostguest_sampler_states, hostguest_unsampled_states)
+
+        # Run a quick simulation
+        thermodynamic_states, sampler_states, unsampled_states = copy.deepcopy(cls.hostguest_test)
+        n_states = len(thermodynamic_states)
+
+        # Remove one sampler state to verify distribution over states.
+        sampler_states = sampler_states[:-1]
+
+        repex = ReplicaExchange()
+
+        # Create simulation and storage file.
+        cls.tmp_dir = tempfile.mkdtemp()
+        storage_path = os.path.join(cls.tmp_dir, 'test_analyze.nc')
+        move = mmtools.mcmc.LangevinDynamicsMove(n_steps=1)
+        cls.repex = ReplicaExchange(mcmc_moves=move, number_of_iterations=n_steps)
+        cls.reporter = Reporter(storage_path)
+        # Generate some phony metadata since the HostGuest Vacuum does not have any
+        metadata = {'standard_state_correction': 4.0}
+        cls.repex.create(thermodynamic_states, sampler_states, storage=cls.reporter,
+                         unsampled_thermodynamic_states=unsampled_states, metadata=metadata)
+        # run some iterations
+        cls.n_states = n_states
+        cls.n_steps = n_steps
+        cls.repex.run(cls.n_steps-1)  # Initial config
+        cls.repex_name = "RepexPhase"
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.tmp_dir)
+
+    def test_repex_phase_initilize(self):
+        """Test that the Repex Phase analyzer initializes correctly"""
+        phase = analyze.RepexPhase(self.reporter, name=self.repex_name)
+        assert phase.reporter is self.reporter
+        assert phase.name == self.repex_name
+
+    def test_repex_mixing_stats(self):
+        """Test that the Repex Phase yields mixing stats that make sense"""
+        phase = analyze.RepexPhase(self.reporter, name=self.repex_name)
+        t, mu = phase.generate_mixing_statistics()
+        # Output is the correct number of states
+        assert t.shape == (self.n_states, self.n_states)
+        # Assert transition matrix values are all 0 <= x <= 1
+        assert np.all(np.logical_and(t >= 0, t <= 1))
+        # Assert all rows add to 1
+        for row in range(self.n_states):
+            assert t[row, :].sum() == 1
+        # Assert all eigenvalues are all <= 1
+        # Floating point error can lead mu[0] to be not exactly 1.0, but like 0.99999998 or something
+        assert np.allclose(mu[0], 1)
+
+    def test_mbar_creation_process(self):
+        """Test each of the steps of the MBAR creation process
+
+        We do this in one function since the test for each part would be a bunch of repeated recreation of the phase
+        """
+        phase = analyze.RepexPhase(self.reporter, name=self.repex_name)
+        u_sampled, u_unsampled = phase.extract_energies()
+        # Test energy output matches appropriate MBAR shapes
+        assert u_sampled.shape == (self.n_states, self.n_states, self.n_steps)
+        assert u_unsampled.shape == (self.n_states, 2, self.n_steps)
+        u_n = phase.get_timeseries(u_sampled)
+        assert u_n.shape == (self.n_steps,)
+        # This may need to be adjusted from time to time as analyze changes
+        discard = 1
+        # Generate mbar semi-manually, use phases's static methods
+        n_eq, g_t, Neff_max = pymbar.timeseries.detectEquilibration(u_n[discard:])
+        u_sampled_sub = phase.remove_unequilibrated_data(u_sampled, n_eq, -1)
+        # Make sure output from subsample is what we expect
+        assert u_sampled_sub.shape == (self.n_states, self.n_states, Neff_max)
+        # Generate MBAR from phase
+        phase_mbar = phase.mbar
+        # Assert mbar object is formed of nstates + unsampled states, Number of effective samples
+        assert phase_mbar.u_kn.shape == (self.n_states + 2, Neff_max*self.n_states)
+        # Check that Free energies are returned correctly
+        fe, dfe = phase.get_free_energy()
+        assert fe.shape == (self.n_states + 2, self.n_states + 2)
+        stored_fe_dict = phase._computed_observables['free_energy']
+        stored_fe, stored_dfe = stored_fe_dict['value'], stored_fe_dict['error']
+        assert np.all(stored_fe == fe)
+        assert np.all(stored_dfe == dfe)
+        # Test reference states and full work up creation
+        iinit, jinit = phase.reference_states
+        output = phase.analyze_phase()
+        fe_out, dfe_out = output['DeltaF'], output['dDeltaF']
+        assert fe_out == fe[iinit, jinit]
+        assert dfe_out == dfe[iinit, jinit]
+        inew, jnew = 1, 2
+        phase.reference_states = [inew, jnew]
+        new_output = phase.analyze_phase()
+        new_fe_out, new_dfe_out = new_output['DeltaF'], new_output['dDeltaF']
+        assert new_fe_out == fe[inew, jnew]
+        assert new_dfe_out == dfe[inew, jnew]
+
+    def test_multi_phase(self):
+        """Test MultiPhaseAnalysis"""
+        # Create the phases
+        full_phase = analyze.RepexPhase(self.reporter, name=self.repex_name)
+        blank_phase = BlankPhase(self.reporter, name="blank")
+        fe_phase = FreeEnergyPhase(self.reporter, name="fe")
+        fes_phase = FEStandardStatePhase(self.reporter, name="fes")
+        # Test that a full phase can be added to itself
+        double = full_phase + full_phase
+        triple = full_phase + full_phase - full_phase
+        # Tests the __neg__ of phase and not just __sub__ of phase
+        quad = - full_phase - full_phase + full_phase + full_phase
+        # Assert that names are unique
+        for names in [double.names, triple.names, quad.names]:
+            # Assert basename in names
+            assert self.repex_name in names
+            # Assert unique names
+            assert len(names) == len(set(names))
+        # Check signs
+        assert double.signs == ['+', '+']
+        assert triple.signs == ['+', '+', '-']
+        assert quad.signs == ['-', '-', '+', '+']
+        # Check cannot combine things that are blank
+        with assert_raises(RuntimeError):
+            _ = full_phase + blank_phase
+        # Check combine partial data
+        full_fe_phase = full_phase + fe_phase
+        # Check methods  of full_fe
+        assert hasattr(full_fe_phase, 'get_free_energy')
+        assert not hasattr(full_fe_phase, 'get_enthalpy')
+        # prep final property
+        full_fes = full_phase + fes_phase
+        # Compute free energy
+        free_energy_full_fe, dfree_energy_full_fe = full_fe_phase.get_free_energy()
+        full_free_energy, full_dfree_energy = full_phase.get_free_energy()
+        i, j = full_phase.reference_states
+        full_free_energy, full_dfree_energy = full_free_energy[i, j], full_dfree_energy[i, j]
+        # Check free energy values
+        assert free_energy_full_fe == full_free_energy + fe_phase.fev
+        assert dfree_energy_full_fe == np.sqrt(full_dfree_energy**2 + fe_phase.dfev**2)
+        # Check by phase (should only yield 1 value, no error)
+        combo_standard_state = full_fes.get_standard_state_correction()
+        assert combo_standard_state == full_phase.get_standard_state_correction() + fes_phase.ssc
+        # Check compound multiphase stuff
+        quad_free_energy, quad_dfree_energy = quad.get_free_energy()
+        assert quad_free_energy == 0
+        assert quad_dfree_energy == np.sqrt(4*full_dfree_energy**2)
+        assert triple.get_standard_state_correction() == (2*full_phase.get_standard_state_correction() -
+                                                          full_phase.get_standard_state_correction())
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -37,7 +37,7 @@ from yank.repex import Reporter, ReplicaExchange, _DictYamlLoader
 # MODULE CONSTANTS
 # ==============================================================================
 
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA # Boltzmann constant
+kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA  # Boltzmann constant
 
 
 # ==============================================================================

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -691,6 +691,17 @@ class TestReplicaExchange(object):
                 original_dict.pop('_cached_transition_counts', None)
                 original_dict.pop('_cached_last_replica_thermodynamic_states', None)
 
+                # Check that the original completed,
+                # No need to check restored since _is_completed is not cached, just computed on the fly
+                original_completed = original_dict.pop('_is_completed')
+                if iteration == 0:
+                    # Should not be completed on first pass
+                    assert not original_completed
+                else:
+                    # Is completed after going through all iterations (see end of this loop)
+                    assert original_completed
+                _ = restored_dict.pop('_is_completed')
+
                 # Check all other arrays. Instantiate list so that we can pop from original_dict.
                 for attr, original_value in list(original_dict.items()):
                     if isinstance(original_value, np.ndarray):

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -35,12 +35,12 @@ standard_protocol = """
         absolute-binding:
             complex:
                 alchemical_path:
-                    lambda_electrostatics: [1.0, 0.9, 0.8, 0.6, 0.4, 0.2, 0.0]
-                    lambda_sterics: [1.0, 0.9, 0.8, 0.6, 0.4, 0.2, 0.0]
+                    lambda_electrostatics: [1.0, 0.5, 0.0]
+                    lambda_sterics: [1.0, 0.5, 0.0]
             solvent:
                 alchemical_path:
-                    lambda_electrostatics: [1.0, 0.8, 0.6, 0.3, 0.0]
-                    lambda_sterics: [1.0, 0.8, 0.6, 0.3, 0.0]"""
+                    lambda_electrostatics: [1.0, 0.5, 0.0]
+                    lambda_sterics: [1.0, 0.5, 0.0]"""
 
 
 def indent(str):
@@ -163,12 +163,12 @@ def get_template_script(output_dir='.'):
         absolute-binding:
             complex:
                 alchemical_path:
-                    lambda_electrostatics: [1.0, 0.9, 0.8, 0.6, 0.4, 0.2, 0.0]
-                    lambda_sterics: [1.0, 0.9, 0.8, 0.6, 0.4, 0.2, 0.0]
+                    lambda_electrostatics: [1.0, 0.5, 0.0]
+                    lambda_sterics: [1.0, 0.5, 0.0]
             solvent:
                 alchemical_path:
-                    lambda_electrostatics: [1.0, 0.8, 0.6, 0.3, 0.0]
-                    lambda_sterics: [1.0, 0.8, 0.6, 0.3, 0.0]
+                    lambda_electrostatics: [1.0, 0.5, 0.0]
+                    lambda_sterics: [1.0, 0.5, 0.0]
     experiments:
         system: explicit-system
         protocol: absolute-binding
@@ -516,16 +516,16 @@ def test_order_phases():
     absolute-binding:
         {}:
             alchemical_path:
-                lambda_electrostatics: [1.0, 0.9, 0.8, 0.6, 0.4, 0.2, 0.0]
-                lambda_sterics: [1.0, 0.9, 0.8, 0.6, 0.4, 0.2, 0.0]
+                lambda_electrostatics: [1.0, 0.5, 0.0]
+                lambda_sterics: [1.0, 0.5, 0.0]
         {}:
             alchemical_path:
-                lambda_electrostatics: [1.0, 0.8, 0.6, 0.3, 0.0]
-                lambda_sterics: [1.0, 0.8, 0.6, 0.3, 0.0]
+                lambda_electrostatics: [1.0, 0.5, 0.0]
+                lambda_sterics: [1.0, 0.5, 0.0]
         {}:
             alchemical_path:
-                lambda_electrostatics: [1.0, 0.8, 0.6, 0.3, 0.0]
-                lambda_sterics: [1.0, 0.8, 0.6, 0.3, 0.0]"""
+                lambda_electrostatics: [1.0, 0.5, 0.0]
+                lambda_sterics: [1.0, 0.5, 0.0]"""
 
     # Find order of phases for which normal parsing is not ordered or the test is useless
     for ordered_phases in itertools.permutations(['athirdphase', 'complex', 'solvent']):
@@ -546,11 +546,11 @@ def test_validation_correct_protocols():
 
     # Alchemical paths
     protocols = [
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_sterics': [1.0, 0.8, 0.6, 0.3, 0.0]},
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_sterics': [1.0, 0.8, 0.6, 0.3, 0.0],
-         'lambda_torsions': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_angles': [1.0, 0.8, 0.6, 0.3, 0.0]},
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_sterics': [1.0, 0.8, 0.6, 0.3, 0.0],
-         'temperature': ['300*kelvin', '320*kelvin', '340*kelvin', '320*kelvin', '300*kelvin']}
+        {'lambda_electrostatics': [1.0, 0.5, 0.0], 'lambda_sterics': [1.0, 0.5, 0.0]},
+        {'lambda_electrostatics': [1.0, 0.5, 0.0], 'lambda_sterics': [1.0, 0.5, 0.0],
+         'lambda_torsions': [1.0, 0.5, 0.0], 'lambda_angles': [1.0, 0.5, 0.0]},
+        {'lambda_electrostatics': [1.0, 0.5, 0.0], 'lambda_sterics': [1.0, 0.5, 0.0],
+         'temperature': ['300*kelvin', '340*kelvin', '300*kelvin']}
     ]
     for protocol in protocols:
         modified_protocol = copy.deepcopy(basic_protocol)
@@ -586,12 +586,12 @@ def test_validation_wrong_protocols():
 
     # Alchemical paths
     protocols = [
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0]},
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_sterics': [1.0, 0.8, 0.6, 0.3, 'wrong!']},
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_sterics': [1.0, 0.8, 0.6, 0.3, 11000.0]},
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_sterics': [1.0, 0.8, 0.6, 0.3, -0.5]},
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_sterics': 0.0},
-        {'lambda_electrostatics': [1.0, 0.8, 0.6, 0.3, 0.0], 'lambda_sterics': [1.0, 0.8, 0.6, 0.3, 0.0], 3: 2}
+        {'lambda_electrostatics': [1.0, 0.5, 0.0]},
+        {'lambda_electrostatics': [1.0, 0.5, 0.0], 'lambda_sterics': [1.0, 0.5, 'wrong!']},
+        {'lambda_electrostatics': [1.0, 0.5, 0.0], 'lambda_sterics': [1.0, 0.5, 11000.0]},
+        {'lambda_electrostatics': [1.0, 0.5, 0.0], 'lambda_sterics': [1.0, 0.5, -0.5]},
+        {'lambda_electrostatics': [1.0, 0.5, 0.0], 'lambda_sterics': 0.0},
+        {'lambda_electrostatics': [1.0, 0.5, 0.0], 'lambda_sterics': [1.0, 0.5, 0.0], 3: 2}
     ]
     for protocol in protocols:
         modified_protocol = copy.deepcopy(basic_protocol)

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -27,7 +27,7 @@ from nose.plugins.attrib import attr
 
 from yank.yamlbuild import *
 # silence the citations at a global level
-repex._global_citation_silence = True
+repex.ReplicaExchange._global_citation_silence = True
 
 # ==============================================================================
 # Subroutines for testing

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -26,6 +26,8 @@ from nose.tools import assert_raises, assert_equal
 from nose.plugins.attrib import attr
 
 from yank.yamlbuild import *
+# silence the citations at a global level
+repex._global_citation_silence = True
 
 # ==============================================================================
 # Subroutines for testing


### PR DESCRIPTION
* Adds a proper set of tests for the analyze module.
* Fixes the previously untested `MultiPhaseAnalyze `code
* Cleans up analyze API docs
* Removes old `analyze.py` legacy code that is no longer used
* Tries to speed up some tests by cutting down the number of states used
* Reduces citation spam, provides internal way to mute citations
    * Very experimental, we can remove this feature if desired.

I have not set this main one up to merge yet, because I want to do this in fragments, so I don't think the tests will run.

@andrrizzi do you think you would have time to look over this? There is quite a lot here. I can also merge the `online-analysis` branch first, then come back and open a new PR to merge this into master after.