### PR TITLE
Add new Regions API to Topography

### DIFF
--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -70,15 +70,38 @@ def test_topography():
     assert len(topography.ions_atoms) == 0
 
 
+def test_topography_regions():
+    """Test that topography regions are created and fetched"""
+    toluene_vacuum = testsystems.TolueneVacuum()
+    topography = Topography(toluene_vacuum.topology)
+    # Should do nothing and return nothing without error
+    assert topography.remove_region('Nothing') is None
+    topography.add_region('A hard list', [0, 1, 2])
+    assert 'A hard list' in topography
+    topography.add_region('A junk list', [5, 5, 5])
+    topography.remove_region('A junk list')
+    assert 'A junk list' not in topography
+    assert topography.get_region('A hard list') == [0, 1, 2]
+    # Confirm that string typing is handled
+    topography.add_region('carbon', 'name C')
+    assert len(topography.get_region('carbon')) > 0
+    with nose.tools.assert_raises(ValueError):
+        topography.add_region('failure', 'Bad selection string')
+    # Ensure region was not added
+    assert 'failure' not in topography
+
+
 def test_topography_serialization():
     """Correct serialization of Topography objects."""
     test_system = testsystems.AlanineDipeptideImplicit()
     topography = Topography(test_system.topology)
+    topography.add_region('atest', [0, 1, 2, 3])
     serialized_topography = mmtools.utils.serialize(topography)
     restored_topography = mmtools.utils.deserialize(serialized_topography)
     assert topography.topology == restored_topography.topology
     assert topography.ligand_atoms == restored_topography.ligand_atoms
     assert topography.solvent_atoms == restored_topography.solvent_atoms
+    assert topography.get_region('atest') == restored_topography.regions['atest']
 
 
 # ==============================================================================

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -83,7 +83,7 @@ def test_topography_regions():
     assert 'A junk list' not in topography
     assert topography.get_region('A hard list') == [0, 1, 2]
     # Confirm that string typing is handled
-    topography.add_region('carbon', 'name C')
+    topography.add_region('carbon', 'element C')
     assert len(topography.get_region('carbon')) > 0
     with nose.tools.assert_raises(ValueError):
         topography.add_region('failure', 'Bad selection string')
@@ -101,7 +101,7 @@ def test_topography_serialization():
     assert topography.topology == restored_topography.topology
     assert topography.ligand_atoms == restored_topography.ligand_atoms
     assert topography.solvent_atoms == restored_topography.solvent_atoms
-    assert topography.get_region('atest') == restored_topography.regions['atest']
+    assert topography.get_region('atest') == restored_topography.get_region('atest')
 
 
 # ==============================================================================

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -252,6 +252,66 @@ def _with_profile(output_file='profile.log'):
 
 
 # =======================================================================================
+# Multimethod wrapping to better handle cyclomatic complexity with input types
+# See Adam Bard's post: https://adambard.com/blog/implementing-multimethods-in-python/
+# =======================================================================================
+
+def multi(dispatch_fn):
+    """
+    Decorator for the dispatch function to handle multiple types
+    Should return a way of classifying multiple input types
+
+    Example
+    -------
+    Instead of doing "If A is class X do J, elif A is class Y do K, else do L", instead wrap this ``multi`` method
+    around the dispatch function which would simply "return type(A)", then use the ``method`` function below to handle
+    types.
+    """
+    def _inner(*args, **kwargs):
+        return _inner.__multi__.get(
+            dispatch_fn(*args, **kwargs),
+            _inner.__multi_default__
+        )(*args, **kwargs)
+    _inner.__multi__ = {}
+    _inner.__multi_default__ = lambda *args, **kwargs: None  # Default default
+    return _inner
+
+
+def method(dispatch_fn, dispatch_key=None):
+    """
+    Decorator around the individual type handlers parsing a multimethod dispatch function decorated by the ``multi``
+    method from above.
+
+    Example
+    -------
+    Following the example from ``multi``, if you have the dispatch function "return type(A)", and you want to do
+    something under the condition of of X or Y and finally Else. Our dispatch function is called ``dispatch``
+
+    One function would be decorated with @method(dispatch, X) since ``dispatch`` would handle the "A is type X" method
+    One function would be decorated with @method(dispatch, Y) since ``dispatch`` would handle the "A is type Y" method
+    One function would be decorated with @method(dispatch) to handle the default "all other results" case.
+
+    Each function would accept its args and kwargs as normal and return as though they were their own functions. You
+    may find it helpful to then have each function call a common processing function once they are done doing their
+    unique things to avoid code repetition
+
+    The function names decorated by @method don't matter and can even be duplicates because they will be be absorbed
+    by the decorator and not made public, but because of how python handles
+    compiling, it will add them as method of ``dispatch`` in order they are found, so all @method's should come after
+    the @multi
+
+    """
+    def apply_decorator(fn):
+        if dispatch_key is None:
+            # Default case
+            dispatch_fn.__multi_default__ = fn
+        else:
+            dispatch_fn.__multi__[dispatch_key] = fn
+        return dispatch_fn
+    return apply_decorator
+
+
+# =======================================================================================
 # Combinatorial tree
 # =======================================================================================
 

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -304,7 +304,7 @@ class Topography(object):
         if utils.is_openeye_installed('oechem'):
             # TODO: Handle SMIRKS in the future
             pass
-        raise ValueError("Either your atoms_description was messed up or you dont have OpenEye OEChem installed! "
+        raise ValueError("Either your atoms_description was messed up or you don't have OpenEye OEChem installed! "
                          "String based atom description could not be processed")
 
 # ==============================================================================

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -235,7 +235,7 @@ class Topography(object):
         KeyError
             If region is not part of the Topography
         """
-        if region_name not in self._combied_regions:
+        if region_name not in self._combined_regions:
             raise KeyError("Cannot find region \"{}\" in this Topography.".format(region_name))
         # Return the built-in if present
         if region_name in self._built_in_regions:
@@ -280,7 +280,7 @@ class Topography(object):
                            "Cannot overwrite built-in regions!".format(region_string))
 
     @property
-    def _combied_regions(self):
+    def _combined_regions(self):
         """
         Return the combined set of regions
         This is its own property despite its simplicity since several functions and methods call it
@@ -290,7 +290,7 @@ class Topography(object):
 
     def __contains__(self, item):
         """Check the in operator to see if region is in this class"""
-        return item in self._combied_regions
+        return item in self._combined_regions
 
     @utils.multi
     def _resolve_atom_indices(self, atom_description):

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -202,7 +202,6 @@ class Topography(object):
         self._check_existing_regions(region_name)
         atom_selection = self._resolve_atom_indices(region_selection)
         self._regions[region_name] = atom_selection
-        pass
 
     def remove_region(self, region_name):
         """

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -285,7 +285,8 @@ class Topography(object):
         Return the combined set of regions
         This is its own property despite its simplicity since several functions and methods call it
         """
-        return self._built_in_regions + self._regions.keys()
+        # Iterate over the dict_keys object since its a static view and should be thread-safe
+        return self._built_in_regions + [region for region in self._regions.keys()]
 
     def __contains__(self, item):
         """Check the in operator to see if region is in this class"""


### PR DESCRIPTION
Add the ability to add and manipulate arbitrary regions to the Topography object. These are more general than the alchemy based alchemical regions and are only subsets of atoms.

Generalizes string selection handling with a future PR to handle SMARTS strings (as marked by TODO's). This PR does not address those so its a smaller chunk to review.

Adds a handy multitmethod technique to reduce cyclomatic complexity we may be able to apply elsewhere.