### PR TITLE
Raise error when number of states in protocol differ

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1562,6 +1562,7 @@ class Boresch(ReceptorLigandRestraint):
 
         # Cast to Python ints to avoid type issues when passing to OpenMM
         restrained_atoms = [int(i) for i in restrained_atoms]
+        logger.debug('Selected atoms to restrain: {}'.format(restrained_atoms))
         return restrained_atoms
 
     def _determine_restraint_parameters(self, sampler_states, topography):

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -21,6 +21,7 @@ This code is licensed under the latest available version of the MIT License.
 # GLOBAL IMPORTS
 # ==============================================================================
 
+import os
 import functools
 import contextlib
 
@@ -44,6 +45,7 @@ def prepare_yield(func, test_case_name, *args):
     f = functools.partial(func, *args)
     f.description = test_case_name + ': ' + func.__doc__
     return f
+
 
 # ==============================================================================
 # TEST TOPOLOGY OBJECT
@@ -326,6 +328,19 @@ class TestAlchemicalPhase(object):
         with nose.tools.assert_raises(ValueError):
             alchemical_phase.create(thermodynamic_state, sampler_state, topography,
                                     protocol, 'not_created.nc', restraint=yank.restraints.Harmonic())
+
+    def test_illegal_protocol(self):
+        """An error is raised when the protocol parameters have a different number of states."""
+        name, thermodynamic_state, sampler_state, topography = self.host_guest_implicit
+        protocol = {
+            'lambda_sterics': [0.0, 1.0],
+            'lambda_electrostatics': [1.0]
+        }
+        alchemical_phase = AlchemicalPhase(sampler=ReplicaExchange())
+        restraint = yank.restraints.Harmonic()
+        with nose.tools.assert_raises(ValueError):
+            alchemical_phase.create(thermodynamic_state, sampler_state, topography,
+                                    protocol, 'not_created.nc', restraint=restraint)
 
     def test_illegal_restraint(self):
         """Raise an error when restraint is handled incorrectly."""

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -16,7 +16,6 @@ Interface for automated free energy calculations.
 # GLOBAL IMPORTS
 # ==============================================================================
 
-import os
 import abc
 import copy
 import time
@@ -473,6 +472,12 @@ class AlchemicalPhase(object):
             Simulation metadata to be stored in the file.
 
         """
+        # Check that protocol has same number of states for each parameter.
+        len_protocol_parameters = {par_name: len(path) for par_name, path in protocol.items()}
+        if len(set(len_protocol_parameters.values())) != 1:
+            raise ValueError('The protocol parameters have a different number '
+                             'of states: {}'.format(len_protocol_parameters))
+
         # Do not modify passed thermodynamic state.
         reference_thermodynamic_state = copy.deepcopy(thermodynamic_state)
         thermodynamic_state = copy.deepcopy(thermodynamic_state)


### PR DESCRIPTION
Address two of the points raised in #720 .
- Log the atoms indices automatically picked by the `Boresch` restraint.
- Raise an error when the user selects a protocol with different number of states.