### PR TITLE
Remove c_rf term in expanded cutoff state with reaction field

### DIFF
--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -21,6 +21,7 @@ This code is licensed under the latest available version of the MIT License.
 # GLOBAL IMPORTS
 # ==============================================================================
 
+import os
 import functools
 import contextlib
 
@@ -115,7 +116,7 @@ class TestAlchemicalPhase(object):
         cls.host_guest_explicit = ('Host-guest explicit', thermodynamic_state, sampler_state, topography)
 
         # Peptide solvated in explicit solvent.
-        test_system = testsystems.AlanineDipeptideExplicit()
+        test_system = testsystems.AlanineDipeptideExplicit(nonbondedMethod=openmm.app.CutoffPeriodic)
         thermodynamic_state = states.ThermodynamicState(test_system.system,
                                                         temperature=temperature)
         sampler_state = states.SamplerState(test_system.positions)
@@ -159,7 +160,7 @@ class TestAlchemicalPhase(object):
             assert standard_state_correction == 0
 
     @classmethod
-    def check_expanded_states(cls, alchemical_phase, protocol, expected_cutoff, expected_switch_width):
+    def check_expanded_states(cls, alchemical_phase, protocol, expected_cutoff, reference_system):
         """The expanded states have been setup correctly."""
         thermodynamic_state = alchemical_phase._sampler._thermodynamic_states[0]
         unsampled_states = alchemical_phase._sampler._unsampled_states
@@ -185,8 +186,20 @@ class TestAlchemicalPhase(object):
             return
         assert len(unsampled_states) == 2
 
-        # Find all nonbonded forces and verify their cutoff.
+        # The switch distances in the nonbonded forces should be preserved.
+        # Get the original(s) from the reference system. We store 5-decimal
+        # strings to avoid having problems with precision in sets.
+        expected_switch_widths = set()
+        for force in reference_system.getForces():
+            try:
+                switch_width = force.getCutoffDistance() - force.getSwitchingDistance()
+                expected_switch_widths.add('{:.5}'.format(switch_width/unit.nanometers))
+            except AttributeError:
+                pass
+
+        # Find all cutoff and switch width for the reference and unsampled states.
         for state in unsampled_states:
+            switch_widths = set()
             system = state.system
             for force in system.getForces():
                 try:
@@ -194,12 +207,15 @@ class TestAlchemicalPhase(object):
                 except AttributeError:
                     continue
                 else:
-                    switch_width = cutoff - force.getSwitchingDistance()
                     err_msg = 'obtained {}, expected {}'.format(cutoff, expected_cutoff)
                     assert np.isclose(cutoff / cutoff_unit, expected_cutoff / cutoff_unit), err_msg
                     if force.getUseSwitchingFunction():
-                        err_msg = 'obtained {}, expected {}'.format(switch_width, expected_switch_width)
-                        assert np.isclose(switch_width / cutoff_unit, expected_switch_width / cutoff_unit), err_msg
+                        switch_width = cutoff - force.getSwitchingDistance()
+                        switch_widths.add('{:.5}'.format(switch_width/unit.nanometers))
+
+            # The unsampled state should preserve all switch widths of the reference system.
+            err_msg = 'obtained {}, expected {}'.format(switch_widths, expected_switch_widths)
+            assert switch_widths == expected_switch_widths, err_msg
 
         # If the thermodynamic systems are restrained, so should be the unsampled ones.
         if is_restrained:
@@ -234,13 +250,10 @@ class TestAlchemicalPhase(object):
             else:
                 correction_cutoff = 'auto'
 
-             # Find expected switch width.
-            system = thermodynamic_state.system
-            for force in system.getForces():
-                try:
-                    expected_switch_width = force.getCutoffDistance() - force.getSwitchingDistance()
-                except AttributeError:
-                    pass
+            # Replace the reaction field of the reference system to compare
+            # also cutoff and switch width for the electrostatics.
+            reference_system = thermodynamic_state.system
+            mmtools.forcefactories.replace_reaction_field(reference_system, return_copy=False)
 
             alchemical_phase = AlchemicalPhase(sampler=ReplicaExchange())
             with self.temporary_storage_path() as storage_path:
@@ -252,7 +265,7 @@ class TestAlchemicalPhase(object):
                 yield prepare_yield(self.check_standard_state_correction, test_name, alchemical_phase,
                                     topography)
                 yield prepare_yield(self.check_expanded_states, test_name, alchemical_phase,
-                                    protocol, correction_cutoff, expected_switch_width)
+                                    protocol, correction_cutoff, reference_system)
 
                 # Free memory.
                 del alchemical_phase

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -116,7 +116,7 @@ class TestAlchemicalPhase(object):
         cls.host_guest_explicit = ('Host-guest explicit', thermodynamic_state, sampler_state, topography)
 
         # Peptide solvated in explicit solvent.
-        test_system = testsystems.AlanineDipeptideExplicit(nonbondedMethod=openmm.app.CutoffPeriodic)
+        test_system = testsystems.AlanineDipeptideExplicit()
         thermodynamic_state = states.ThermodynamicState(test_system.system,
                                                         temperature=temperature)
         sampler_state = states.SamplerState(test_system.positions)

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -468,6 +468,11 @@ class AlchemicalPhase(object):
         is_periodic = thermodynamic_state.is_periodic
         is_complex = len(topography.receptor_atoms) > 0
 
+        # We currently don't support reaction field.
+        nonbonded_method = mmtools.forces.find_nonbonded_force(reference_system).getNonbondedMethod()
+        if nonbonded_method == openmm.NonbondedForce.CutoffPeriodic:
+            raise RuntimeError('CutoffPeriodic is not supported yet. Use PME for explicit solvent.')
+
         # Make sure sampler_states is a list of SamplerStates.
         if isinstance(sampler_states, mmtools.states.SamplerState):
             sampler_states = [sampler_states]
@@ -589,9 +594,7 @@ class AlchemicalPhase(object):
         if is_periodic and anisotropic_dispersion_cutoff is not None:
             # Create non-alchemically modified state with an expanded cutoff.
             reference_state_expanded = self._expand_state_cutoff(reference_thermodynamic_state,
-                                                                 anisotropic_dispersion_cutoff,
-                                                                 replace_reaction_field=True,
-                                                                 switch_width=alchemical_factory.switch_width)
+                                                                 anisotropic_dispersion_cutoff)
 
             # Add the restraint if any. The free energy of removing the restraint
             # will be taken into account with the standard state correction.

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -16,7 +16,6 @@ Interface for automated free energy calculations.
 # GLOBAL IMPORTS
 # ==============================================================================
 
-import os
 import abc
 import copy
 import time
@@ -590,7 +589,9 @@ class AlchemicalPhase(object):
         if is_periodic and anisotropic_dispersion_cutoff is not None:
             # Create non-alchemically modified state with an expanded cutoff.
             reference_state_expanded = self._expand_state_cutoff(reference_thermodynamic_state,
-                                                                 anisotropic_dispersion_cutoff)
+                                                                 anisotropic_dispersion_cutoff,
+                                                                 replace_reaction_field=True,
+                                                                 switch_width=alchemical_factory.switch_width)
 
             # Add the restraint if any. The free energy of removing the restraint
             # will be taken into account with the standard state correction.
@@ -754,8 +755,15 @@ class AlchemicalPhase(object):
     # -------------------------------------------------------------------------
 
     @staticmethod
-    def _expand_state_cutoff(thermodynamic_state, expanded_cutoff_distance):
-        """Expand the thermodynamic state cutoff to the given one."""
+    def _expand_state_cutoff(thermodynamic_state, expanded_cutoff_distance,
+                             replace_reaction_field=False, switch_width=None):
+        """Expand the thermodynamic state cutoff to the given one.
+
+        If replace_reaction_field is True, the system will be modified
+        to use an UnshiftedReactionFieldForce. In this case switch_width
+        must be specified.
+
+        """
         # If we use a barostat we leave more room for volume fluctuations or
         # we risk fatal errors. This is how much we allow the box size to change.
         fluctuation_size = 0.8
@@ -807,6 +815,12 @@ class AlchemicalPhase(object):
                     # there is a setting for that.
                     force.setCutoffDistance(expanded_cutoff_distance)
                     force.setSwitchingDistance(switching_distance + cutoff_diff)
+
+        # Replace reaction field NonbondedForce to remove constant shift term.
+        # AbsoluteAlchemicalFactory already does it for the other states.
+        if replace_reaction_field:
+            mmtools.forcefactories.replace_reaction_field(system, return_copy=False,
+                                                          switch_width=switch_width)
 
         # Return the new thermodynamic state with the expanded cutoff.
         thermodynamic_state.system = system


### PR DESCRIPTION
Fix #670 .

We'll need to cut a new openmmtools release before tests can pass. I've also run hydration free energy calculations with RF on the cluster to test if this makes it work.