### PR TITLE
Bugfix for multi-molecule mol2 files and allow to specify parameters in solvents

### DIFF
--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -112,7 +112,20 @@ def dispatch_extract_trajectory(args):
         kwargs["nc_checkpoint_file"] = args['--checkpoint']
 
     # Extract trajectory
-    analyze.extract_trajectory(output_path, nc_path, **kwargs)
+    trajectory = analyze.extract_trajectory(nc_path, **kwargs)
+
+    # Detect output format.
+    extension = os.path.splitext(output_path)[1][1:]  # remove dot
+    try:
+        save_function = getattr(trajectory, 'save_' + extension)
+    except AttributeError:
+        raise ValueError('Cannot detect format from extension of file {}'.format(output_path))
+
+    # Create output directory and save trajectory
+    output_dir = os.path.dirname(output_path)
+    if output_dir != '' and not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    save_function(output_path)
 
     return True
 

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -877,7 +877,7 @@ class ExperimentBuilder(object):
                         if not utils.is_openeye_installed(oetools=('oechem',)):
                             err_msg = 'Molecule {}: Cannot "select" from {} file without OpenEye toolkit'
                             raise RuntimeError(err_msg.format(comb_mol_name, extension))
-                        n_models = utils.read_oe_molecule(comb_molecule['filepath']).NumConfs()
+                        n_models = len(utils.load_oe_molecules(comb_molecule['filepath']))
 
                     else:
                         raise YamlParseError('Molecule {}: Cannot "select" from {} file'.format(

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -972,6 +972,10 @@ class ExperimentBuilder(object):
     # Parsing and syntax validation
     # --------------------------------------------------------------------------
 
+    # Shared schema for leap parameters. Molecules, solvents and systems use it.
+    # Simple strings are converted to list of strings.
+    _LEAP_PARAMETERS_SCHEMA = {'parameters': And(Use(lambda p: [p] if isinstance(p, str) else p), [str])}
+
     @classmethod
     def _validate_options(cls, options, validate_general_options):
         """Validate molecules syntax.
@@ -1028,8 +1032,8 @@ class ExperimentBuilder(object):
             raise YamlParseError(str(e))
         return validated_options
 
-    @staticmethod
-    def _validate_molecules(molecules_description):
+    @classmethod
+    def _validate_molecules(cls, molecules_description):
         """Validate molecules syntax.
 
         Parameters
@@ -1074,9 +1078,8 @@ class ExperimentBuilder(object):
                                                       update_keys={'select': int},
                                                       exclude_keys=['extract_range'])
 
-        parameters_schema = {  # simple strings are converted to list of strings
-            'parameters': And(Use(lambda p: [p] if isinstance(p, str) else p), [str])}
-        common_schema = {Optional('leap'): parameters_schema, Optional('openeye'): {'quacpac': 'am1-bcc'},
+        common_schema = {Optional('leap'): cls._LEAP_PARAMETERS_SCHEMA,
+                         Optional('openeye'): {'quacpac': 'am1-bcc'},
                          Optional('antechamber'): {'charge_method': Or(str, None)},
                          Optional('epik'): epik_schema}
         molecule_schema = Or(
@@ -1085,7 +1088,8 @@ class ExperimentBuilder(object):
             utils.merge_dict({'filepath': is_small_molecule, Optional('select'): Or(int, 'all')},
                              common_schema),
             {'filepath': is_peptide, Optional('select'): Or(int, 'all'),
-             Optional('leap'): parameters_schema, Optional('strip_protons'): bool}
+             Optional('leap'): cls._LEAP_PARAMETERS_SCHEMA,
+             Optional('strip_protons'): bool}
         )
 
         # Schema validation
@@ -1116,8 +1120,8 @@ class ExperimentBuilder(object):
 
         return validated_molecules
 
-    @staticmethod
-    def _validate_solvents(solvents_description):
+    @classmethod
+    def _validate_solvents(cls, solvents_description):
         """Validate molecules syntax.
 
         Parameters
@@ -1171,6 +1175,11 @@ class ExperimentBuilder(object):
         vacuum_schema = utils.generate_signature_schema(AmberPrmtopFile.createSystem,
                                 update_keys={'nonbonded_method': Use(to_no_cutoff)},
                                 exclude_keys=['rigid_water', 'implicit_solvent'])
+
+        # Common schema to all types of solvents
+        for schema in [explicit_schema, implicit_schema, vacuum_schema]:
+            schema.update({Optional('leap'): cls._LEAP_PARAMETERS_SCHEMA})
+
         solvent_schema = Schema(Or(explicit_schema, implicit_schema, vacuum_schema))
 
         # Schema validation
@@ -1180,6 +1189,9 @@ class ExperimentBuilder(object):
             except SchemaError as e:
                 raise YamlParseError('Solvent {}: {}'.format(solvent_id, e.autos[-1]))
 
+            # Create empty parameters list if not specified
+            if 'leap' not in validated_solvents[solvent_id]:
+                validated_solvents[solvent_id]['leap'] = {'parameters': []}
         return validated_solvents
 
     @staticmethod
@@ -1321,9 +1333,6 @@ class ExperimentBuilder(object):
         # Define experiment Schema
         validated_systems = systems_description.copy()
 
-        # Schema for leap parameters. Simple strings are converted to list of strings.
-        parameters_schema = {'parameters': And(Use(lambda p: [p] if isinstance(p, str) else p), [str])}
-
         # Schema for DSL specification with system files.
         dsl_schema = {Optional('ligand_dsl'): str, Optional('solvent_dsl'): str}
 
@@ -1331,10 +1340,10 @@ class ExperimentBuilder(object):
         system_schema = Schema(Or(
             {'receptor': is_known_molecule, 'ligand': is_known_molecule,
              'solvent': is_pipeline_solvent, Optional('pack', default=False): bool,
-             Optional('leap'): parameters_schema},
+             Optional('leap'): self._LEAP_PARAMETERS_SCHEMA},
 
             {'solute': is_known_molecule, 'solvent1': is_pipeline_solvent,
-             'solvent2': is_pipeline_solvent, Optional('leap'): parameters_schema},
+             'solvent2': is_pipeline_solvent, Optional('leap'): self._LEAP_PARAMETERS_SCHEMA},
 
             utils.merge_dict(dsl_schema, {'phase1_path': Use(system_files('amber')),
                                           'phase2_path': Use(system_files('amber')),

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1328,6 +1328,7 @@ class SetupDatabase:
             molecule_parameters = self.molecules[mol_id]['leap']['parameters']
             tleap.load_parameters(*molecule_parameters)
 
+        tleap.load_parameters(*solvent['leap']['parameters'])
         tleap.load_parameters(*system_parameters)
 
         # Load molecules and create complexes
@@ -1386,8 +1387,6 @@ class SetupDatabase:
 
             # Solvate unit. Solvent models different than tip3p need parameter modifications.
             solvent_model = solvent['solvent_model']
-            if not solvent_model.startswith('tip3p'):
-                tleap.load_parameters('frcmod.' + solvent_model)
             leap_solvent_model = _OPENMM_LEAP_SOLVENT_MODELS_MAP[solvent_model]
             clearance = float(solvent['clearance'].value_in_unit(unit.angstroms))
             tleap.solvate(leap_unit=unit_to_solvate, solvent_model=leap_solvent_model, clearance=clearance)

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1116,7 +1116,7 @@ class SetupDatabase:
                     if not utils.is_openeye_installed(oetools=('oechem',)):
                         raise RuntimeError('Cannot support {} files selection without OpenEye'.format(
                                 extension[1:]))
-                    oe_molecule = utils.read_oe_molecule(mol_descr['filepath'], conformer_idx=model_idx)
+                    oe_molecule = utils.load_oe_molecules(mol_descr['filepath'], molecule_idx=model_idx)
                     if extension == '.mol2':
                         mol_names = utils.Mol2File(mol_descr['filepath']).resnames
                         utils.write_oe_molecule(oe_molecule, single_file_path, mol2_resname=mol_names[model_idx])
@@ -1218,7 +1218,7 @@ class SetupDatabase:
                 if not utils.is_openeye_installed(oetools=('oechem',)):
                     raise RuntimeError('Cannot support sdf files without OpenEye OEChem')
                 mol2_file_path = os.path.join(mol_dir, mol_id + '.mol2')
-                oe_molecule = utils.read_oe_molecule(mol_descr['filepath'])
+                oe_molecule = utils.load_oe_molecules(mol_descr['filepath'], molecule_idx=0)
 
                 # We set the residue name as the first three uppercase letters of mol_id
                 residue_name = re.sub('[^A-Za-z]+', '', mol_id.upper())[:3]
@@ -1238,7 +1238,7 @@ class SetupDatabase:
                         logger.error(err_msg)
                         raise RuntimeError(err_msg)
                     mol2_file_path = os.path.join(mol_dir, mol_id + '.mol2')
-                    oe_molecule = utils.read_oe_molecule(mol_descr['filepath'])
+                    oe_molecule = utils.load_oe_molecules(mol_descr['filepath'], molecule_idx=0)
 
                     # Setting keep_confs = None keeps the original conformation
                     oe_molecule = moltools.openeye.get_charges(oe_molecule, keep_confs=None)
@@ -1347,7 +1347,7 @@ class SetupDatabase:
                 for i, mol_id in enumerate(molecule_ids):
                     if mol_id not in self._pos_cache:
                         self._pos_cache[mol_id] = utils.get_oe_mol_positions(
-                                utils.read_oe_molecule(self.molecules[mol_id]['filepath']))
+                                utils.load_oe_molecules(self.molecules[mol_id]['filepath'], molecule_idx=0))
                     positions[i] = self._pos_cache[mol_id]
 
                 # Find and apply the transformation to fix clashing

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1118,7 +1118,7 @@ class SetupDatabase:
                                 extension[1:]))
                     oe_molecule = utils.load_oe_molecules(mol_descr['filepath'], molecule_idx=model_idx)
                     if extension == '.mol2':
-                        mol_names = utils.Mol2File(mol_descr['filepath']).resnames
+                        mol_names = list(utils.Mol2File(mol_descr['filepath']).resnames)
                         utils.write_oe_molecule(oe_molecule, single_file_path, mol2_resname=mol_names[model_idx])
                     else:
                         utils.write_oe_molecule(oe_molecule, single_file_path)

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1328,8 +1328,8 @@ class SetupDatabase:
             molecule_parameters = self.molecules[mol_id]['leap']['parameters']
             tleap.load_parameters(*molecule_parameters)
 
-        tleap.load_parameters(*solvent['leap']['parameters'])
         tleap.load_parameters(*system_parameters)
+        tleap.load_parameters(*solvent['leap']['parameters'])
 
         # Load molecules and create complexes
         # ------------------------------------

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -756,8 +756,8 @@ def test_clashing_atoms():
         system_description['solvent'] = utils.CombinatorialLeaf(['vacuum', 'PME'])
 
         # Sanity check: at the beginning molecules clash
-        toluene_pos = utils.get_oe_mol_positions(utils.read_oe_molecule(toluene_path))
-        benzene_pos = utils.get_oe_mol_positions(utils.read_oe_molecule(benzene_path))
+        toluene_pos = utils.get_oe_mol_positions(utils.load_oe_molecules(toluene_path, molecule_idx=0))
+        benzene_pos = utils.get_oe_mol_positions(utils.load_oe_molecules(benzene_path, molecule_idx=0))
         assert pipeline.compute_min_dist(toluene_pos, benzene_pos) < pipeline.SetupDatabase.CLASH_THRESHOLD
 
         exp_builder = ExperimentBuilder(yaml_content)
@@ -886,7 +886,7 @@ class TestMultiMoleculeFiles(object):
         # Create 2-molecule sdf and mol2 with OpenEye
         if utils.is_openeye_installed():
             from openeye import oechem
-            oe_benzene = utils.read_oe_molecule(examples_paths()['benzene'])
+            oe_benzene = utils.load_oe_molecules(examples_paths()['benzene'], molecule_idx=0)
             oe_benzene_pos = utils.get_oe_mol_positions(oe_benzene).dot(rot)
             oe_benzene.NewConf(oechem.OEFloatArray(oe_benzene_pos.flatten()))
 
@@ -1122,7 +1122,7 @@ class TestMultiMoleculeFiles(object):
 
                 # The mol2 represents the right molecule
                 csv_smiles_str = pipeline.read_csv_lines(self.smiles_path, lines=i).strip().split(',')[1]
-                mol2_smiles_str = OEMolToSmiles(utils.read_oe_molecule(mol2_path))
+                mol2_smiles_str = OEMolToSmiles(utils.load_oe_molecules(mol2_path, molecule_idx=0))
                 assert mol2_smiles_str == csv_smiles_str
 
                 # The molecule now both set up and processed
@@ -1207,9 +1207,9 @@ class TestMultiMoleculeFiles(object):
                     assert os.path.getsize(os.path.join(single_mol_path)) > 0
 
                     # The positions must be approximately correct (antechamber move the molecule)
-                    selected_oe_mol = utils.read_oe_molecule(single_mol_path)
+                    selected_oe_mol = utils.load_oe_molecules(single_mol_path, molecule_idx=0)
                     selected_pos = utils.get_oe_mol_positions(selected_oe_mol)
-                    second_oe_mol = utils.read_oe_molecule(multi_path, conformer_idx=model_idx)
+                    second_oe_mol = utils.load_oe_molecules(multi_path, molecule_idx=model_idx)
                     second_pos = utils.get_oe_mol_positions(second_oe_mol)
                     assert selected_oe_mol.NumConfs() == 1
                     assert np.allclose(selected_pos, second_pos, atol=1e-1)

--- a/Yank/tests/test_yaml.py
+++ b/Yank/tests/test_yaml.py
@@ -1194,7 +1194,7 @@ class TestMultiMoleculeFiles(object):
                     if extension == 'mol2':
                         # OpenEye loses the resname when writing a mol2 file.
                         mol2_file = utils.Mol2File(single_mol_path)
-                        assert len(mol2_file.resnames) == 1
+                        assert len(list(mol2_file.resnames)) == 1
                         assert mol2_file.resname != '<0>'
 
                     # sdf files must be converted to mol2 to be fed to antechamber

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1183,39 +1183,58 @@ class Mol2File(object):
 
     @property
     def resname(self):
-        """The string name of the first molecule found in the mol2 file."""
-        residue = parmed.load_file(self._file_path)
-        if isinstance(residue, parmed.modeller.residue.ResidueTemplateContainer):
-            return residue[0].name
-        return residue.name
+        """The residue name of the first molecule found in the mol2 file.
 
-    @resname.setter
-    def resname(self, value):
-        residue = parmed.load_file(self._file_path)
-        if isinstance(residue, parmed.modeller.residue.ResidueTemplateContainer):
-            residue[0].name = value
-        else:
-            residue.name = value
-        parmed.formats.Mol2File.write(residue, self._file_path)
+        This assumes that each molecule in the mol2 file has a single residue name.
+
+        """
+        return next(self.resnames)
 
     @property
     def resnames(self):
-        """The list of the names of all the molecules in the file (read-only)."""
-        residues = parmed.load_file(self._file_path)
-        if isinstance(residues, parmed.modeller.residue.ResidueTemplateContainer):
-            return [residue.name for residue in residues]
-        return [residues.name]
+        """Iterate over the names of all the molecules in the file (read-only).
+
+        This assumes that each molecule in the mol2 file has a single residue name.
+
+        """
+        new_resname = False
+        with open(self._file_path, 'r') as f:
+            for line in f:
+                # If the previous line was the ATOM directive, yield the resname.
+                if new_resname:
+                    # The residue name is the 8th word in the line.
+                    yield line.split()[7]
+                    new_resname = False
+                # Go on until you find an atom.
+                elif line.startswith('@<TRIPOS>'):
+                    section = line[9:].strip()
+                    if section == 'ATOM':
+                        new_resname = True
 
     @property
     def net_charge(self):
         """Net charge of the file as a float"""
         residue = parmed.load_file(self._file_path)
-        return sum(a.charge for a in residue.atoms)
+        try:
+            tot_charge = sum(a.charge for a in residue.atoms)
+        except AttributeError:  # residue is a ResidueTemplateContainer
+            tot_charge = 0.0
+            for res in residue:
+                tot_charge += sum(a.charge for a in res.atoms)
+        return tot_charge
 
     @net_charge.setter
     def net_charge(self, value):
         residue = parmed.load_file(self._file_path)
-        residue.fix_charges(to=value, precision=6)
+        try:
+            residue.fix_charges(to=value, precision=6)
+        except TypeError:  # residue is a ResidueTemplateContainer
+            if value is not None:
+                raise ValueError('Cannot modify the net charge of a mol2 '
+                                 'file molecule with multiple residues.')
+            logging.warning("Found mol2 file with multiple residues. The charge of "
+                            "each residue will be rounded to the nearest integer.")
+            residue.fix_charges(precision=6)
         parmed.formats.Mol2File.write(residue, self._file_path)
 
 
@@ -1289,7 +1308,7 @@ def load_oe_molecules(file_path, molecule_idx=None):
 
     Returns
     -------
-    molecule : OEGraphMol or list of OEGraphMol
+    molecule : openeye.oechem.OEMol or list of openeye.oechem.OEMol
         The molecules stored in the file. If molecule_idx is specified
         only one molecule is returned, otherwise a list (even if the
         file contain only 1 molecule).
@@ -1305,7 +1324,7 @@ def load_oe_molecules(file_path, molecule_idx=None):
     # Read all molecules.
     molecules = []
     for mol in ifs.GetOEMols():
-        molecules.append(oechem.OEGraphMol(mol))
+        molecules.append(oechem.OEMol(mol))
 
     # Select conformation of interest
     if molecule_idx is not None:

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1315,9 +1315,15 @@ def load_oe_molecules(file_path, molecule_idx=None):
 
     """
     from openeye import oechem
+    extension = os.path.splitext(file_path)[1][1:]  # Remove dot.
 
     # Open input file stream
     ifs = oechem.oemolistream()
+    if extension == 'mol2':
+        mol2_flavor = (oechem.OEIFlavor_Generic_Default |
+                       oechem.OEIFlavor_MOL2_Default |
+                       oechem.OEIFlavor_MOL2_Forcefield)
+        ifs.SetFlavor(oechem.OEFormat_MOL2, mol2_flavor)
     if not ifs.open(file_path):
         oechem.OEThrow.Fatal('Unable to open {}'.format(file_path))
 

--- a/docs/yamlpages/solvents.rst
+++ b/docs/yamlpages/solvents.rst
@@ -354,3 +354,31 @@ Valid Options (0 * molar): <Quantity Concentration> [1]_
    e.g. "<Quantity Length>" indicates any measure of length may be used for <unit> such as nanometer or angstrom.
    Compound units are also parsed such as ``kilogram / meter**3`` for density.
    Only full unit names as they appear in the simtk.unit package (part of OpenMM) are allowed; so "nm" and "A" will be rejected.
+
+
+
+
+.. _yaml_solvents_leap:
+
+.. rst-class:: html-toggle
+
+``leap``
+--------
+.. code-block:: yaml
+
+   solvents:
+     {UserDefinedSolvent}:
+       leap:
+         parameters: [leaprc.water.tip3p]
+
+Load solvent-specific force field parameters. This is useful if you plan to run a combinatorial experiment over
+multiple solvent models that require different parameters.
+
+This command has only one mandatory subargument ``parameters``, which can accept both single files as a string or a
+comma separated list of files enclosed by [ ]. File paths are relative to either the AmberTools default paths or to
+the folder the YAML script is in.
+
+Alternatively, the solvent parameters can be specified also as :ref:`leap arguments in the system section <yaml_systems_head>`.
+There is no difference between the two solutions other than convenience.
+
+**OPTIONAL**


### PR DESCRIPTION
- When reading a multi-structure mol2 file with openeye, we assumed it contained different conformation of the same molecule. I've removed this assumption to handle different molecules in the same file.
- When there are multiple structures/residues in the mol2 file, `parmed` returns a `ResidueTemplateContainer` instead of a `ResidueTemplate` object. I've fixed `Mol2File.net_charge` and `Mol2File.resname(s)` to handle this case.
- I've added an optional `leap.parameters` key to the YAML `solvents` section. This is super useful to run different explicit solvent models that require different parameters files for both water molecules and ions.

I still have to update the YAML docs before merging. I opened a PR to check if tests pass.