### PR TITLE
Add solute-only trajectory storage

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -201,6 +201,7 @@ class AlchemicalPhaseFactory(object):
         'number_of_equilibration_iterations': 0,
         'equilibration_timestep': 1.0 * unit.femtosecond,
         'checkpoint_interval': 10,
+        'store_solute_trajectory': True,
         'integrator_splitting': "V R O R V",
     }
 
@@ -243,8 +244,19 @@ class AlchemicalPhaseFactory(object):
         # Create a reporter if this is only a path.
         if isinstance(self.storage, str):
             checkpoint_interval = self.options['checkpoint_interval']
+            # Get the solute atoms
+            if self.options['store_solute_trajectory']:
+                solute_atoms = self.topography.solute_atoms
+                if checkpoint_interval == 1:
+                    logger.warning("WARNING! You have specified both a solute-only trajectory AND a checkpoint "
+                                   "interval of 1! You are about write the trajectory of the solute twice!\n"
+                                   "This can be okay if you are running explicit solvent and want faster retrieval "
+                                   "of the solute atoms, but in implicit solvent, this is redundant.")
+            else:
+                solute_atoms = ()
             # We don't allow checkpoint file overwriting in YAML file
-            reporter = repex.Reporter(self.storage, checkpoint_interval=checkpoint_interval)
+            reporter = repex.Reporter(self.storage, checkpoint_interval=checkpoint_interval,
+                                      analysis_particle_indices=solute_atoms)
             create_kwargs['storage'] = reporter
             self.storage = reporter
 

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -557,11 +557,10 @@ class Reporter(object):
             sampler_subset = []
             for sampler_state in sampler_states:
                 positions = sampler_state.positions
-                # Subset positions by converting tuple of indices into the correct indexing scheme
-                # np.unravel_index works with tuples and lists
-                # Doing positions[tuple] tries to treat each index as a different dimension, which is different than
-                # positions[list]
-                position_subset = positions[np.unravel_index(self._analysis_particle_indices, positions.shape)]
+                # Subset positions
+                # Need the [arg, :] to get uniform behavior with tuple and list for arg
+                # since a ndarray[tuple] is different than ndarray[list]
+                position_subset = positions[self._analysis_particle_indices, :]
                 sampler_subset.append(mmtools.states.SamplerState(position_subset,
                                                                   box_vectors=sampler_state.box_vectors))
             self._write_sampler_states_to_given_file(sampler_subset, iteration, storage_file='analysis',

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -140,6 +140,7 @@ class Reporter(object):
         self._storage_checkpoint = None
         self._storage_analysis = None
         self._checkpoint_interval = checkpoint_interval
+        # Cast to tuple no mater what 1-D-like input was given
         self._analysis_particle_indices = tuple(analysis_particle_indices)
         if open_mode is not None:
             self.open(open_mode)

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -354,7 +354,8 @@ class Reporter(object):
                 ncvar_analysis_particles.long_name = ("analysis_particle_indices[analysis_particles] is the indices of "
                                                       "the particles with extra information stored about them in the"
                                                       "analysis file.")
-            # Now handle the "variable does exist but does not match the provided ones
+            # Now handle the "variable does exist but does not match the provided ones"
+            # Although redundant if it was just created, its an easy check to make
             stored_analysis_particles = self._storage_analysis.variables['analysis_particle_indices'][:]
             if self._analysis_particle_indices != tuple(stored_analysis_particles.astype(int)):
                 logger.debug("analysis_particle_indices != on-file analysis_particle_indices!"
@@ -505,7 +506,8 @@ class Reporter(object):
     def read_sampler_states(self, iteration, analysis_particles_only=False):
         """Retrieve the stored sampler states on the checkpoint file
 
-        If the iteration is not on the checkpoint interval, None is returned
+        If the iteration is not on the checkpoint interval, None is returned.
+        Exception to this is if``analysis_particles_only``, see the Returns for output behavior.
 
 
         Parameters
@@ -520,10 +522,11 @@ class Reporter(object):
         sampler_states : list of SamplerStates or None
             The previously stored sampler states for each replica.
 
-            If the iteration is not on the checkpoint_interval and the analysis_particles_only is not set,
+            If the iteration is not on the ``checkpoint_interval`` and the ``analysis_particles_only`` is not set,
             None is returned
 
-            If analysis_particles_only is set, will return only the subset of particles which make up the solute
+            If ``analysis_particles_only`` is set, will return only the subset of particles which were defined by the
+            ``analysis_particle_indices`` on reporter creation
 
         """
         if analysis_particles_only:
@@ -540,7 +543,8 @@ class Reporter(object):
     def write_sampler_states(self, sampler_states, iteration):
         """Store all sampler states for a given iteration on the checkpoint file
 
-        If the iteration is not on the checkpoint interval, only the analysis_particle_indices data is written, if set.
+        If the iteration is not on the checkpoint interval, only the ``analysis_particle_indices`` data is written,
+        if set.
 
         Parameters
         ----------

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -289,14 +289,17 @@ class TestPhaseAnalyzer(object):
 
     def test_extract_trajectory(self):
         """extract_trajectory handles checkpointing and skip frame correctly."""
-        print(self.reporter.read_last_iteration())
+        # print(self.reporter.read_last_iteration())
         trajectory = analyze.extract_trajectory(self.reporter.filepath, state_index=0, skip_frame=2)
         assert len(trajectory) == 1
         full_trajectory = analyze.extract_trajectory(self.reporter.filepath, state_index=0, keep_solvent=True)
         # This should work since its pure Python integer division
-        assert len(full_trajectory) == (self.n_steps + 1) / self.checkpoint_interval
+        # Follows the checkpoint interval logic
+        # The -1 is because frame 0 is discarded from trajectory extraction due to equilibration problems
+        # Should this change in analyze, then this logic will need to be changed as well
+        assert len(full_trajectory) == ((self.n_steps + 1) / self.checkpoint_interval) - 1
         # Make sure the "solute"-only (analysis atoms) trajectory has the correct properties
         solute_trajectory = analyze.extract_trajectory(self.reporter.filepath, state_index=0, keep_solvent=False)
-        assert len(solute_trajectory) == self.n_steps
+        assert len(solute_trajectory) == self.n_steps - 1
         assert solute_trajectory.n_atoms == len(self.analysis_atoms)
 

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -388,26 +388,9 @@ class TestReporter(object):
                 # This assert is dual purpose: Positions are identical; Analysis shape is correct
                 # Will raise a ValueError for np.allclose(x,y) if x.shape != y.shape
                 # Will raise AssertionError if the values are not allclose
-                assert np.allclose(analysis_state.positions, restored_checkpoint_states[analysis_particles, :])
+                assert np.allclose(analysis_state.positions, checkpoint_state.positions[analysis_particles, :])
                 assert np.allclose(analysis_state.box_vectors / unit.nanometer,
                                    checkpoint_state.box_vectors / unit.nanometer)
-
-    def test_analysis_particles(self):
-        """Check that analysis particles are stored separate from the checkpoint particles"""
-        with self.temporary_reporter(analysis_particle_indices=(1, 2), checkpoint_interval=2) as reporter:
-            # Create sampler states.
-            alanine_test = testsystems.AlanineDipeptideVacuum()
-            positions = alanine_test.positions
-            box_vectors = alanine_test.system.getDefaultPeriodicBoxVectors()
-            sampler_states = [mmtools.states.SamplerState(positions=positions, box_vectors=box_vectors)
-                              for _ in range(2)]
-            # Check that after writing and reading, states are identical.
-            reporter.write_sampler_states(sampler_states, iteration=0)
-            reporter.write_last_iteration(0)
-            restored_sampler_states = reporter.read_sampler_states(iteration=0)
-            for state, restored_state in zip(sampler_states, restored_sampler_states):
-                assert np.allclose(state.positions, restored_state.positions)
-                assert np.allclose(state.box_vectors / unit.nanometer, restored_state.box_vectors / unit.nanometer)
 
     def test_store_replica_thermodynamic_states(self):
         """Check storage of replica thermodynamic states indices."""

--- a/docs/building_docs.rst
+++ b/docs/building_docs.rst
@@ -19,7 +19,7 @@ If you'd like to build the docs on your machine, you'll first need to install sp
 
 .. code-block:: bash
 
-    $ conda install sphinx numpydoc
+    $ conda install sphinx numpydoc sphinx_rtd_theme runipy
 
 You may also need Jupyter notebooks and matplotlib:
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -21,6 +21,7 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 - Fixed the number of neutralizing counterions when receptor and ligand have opposite charges (we were adding too many in this case).
 - Fixed the log file name with lists of experiments that ended up being just .log.
 - Implemented workaround for fixing the net charge of cyclic multi-residue mol2 files.
+- Solute-only trajectories can now be stored every iteration, regardless of checkpoint interval
 
 0.17.0 Auto Alchemical Path and Split Langevin Integrators
 ----------------------------------------------------------

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -66,6 +66,7 @@ Detailed Options List
     * :ref:`nsteps_per_iteration <yaml_options_nsteps_per_iteration>`
     * :ref:`timestep <yaml_options_timestep>`
     * :ref:`checkpoint_interval <yaml_options_checkpoint_interval>`
+    * :ref:`store_solute_trajectory <yaml_options_store_solute_trajectory>`
     * :ref:`replica_mixing_scheme <yaml_options_replica_mixing_scheme>`
     * :ref:`collision_rate <yaml_options_collision_rate>`
     * :ref:`constraint_tolerance <yaml_options_constraint_tolerance>`

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -648,6 +648,26 @@ Valid Options (10): <Integer ``>= 1``>
 
 
 
+.. _yaml_options_store_solute_trajectory:
+
+.. rst-class:: html-toggle
+
+``store_solute_trajectory``
+---------------------------
+.. code-block:: yaml
+
+   options:
+     store_solute_trajectory: yes
+
+Specify if you want an additional trajectory of just the solute atoms stored every iteration, regardless of the
+``checkpoint_interval``.
+
+If specified, this will write the data to the analysis file in addition to the normal information stored in the
+checkpoint file. As such, you should be careful when considering space and the ``checkpoint_interval`` setting. For
+instance, an implicit solvent simulation with ``checkpoint_interval: 1`` will result in a redundant copy of the
+complete trajectory.
+
+
 .. _yaml_options_replica_mixing_scheme:
 
 .. rst-class:: html-toggle

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -667,6 +667,8 @@ checkpoint file. As such, you should be careful when considering space and the `
 instance, an implicit solvent simulation with ``checkpoint_interval: 1`` will result in a redundant copy of the
 complete trajectory.
 
+Valid Options: [yes]/no
+
 
 .. _yaml_options_replica_mixing_scheme:
 


### PR DESCRIPTION
This PR adds the ability for YANK to store only the solute trajectory as part of the analysis file. Minimal changes to the API calls in the form of new keywords; no new public methods nor changes to existing calls which would break backwards compatibility.

This is constructed automatically from the Topography if the appropriate flag is set in the YAML file, which defaults to True.

There are no new tests for this at the moment, which we may want to write before merging, but I at least want to get the conversation started and the code reviewed.

This has also changed the logic in the trajectory analysis code, so that will need to be verified (again, tests would fix)

Progress towards #777