### PR TITLE
Small changes to repex API

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -1515,7 +1515,7 @@ def extract_trajectory(output_path, nc_path, nc_checkpoint_file=None, state_inde
 
     # Import simulation data
     try:
-        reporter = Reporter(nc_path, open_mode='r', checkpoint_storage_file=nc_checkpoint_file)
+        reporter = Reporter(nc_path, open_mode='r', checkpoint_storage=nc_checkpoint_file)
         metadata = reporter.read_dict('metadata')
         reference_system = mmtools.utils.deserialize(metadata['reference_state']).system
         topology = mmtools.utils.deserialize(metadata['topography']).topology

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -1183,8 +1183,9 @@ class ReplicaExchange(object):
         they will be assigned to the correspondent thermodynamic state on
         creation. If None is provided, Langevin dynamics with 2fm timestep, 5.0/ps collision rate,
         and 500 steps per iteration will be used.
-    number_of_iterations : int, Optional, Default: 1
+    number_of_iterations : int or None, Optional, Default: 1
         The number of iterations to perform
+        If None, an unlimited number of iterations is run
     replica_mixing_scheme : 'swap-all', 'swap-neighbors' or None, Default: 'swap-all'
         The scheme used to swap thermodynamic states between replicas.
     online_analysis_interval : None or Int >= 1, optional, default None

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -84,7 +84,7 @@ class Reporter(object):
     storage : str
         The path to the storage file for analysis.
 
-        A second checkpoint file will be determined from either ``checkpoint_storage_file`` or automatically based on
+        A second checkpoint file will be determined from either ``checkpoint_storage`` or automatically based on
         the storage option
 
         In the future this will be able to take Storage classes as well.
@@ -102,7 +102,7 @@ class Reporter(object):
 
         Attempting to read checkpointing information results in a masked array where only entries which were written
         are unmasked
-    checkpoint_storage_file : str or None, optional
+    checkpoint_storage : str or None, optional
         Optional name of the checkpoint point file. This file is used to save trajectory information and other less
         frequently accessed data.
 
@@ -118,20 +118,20 @@ class Reporter(object):
     filepath
 
     """
-    def __init__(self, storage, open_mode=None, checkpoint_interval=10, checkpoint_storage_file=None):
+    def __init__(self, storage, open_mode=None, checkpoint_interval=10, checkpoint_storage=None):
         # Handle checkpointing
         if type(checkpoint_interval) != int:
             raise ValueError("checkpoint_interval must be an integer!")
         dirname, filename = os.path.split(storage)
-        if checkpoint_storage_file is None:
+        if checkpoint_storage is None:
             basename, ext = os.path.splitext(filename)
             addon = "_checkpoint"
-            checkpoint_storage_file = os.path.join(dirname, basename + addon + ext)
-            logger.debug("Initial checkpoint file automatically chosen as {}".format(checkpoint_storage_file))
+            checkpoint_storage = os.path.join(dirname, basename + addon + ext)
+            logger.debug("Initial checkpoint file automatically chosen as {}".format(checkpoint_storage))
         else:
-            checkpoint_storage_file = os.path.join(dirname, checkpoint_storage_file)
+            checkpoint_storage = os.path.join(dirname, checkpoint_storage)
         self._storage_file_analysis = storage
-        self._storage_file_checkpoint = checkpoint_storage_file
+        self._storage_file_checkpoint = checkpoint_storage
         self._storage_checkpoint = None
         self._storage_analysis = None
         self._checkpoint_interval = checkpoint_interval

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -115,7 +115,7 @@ class Reporter(object):
 
     Attributes
     ----------
-    filename
+    filepath
 
     """
     def __init__(self, storage, open_mode=None, checkpoint_interval=10, checkpoint_storage_file=None):
@@ -139,7 +139,7 @@ class Reporter(object):
             self.open(open_mode)
 
     @property
-    def filename(self):
+    def filepath(self):
         """
         Returns the string file name of the primary storage file
 
@@ -1416,7 +1416,7 @@ class ReplicaExchange(object):
         else:
             reporter = storage
             reporter.open(mode='r')
-            file_name = reporter.filename
+            file_name = reporter.filepath
         if not reporter.storage_exists():
             reporter.close()
             raise RuntimeError('Storage file {} or its subfiles do not exist; cannot resume.'.format(file_name))
@@ -1654,7 +1654,7 @@ class ReplicaExchange(object):
             file_string = storage
         else:
             reporter = storage
-            file_string = reporter.filename
+            file_string = reporter.filepath
         if mpi.run_single_node(0, reporter.storage_exists, broadcast_result=True):
             files_exist = True
         if files_exist:

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -251,14 +251,14 @@ class TestReporter(object):
 
     @staticmethod
     @contextlib.contextmanager
-    def temporary_reporter(checkpoint_interval=1, checkpoint_storage_file=None):
+    def temporary_reporter(checkpoint_interval=1, checkpoint_storage=None):
         """Create and initialize a reporter in a temporary directory."""
         with mmtools.utils.temporary_directory() as tmp_dir_path:
             storage_file = os.path.join(tmp_dir_path, 'temp_dir/test_storage.nc')
             assert not os.path.isfile(storage_file)
             reporter = Reporter(storage=storage_file, open_mode='w',
                                 checkpoint_interval=checkpoint_interval,
-                                checkpoint_storage_file=checkpoint_storage_file)
+                                checkpoint_storage=checkpoint_storage)
             assert reporter.storage_exists(skip_size=True)
             yield reporter
 
@@ -1089,7 +1089,7 @@ class TestReplicaExchange(object):
             cp_file = 'checkpoint_file.nc'
             base, head = os.path.split(storage_path)
             cp_path = os.path.join(base, cp_file)
-            reporter = Reporter(storage_path, checkpoint_storage_file=cp_file, open_mode='w')
+            reporter = Reporter(storage_path, checkpoint_storage=cp_file, open_mode='w')
             reporter.close()
             assert os.path.isfile(storage_path)
             assert os.path.isfile(cp_path)
@@ -1098,7 +1098,7 @@ class TestReplicaExchange(object):
         """Test that checkpoint and storage files have the same UUID"""
         with self.temporary_storage_path() as storage_path:
             cp_file = 'checkpoint_file.nc'
-            reporter = Reporter(storage_path, checkpoint_storage_file=cp_file, open_mode='w')
+            reporter = Reporter(storage_path, checkpoint_storage=cp_file, open_mode='w')
             assert reporter._storage_checkpoint.UUID == reporter._storage_analysis.UUID
 
     def test_uuid_mismatch_errors(self):
@@ -1108,23 +1108,23 @@ class TestReplicaExchange(object):
             storage_mod = file_base + '_mod' + ext
             cp_file_main = 'checkpoint_file.nc'
             cp_file_mod = 'checkpoint_mod.nc'
-            reporter_main = Reporter(storage_path, checkpoint_storage_file=cp_file_main, open_mode='w')
+            reporter_main = Reporter(storage_path, checkpoint_storage=cp_file_main, open_mode='w')
             reporter_main.close()
-            reporter_mod = Reporter(storage_mod, checkpoint_storage_file=cp_file_mod, open_mode='w')
+            reporter_mod = Reporter(storage_mod, checkpoint_storage=cp_file_mod, open_mode='w')
             reporter_mod.close()
             del reporter_main, reporter_mod
             with assert_raises(IOError):
-                Reporter(storage_path, checkpoint_storage_file=cp_file_mod, open_mode='r')
+                Reporter(storage_path, checkpoint_storage=cp_file_mod, open_mode='r')
 
     def test_analysis_opens_without_checkpoint(self):
         """Test that the analysis file can open without the checkpoint file"""
         with self.temporary_storage_path() as storage_path:
             cp_file = 'checkpoint_file.nc'
             cp_file_mod = 'checkpoint_mod.nc'
-            reporter = Reporter(storage_path, checkpoint_storage_file=cp_file, open_mode='w')
+            reporter = Reporter(storage_path, checkpoint_storage=cp_file, open_mode='w')
             reporter.close()
             del reporter
-            Reporter(storage_path, checkpoint_storage_file=cp_file_mod, open_mode='r')
+            Reporter(storage_path, checkpoint_storage=cp_file_mod, open_mode='r')
 
     def test_storage_reporter_and_string(self):
         """Test that creating a repex by storage string and reporter is the same"""

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -781,7 +781,7 @@ class TestReplicaExchange(object):
 
             # Update options and check the storage is synchronized.
             repex.number_of_iterations = 123
-            repex.replica_mixing_scheme = 'none'
+            repex.replica_mixing_scheme = None
 
             # Displace positions of the first sampler state.
             sampler_states = repex.sampler_states
@@ -796,7 +796,7 @@ class TestReplicaExchange(object):
                 reporter = Reporter(storage_path, open_mode='r')
                 restored_options = reporter.read_dict('options')
                 assert restored_options['number_of_iterations'] == 123
-                assert restored_options['replica_mixing_scheme'] == 'none'
+                assert restored_options['replica_mixing_scheme'] is None
 
                 restored_sampler_states = reporter.read_sampler_states(iteration=0)
                 assert np.allclose(restored_sampler_states[0].positions,

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -248,7 +248,7 @@ def test_yaml_parsing():
         minimize: False
         minimize_tolerance: 1.0 * kilojoules_per_mole / nanometers
         minimize_max_iterations: 0
-        replica_mixing_scheme: swap-all
+        replica_mixing_scheme: null
         annihilate_sterics: no
         annihilate_electrostatics: true
     """
@@ -257,9 +257,10 @@ def test_yaml_parsing():
     assert len(exp_builder._options) == 32
 
     # Check correct types
+    assert exp_builder._options['output_dir'] == '/path/to/output/'
     assert exp_builder._options['pressure'] is None
     assert exp_builder._options['constraints'] == openmm.app.AllBonds
-    assert exp_builder._options['replica_mixing_scheme'] == 'swap-all'
+    assert exp_builder._options['replica_mixing_scheme'] is None
     assert exp_builder._options['timestep'] == 2.0 * unit.femtoseconds
     assert exp_builder._options['randomize_ligand_sigma_multiplier'] == 1.0e-2
     assert exp_builder._options['nsteps_per_iteration'] == 2500

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -395,7 +395,7 @@ class AlchemicalPhase(object):
             reporter = storage
         if not reporter.storage_exists():
             reporter.close()
-            raise RuntimeError('Storage file at {} does not exists; cannot resume.'.format(reporter.filename))
+            raise RuntimeError('Storage file at {} does not exists; cannot resume.'.format(reporter.filepath))
 
         # TODO: this should skip the Reporter and use the Storage to read storage.metadata.
         # Open Reporter for reading and read metadata.

--- a/docs/examples/p-xylene-explicit.rst
+++ b/docs/examples/p-xylene-explicit.rst
@@ -89,7 +89,7 @@ Let us look at the receptor, T4-Lysozyme. We'll look at the whole code block for
 First we define our molecule name ``t4-lysozyme``, this name will come up again in later sections, hence why we have
 given it a meaningful name.
 
-Next we tell YANK where the file is, so ``filename`` points at the file relative to where
+Next we tell YANK where the file is, so ``filepath`` points at the file relative to where
 the the yaml script.
 
 Lastly we have to tell YANK where to get the molecule's parameters to put into a simulation. The combination of
@@ -108,7 +108,7 @@ Now let us look at the ligand molecule, para-xylene
 
 First we give our ligand a meaningful name: ``p-xylene``.
 
-Next we tell YANK where the file is with ``filename``.
+Next we tell YANK where the file is with ``filepath``.
 
 The ``antechamber`` command is probably the most loaded command in the YAML file. Several things happen when this command
 is invoked. First, specifying ``antechamber`` tells YANK to prep the molecule by running it through ANTECHAMBER to get

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -640,9 +640,10 @@ Valid Options (10): <Integer ``>= 1``>
 
 Specifies how the Hamiltonian Replica Exchange attempts swaps between replicas.
 ``swap-all`` will attempt to exchange every state with every other state. ``swap-neighbors``  will attempt only
-exchanges between adjacent states.
+exchanges between adjacent states. If ``null`` is specified, no mixing is done, and effectively disables all replica
+exchange functionality.
 
-Valid Options: [swap-all]/swap-neighbors
+Valid Options: [swap-all]/swap-neighbors/null
 
 
 


### PR DESCRIPTION
Just small changes to the API that we discussed before releasing 1.0 . The 3 commits messages are pretty self-explanatory.

@Lnaden should I also rename the `checkpoint_storage_file` argument in `Reporter.__init__()` to `checkpoint_storage` to be consistent with the analysis one that is called `storage` (or do the opposite)?