### PR TITLE
Cut Yank 0.18.0

### DIFF
--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -292,12 +292,14 @@ class TestPhaseAnalyzer(object):
         # print(self.reporter.read_last_iteration())
         trajectory = analyze.extract_trajectory(self.reporter.filepath, state_index=0, skip_frame=2)
         assert len(trajectory) == 1
+        self.reporter.close()
         full_trajectory = analyze.extract_trajectory(self.reporter.filepath, state_index=0, keep_solvent=True)
         # This should work since its pure Python integer division
         # Follows the checkpoint interval logic
         # The -1 is because frame 0 is discarded from trajectory extraction due to equilibration problems
         # Should this change in analyze, then this logic will need to be changed as well
         assert len(full_trajectory) == ((self.n_steps + 1) / self.checkpoint_interval) - 1
+        self.reporter.close()
         # Make sure the "solute"-only (analysis atoms) trajectory has the correct properties
         solute_trajectory = analyze.extract_trajectory(self.reporter.filepath, state_index=0, keep_solvent=False)
         assert len(solute_trajectory) == self.n_steps - 1

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
 
 requirements:
   build:
-    - python >=3.5
+    - python
     - cython
     - numpy
     - scipy
@@ -33,7 +33,7 @@ requirements:
     #- gcc 4.8.2 # [osx]
 
   run:
-    - python >=3.5
+    - python
     - pandas
     - numpy
     - scipy

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
 
 requirements:
   build:
-    - python
+    - python >=3.5
     - cython
     - numpy
     - scipy
@@ -33,7 +33,7 @@ requirements:
     #- gcc 4.8.2 # [osx]
 
   run:
-    - python
+    - python >=3.5
     - pandas
     - numpy
     - scipy

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,8 +6,8 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
-0.17.1 In Development (Work in Progress)
-----------------------------------------
+0.18.0 Python 2 Dropped, Solute Only Trajectories, and Trailblaze Bugfixes
+--------------------------------------------------------------------------
 - Python 2.X Support officially *removed*
 - Additional doc cleanups
 - Added restraint selection flowchart to documentation
@@ -21,6 +21,7 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 - Fixed the number of neutralizing counterions when receptor and ligand have opposite charges (we were adding too many in this case).
 - Fixed the log file name with lists of experiments that ended up being just .log.
 - Implemented workaround for fixing the net charge of cyclic multi-residue mol2 files.
+- Added GAFF2 Torsion support based on YAML input files
 - Solute-only trajectories can now be stored every iteration, regardless of checkpoint interval
 
 0.17.0 Auto Alchemical Path and Split Langevin Integrators

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.17.1"  # Primary base version of the build
-DEVBUILD = "0"      # Dev build status, Either None or Integer as string
-ISRELEASED = False  # Are we releasing this as a full cut?
+VERSION = "0.18.0"  # Primary base version of the build
+DEVBUILD = None  # Dev build status, Either None or Integer as string
+ISRELEASED = True  # Are we releasing this as a full cut?
 __version__ = VERSION
 ########################
 CLASSIFIERS = """\
@@ -143,7 +143,7 @@ setup(
         'numpy',
         'scipy',
         'cython',
-        'openmm',
+        'openmm>=7.1',
         'pymbar',
         'openmmtools>=0.13.1',
         'docopt>=0.6.1',

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ setup(
     package_data={'yank': find_package_data('Yank/tests/data', 'yank') + ['reports/*.ipynb'],
                   },
     zip_safe=False,
+    python_requires=">=3.5",
     install_requires=[
         'numpy',
         'scipy',


### PR DESCRIPTION
Due to official Python 2 support dropped, a new major revision is being cut.

Also taking advantage of the new feature in setuptools/pip for `python_requires` + the conda-recipe to force python 3.5 and up. The additional keyword should not cause an issue for pip < 9.0.1

Tests must pass before we can merge this to test the new requirements feature