### PR TITLE
Change the default integrator to sock Langevin

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -201,7 +201,7 @@ class AlchemicalPhaseFactory(object):
         'number_of_equilibration_iterations': 0,
         'equilibration_timestep': 1.0 * unit.femtosecond,
         'checkpoint_interval': 10,
-        'integrator_splitting': "BAOAB",
+        'integrator_splitting': None,
     }
 
     def __init__(self, sampler, thermodynamic_state, sampler_states, topography,

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -50,7 +50,7 @@ Detailed Options List
     * :ref:`randomize_ligand_close_cutoff <yaml_options_ligand_close_cutoff>`
     * :ref:`temperature <yaml_options_temperature>`
     * :ref:`pressure <yaml_options_pressure>`
-    * :ref:`splitting <yaml_options_splitting>`
+    * :ref:`integrator_splitting <yaml_options_integrator_splitting>`
     * :ref:`hydrogen_mass <yaml_options_hydrogen_mass>`
     * :ref:`constraints <yaml_options_constraints>`
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -313,16 +313,16 @@ Valid options (1 * atmosphere): null / <Quantity Pressure> [1]_
 
 
 
-.. _yaml_options_splitting:
+.. _yaml_options_integrator_splitting:
 
 .. rst-class:: html-toggle
 
-``splitting``
--------------
+``integrator_splitting``
+------------------------
 .. code-block:: yaml
 
    options:
-     splitting: null
+     integrator_splitting: null
 
 Sequence of "R", "V", "O" (and optionally "{", "}", "V0", "V1", ...) sub-steps to be executed each timestep with a space
 between each step. Tells the
@@ -330,7 +330,7 @@ integrator how to subdivide the work of taking a full timestep, with optional HM
 For example: ``V R O R V`` is a `BAOAB Integrator <https://journals.aps.org/pre/abstract/10.1103/PhysRevE.75.056707>`_
 If you don't want a splitting integrator, specify ``null`` to get a standard Langevin integrator.
 For more details, see
-`the OpenMMTools documentation splits <http://openmmtools.readthedocs.io/en/latest/api/generated/openmmtools.integrators.LangevinIntegrator.html#openmmtools.integrators.LangevinIntegrator>`_.
+`the OpenMMTools documentation <http://openmmtools.readthedocs.io/en/latest/api/generated/openmmtools.integrators.LangevinIntegrator.html#openmmtools.integrators.LangevinIntegrator>`_.
 
 Valid options (``null``): ``null``/<String of R, V, O, {, and/or }; white space " " delimiter>
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -322,15 +322,17 @@ Valid options (1 * atmosphere): null / <Quantity Pressure> [1]_
 .. code-block:: yaml
 
    options:
-     splitting: V R O R V
+     splitting: null
 
 Sequence of "R", "V", "O" (and optionally "{", "}", "V0", "V1", ...) sub-steps to be executed each timestep with a space
 between each step. Tells the
-integrator how to subdivide the work of taking a full timestep. For more details, see
-`the OpenMMTools documentation splits <http://openmmtools.readthedocs.io/en/latest/api/generated/openmmtools.integrators.LangevinIntegrator.html#openmmtools.integrators.LangevinIntegrator>`_.
+integrator how to subdivide the work of taking a full timestep, with optional HMC moves.
+For example: ``V R O R V`` is a `BAOAB Integrator <https://journals.aps.org/pre/abstract/10.1103/PhysRevE.75.056707>`_
 If you don't want a splitting integrator, specify ``null`` to get a standard Langevin integrator.
+For more details, see
+`the OpenMMTools documentation splits <http://openmmtools.readthedocs.io/en/latest/api/generated/openmmtools.integrators.LangevinIntegrator.html#openmmtools.integrators.LangevinIntegrator>`_.
 
-Valid options (V R O R V): <String of R, V, O, {, and/or }>/``null``
+Valid options (``null``): ``null``/<String of R, V, O, {, and/or }; white space " " delimiter>
 
 
 .. _yaml_options_hydrogen_mass:


### PR DESCRIPTION
The splitting integrator is anywhere from 50-80% slower than stock Langevin, so this uses the stock one as default. If we can speed up the splitting integrator, we can change this back in the future.

Also fixes a bug where the default was "BAOAB" which fails since it expects R and V