### PR TITLE
Analyze api cleanup

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -525,7 +525,7 @@ class YankPhaseAnalyzer(ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def extract_energies(self):
+    def get_states_energies(self):
         """
         Extract the deconvoluted energies from a phase.
 
@@ -761,7 +761,7 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
                 mu[1], 1.0 / (1.0 - mu[1]))
             )
 
-    def extract_energies(self):
+    def get_states_energies(self):
         """
         Extract and decorrelate energies from the ncfile to gather energies common data for other functions
 
@@ -993,7 +993,7 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
         Returns nothing, but sets self._equilibration_data
         """
         if input_data is None:
-            input_data, _ = self.extract_energies()
+            input_data, _ = self.get_states_energies()
         u_n = self.get_timeseries(input_data)
         # Discard equilibration samples.
         # TODO: if we include u_n[0] (the energy right after minimization) in the equilibration detection,
@@ -1001,7 +1001,7 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
         self._equilibration_data = get_equilibration_data(u_n[1:])
 
     def _create_mbar_from_scratch(self):
-        u_kln, unsampled_u_kln = self.extract_energies()
+        u_kln, unsampled_u_kln = self.get_states_energies()
         self._get_equilibration_data_auto(input_data=u_kln)
         number_equilibrated, g_t, Neff_max = self._equilibration_data
         u_kln = remove_unequilibrated_data(u_kln, number_equilibrated, -1)

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -687,6 +687,8 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
 
         # Read data from disk
         if number_equilibrated is None:
+            if self._equilibration_data is None:
+                self._get_equilibration_data_auto()
             number_equilibrated, _, _ = self._equilibration_data
         states = self._reporter.read_replica_thermodynamic_states()
         n_iterations, n_states = states.shape

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -129,10 +129,10 @@ def dispatch_report(args):
         import matplotlib
         import jupyter
     except ImportError:
-        error_msg = "Rendering this notebook requires the following packages:\n"
-        " - matplotlib\n"
-        " - jupyter\n"
-        "These are not required to generate the notebook however"
+        error_msg = ("Rendering this notebook requires the following packages:\n"
+                     " - matplotlib\n"
+                     " - jupyter\n"
+                     "These are not required to generate the notebook however")
         if file_extension.lower() in static_extensions:
             error_msg += "\nRendering as static {} is not possible without the packages!".format(file_extension)
             raise ImportError(error_msg)

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -142,7 +142,7 @@ def dispatch_report(args):
     with open(template_path, 'r') as template:
         notebook_text = re.sub('STOREDIRBLANK', store, template.read())
     if file_extension.lower() in static_extensions:
-        # Cast to static ouptput
+        # Cast to static output
         print("Rendering notebook as static file...")
         import nbformat
         from nbconvert.preprocessors import ExecutePreprocessor
@@ -163,7 +163,7 @@ def dispatch_report(args):
             # Read the temp notebook into a notebook_node object nbconvert can work with
             with open(tmp_nb_path, 'r') as tmp_notebook:
                 loaded_notebook = nbformat.read(tmp_notebook, as_version=4)
-            ep = ExecutePreprocessor()
+            ep = ExecutePreprocessor(timeout=None)
             # Set the title name, does not appear in all exporters
             resource_data = {'metadata': {'name': 'YANK Simulation Report: {}'.format(file_base_name)}}
             # Process notebook

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -2355,11 +2355,11 @@ class ReplicaExchange(object):
         # importing, its not in the name space which causes relative analyze import of repex to crash as neither of them
         # are the __main__ package.
         # https://stackoverflow.com/questions/6351805/cyclic-module-dependencies-and-relative-imports-in-python
-        from .analyze import RepexPhase
+        from .analyze import ReplicaExchangeAnalyzer
 
         # Start the analysis
         bump_error_counter = False
-        analysis = RepexPhase(self._reporter, analysis_kwargs={'initial_f_k': self._last_mbar_f_k})
+        analysis = ReplicaExchangeAnalyzer(self._reporter, analysis_kwargs={'initial_f_k': self._last_mbar_f_k})
 
         # Indices for online analysis, "i'th index, j'th index"
         idx, jdx = 0, -1

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -147,7 +147,7 @@ class HealthReportData(object):
             self._n_discarded = discard_from_start
             self.u_ns[phase_name] = analyzer.get_timeseries(u_kln)
             # Timeseries statistics
-            g_t, Neff_t = analyzer.get_equilibration_data_per_sample(self.u_ns[phase_name])
+            g_t, Neff_t = analyze.get_equilibration_data_per_sample(self.u_ns[phase_name])
             self.Neff_maxs[phase_name] = Neff_t.max()
             self.nequils[phase_name] = Neff_t.argmax()
             self.g_ts[phase_name] = g_t[int(self.nequils[phase_name])]

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -139,7 +139,7 @@ class HealthReportData(object):
             analyzer = self.analyzers[phase_name]
 
             # Data crunching to get timeseries
-            u_kln, _ = analyzer.extract_energies()
+            u_kln, _ = analyzer.get_states_energies()
             # TODO: Figure out how not to discard the first sample
             # Sample at index 0 is actually the minimized structure and NOT from the equilibrium distribution
             # This throws off all of the equilibrium data

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -161,7 +161,7 @@ class TestPhaseAnalyzer(object):
         cls.n_states = n_states
         cls.n_steps = n_steps
         cls.repex.run(cls.n_steps-1)  # Initial config
-        cls.repex_name = "RepexPhase"
+        cls.repex_name = "RepexAnalyzer"
 
     @classmethod
     def teardown_class(cls):
@@ -169,13 +169,13 @@ class TestPhaseAnalyzer(object):
 
     def test_repex_phase_initilize(self):
         """Test that the Repex Phase analyzer initializes correctly"""
-        phase = analyze.RepexPhase(self.reporter, name=self.repex_name)
+        phase = analyze.ReplicaExchangeAnalyzer(self.reporter, name=self.repex_name)
         assert phase.reporter is self.reporter
         assert phase.name == self.repex_name
 
     def test_repex_mixing_stats(self):
         """Test that the Repex Phase yields mixing stats that make sense"""
-        phase = analyze.RepexPhase(self.reporter, name=self.repex_name)
+        phase = analyze.ReplicaExchangeAnalyzer(self.reporter, name=self.repex_name)
         t, mu = phase.generate_mixing_statistics()
         # Output is the correct number of states
         assert t.shape == (self.n_states, self.n_states)
@@ -193,7 +193,7 @@ class TestPhaseAnalyzer(object):
 
         We do this in one function since the test for each part would be a bunch of repeated recreation of the phase
         """
-        phase = analyze.RepexPhase(self.reporter, name=self.repex_name)
+        phase = analyze.ReplicaExchangeAnalyzer(self.reporter, name=self.repex_name)
         u_sampled, u_unsampled = phase.extract_energies()
         # Test energy output matches appropriate MBAR shapes
         assert u_sampled.shape == (self.n_states, self.n_states, self.n_steps)
@@ -234,7 +234,7 @@ class TestPhaseAnalyzer(object):
     def test_multi_phase(self):
         """Test MultiPhaseAnalysis"""
         # Create the phases
-        full_phase = analyze.RepexPhase(self.reporter, name=self.repex_name)
+        full_phase = analyze.ReplicaExchangeAnalyzer(self.reporter, name=self.repex_name)
         blank_phase = BlankPhase(self.reporter, name="blank")
         fe_phase = FreeEnergyPhase(self.reporter, name="fe")
         fes_phase = FEStandardStatePhase(self.reporter, name="fes")

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -200,7 +200,7 @@ class TestPhaseAnalyzer(object):
         discard = 1
         # Generate mbar semi-manually, use phases's static methods
         n_eq, g_t, Neff_max = pymbar.timeseries.detectEquilibration(u_n[discard:])
-        u_sampled_sub = phase.remove_unequilibrated_data(u_sampled, n_eq, -1)
+        u_sampled_sub = analyze.remove_unequilibrated_data(u_sampled, n_eq, -1)
         # Make sure output from subsample is what we expect
         assert u_sampled_sub.shape == (self.n_states, self.n_states, Neff_max)
         # Generate MBAR from phase

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -45,7 +45,7 @@ class BlankPhase(analyze.YankPhaseAnalyzer):
     def _create_mbar_from_scratch(self):
         pass
 
-    def extract_energies(self):
+    def get_states_energies(self):
         pass
 
     @staticmethod
@@ -190,7 +190,7 @@ class TestPhaseAnalyzer(object):
         We do this in one function since the test for each part would be a bunch of repeated recreation of the phase
         """
         phase = analyze.ReplicaExchangeAnalyzer(self.reporter, name=self.repex_name)
-        u_sampled, u_unsampled = phase.extract_energies()
+        u_sampled, u_unsampled = phase.get_states_energies()
         # Test energy output matches appropriate MBAR shapes
         assert u_sampled.shape == (self.n_states, self.n_states, self.n_steps)
         assert u_unsampled.shape == (self.n_states, 2, self.n_steps)

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -10,25 +10,21 @@ Test analyze.py facility.
 # =============================================================================================
 
 import os
-import math
 import copy
 import shutil
 import tempfile
-import contextlib
 
-import yaml
 import pymbar
 import numpy as np
-import scipy.integrate
-from simtk import openmm, unit
+from simtk import unit
 from nose.plugins.attrib import attr
 from nose.tools import assert_raises
 
 import openmmtools as mmtools
 from openmmtools import testsystems
 
-from yank import mpi, utils, analyze
-from yank.repex import Reporter, ReplicaExchange, _DictYamlLoader
+from yank import analyze
+from yank.repex import Reporter, ReplicaExchange
 
 # ==============================================================================
 # MODULE CONSTANTS


### PR DESCRIPTION
* Moved analyze static class functions to module functions
* Renamed some functions and classes to be more clear
* Added ability to pre-render jupyter notebooks as static HTML or PDF objects
    * PDF requires `xelatex` binary, provided by most LaTeX engines
    * Personal note: This was much harder than it should have been