### PR TITLE
Add links to the individual Restraint API

### DIFF
--- a/docs/yamlpages/experiments.rst
+++ b/docs/yamlpages/experiments.rst
@@ -1,3 +1,5 @@
+.. py:currentmodule:: yank.restraints
+
 .. _yaml_experiments_head:
 
 Experiments Header in YAML Files
@@ -36,7 +38,13 @@ to create the experiment and are the only required arguments.
 The ``restraint`` is an **optional** keyword that applies a restraint to the ligand to keep it close to the receptor.
 The only required keyword is ``type``. Valid types are: ``FlatBottom``/``Harmonic``/``Boresch``/``null``. If not
 specified, assumes ``null``. Every restraint has his own set of optional parameters that are passed directly to the
-Python constructor of the restraint. See the API documentation in ``yank.restraints`` for the available parameters.
+Python constructor of the restraint. See the API documentation in ``yank.restraints`` for the available parameters; you
+can use the links below to jump to each of individual restraint types, the keyword arguments for each restraint type
+are accepted as arguments in the YAML file:
+
+* :class:`FlatBottom Radially-Symmetric Restraints <FlatBottom>`
+* :class:`Harmonic Radially-Symmetric Restraints <Harmonic>`
+* :class:`Boresch Orientational Restraints <Boresch>`
 
 The ``options`` directive lets you overwrite :doc:`any global setting <options>` specified in the header ``options`` for
 this specific experiment.
@@ -58,3 +66,9 @@ A single experiment can be defined by the following example. However, if one wou
 #. Create an ``experiments`` header below your user defined ones with the syntax: ``experiments: [{UserDefinedExperiment}, {UserDefinedExperiment}, ...]`` where the list is the experiments you defined.
 
   * **NOTE**: There are no sub-directives under the ``experiments`` header when invoked this way.
+
+
+.. _yaml_experiments_restraints:
+
+Restraints Options
+==================


### PR DESCRIPTION
The render looks like this where each item links to the API for the individual restraint (from screenshot)

![restraints api](https://i.imgur.com/TmLdeob.png)

@davidlmobley is this what you were expecting for this page, or should there be more information to be clearer?

Fixes #765
Progress to #764 