### PR TITLE
Officially drop Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ script:
 
 env:
   matrix:
-    - python=2.7 CONDA_PY=2.7
     - python=3.5 CONDA_PY=3.5
     - python=3.5 CONDA_PY=35 DEVOMNIA=true
     - python=3.6 CONDA_PY=3.6

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -669,7 +669,7 @@ def get_data_filename(relative_path):
     relative_path : str
         Name of the file to load, with respect to the yank egg folder which
         is typically located at something like
-        ``~/anaconda/lib/python2.7/site-packages/yank-*.egg/examples/``
+        ``~/anaconda/lib/python3.6/site-packages/yank-*.egg/examples/``
 
     Returns
     -------
@@ -788,6 +788,8 @@ def merge_dict(dict1, dict2):
 
     In Python 3.5 there is a syntax to do this ``{**dict1, **dict2}`` but
     in Python 2 you need to go through ``update()``.
+
+    TODO: Refactor to no longer need this now that Python 2 is dropped
 
     Parameters
     ----------

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -8,6 +8,7 @@ source:
 build:
   preserve_egg_dir: True
   number: 0
+  skip: True # [py2k]
 
 requirements:
   build:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ numpydoc_class_members_toctree = False
 
 extensions.append('notebook_sphinxext')
 
-_python_doc_base = 'http://docs.python.org/2.7'
+_python_doc_base = 'http://docs.python.org/3.6'
 intersphinx_mapping = {
     _python_doc_base: None,
     'http://docs.scipy.org/doc/numpy': None,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,22 +14,21 @@ The `yank Anaconda Cloud page <https://anaconda.org/omnia/yank>`_ has useful ins
 If you are using the `anaconda <https://www.continuum.io/downloads/>`_ scientific Python distribution, you already have the ``conda`` package manager installed.
 If not, the quickest way to get started is to install the `miniconda <http://conda.pydata.org/miniconda.html>`_ distribution, a lightweight minimal installation of Anaconda Python.
 
-On ``linux``, you can install the Python 2.7 version into ``$HOME/miniconda2`` with (on ``bash`` systems. Replace
-``Miniconda2`` with ``Miniconda`` if you want to use Python 3):
+On ``linux``, you can install the Python 3.6 version into ``$HOME/miniconda3`` with:
 
 .. code-block:: bash
 
    $ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-   $ bash ./Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda2
-   $ export PATH="$HOME/miniconda2/bin:$PATH"
+   $ bash ./Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda3
+   $ export PATH="$HOME/miniconda3/bin:$PATH"
 
 On ``osx``, you want to use the ``osx`` binary
 
 .. code-block:: bash
 
    $ wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-   $ bash ./Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda2
-   $ export PATH="$HOME/miniconda2/bin:$PATH"
+   $ bash ./Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda3
+   $ export PATH="$HOME/miniconda3/bin:$PATH"
 
 You may want to add the new ```$PATH`` extension to your ``~/.bashrc`` file to ensure Anaconda Python is used by
 default.
@@ -225,7 +224,9 @@ Supported platforms and environments
 Software
 --------
 
-YANK runs on Python 2.7, Python 3.5, and Python 3.6
+YANK runs on Python 3.5, and Python 3.6
+
+We no longer support Python 2.X.
 
 Dependencies
 ++++++++++++


### PR DESCRIPTION
This does not change any of the code, but the documentation and the tests no longer use Python 2 in any way.
In future bug cleanups, we can change all the python 2/3 compatibility things hanging around.

Fixes #761