### PR TITLE
Arbitrary Molecular Regions in YAML

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2181,15 +2181,15 @@ class ExperimentBuilder(object):
         try:  # binding free energy calculations
             solvent_ids = [db_system['solvent'],
                            db_system['solvent']]
-            ligand_regions = self._db.molecules.get(db_system.get('ligand', {}), {}).get('regions', {})
-            receptor_regions = self._db.molecules.get(db_system.get('receptor', {}), {}).get('regions', {})
+            ligand_regions = self._db.molecules.get(db_system.get('ligand'), {}).get('regions', {})
+            receptor_regions = self._db.molecules.get(db_system.get('receptor'), {}).get('regions', {})
             # Name clashes have been resolved in the yaml validation
             regions = {**ligand_regions, **receptor_regions}
         except KeyError:  # partition/solvation free energy calculations
             try:
                 solvent_ids = [db_system['solvent1'],
                                db_system['solvent2']]
-                regions = self._db.molecules.get(db_system.get('solute', {}), {}).get('regions', {})
+                regions = self._db.molecules.get(db_system.get('solute'), {}).get('regions', {})
             except KeyError:  # from xml/pdb system files
                 assert 'phase1_path' in db_system
                 solvent_ids = [None, None]

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2181,15 +2181,15 @@ class ExperimentBuilder(object):
         try:  # binding free energy calculations
             solvent_ids = [db_system['solvent'],
                            db_system['solvent']]
-            ligand_regions = self._db.molecules.get(db_system['ligand'], {}).get('regions', {})
-            receptor_regions = self._db.molecules.get(db_system['receptor'], {}).get('regions', {})
+            ligand_regions = self._db.molecules.get(db_system.get('ligand', {}), {}).get('regions', {})
+            receptor_regions = self._db.molecules.get(db_system.get('receptor', {}), {}).get('regions', {})
             # Name clashes have been resolved in the yaml validation
             regions = {**ligand_regions, **receptor_regions}
         except KeyError:  # partition/solvation free energy calculations
             try:
                 solvent_ids = [db_system['solvent1'],
                                db_system['solvent2']]
-                regions = self._db.molecules.get(db_system['solute'], {}).get('regions', {})
+                regions = self._db.molecules.get(db_system.get('solute', {}), {}).get('regions', {})
             except KeyError:  # from xml/pdb system files
                 assert 'phase1_path' in db_system
                 solvent_ids = [None, None]

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2181,15 +2181,15 @@ class ExperimentBuilder(object):
         try:  # binding free energy calculations
             solvent_ids = [system['solvent'],
                            system['solvent']]
-            ligand_regions = self._db.molecules[system['ligand']].get('regions', {})
-            receptor_regions = self._db.molecules[system['receptor']].get('regions', {})
+            ligand_regions = self._db.molecules.get(system['ligand'], {}).get('regions', {})
+            receptor_regions = self._db.molecules.get(system['receptor'], {}).get('regions', {})
             # Name clashes have been resolved in the yaml validation
             regions = {**ligand_regions, **receptor_regions}
         except KeyError:  # partition/solvation free energy calculations
             try:
                 solvent_ids = [system['solvent1'],
                                system['solvent2']]
-                regions = self._db.molecules[system['solute']].get('regions', {})
+                regions = self._db.molecules.get(system['solute'], {}).get('regions', {})
             except KeyError:  # from xml/pdb system files
                 assert 'phase1_path' in system
                 solvent_ids = [None, None]

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2179,7 +2179,7 @@ class ExperimentBuilder(object):
         # Determine complex and solvent phase solvents while also getting regions
         system_description = self._db.systems[system_id]
         try:  # binding free energy calculations
-            system_description = [system_description['solvent'],
+            solvent_ids = [system_description['solvent'],
                                   system_description['solvent']]
             ligand_regions = self._db.molecules.get(system_description.get('ligand'), {}).get('regions', {})
             receptor_regions = self._db.molecules.get(system_description.get('receptor'), {}).get('regions', {})

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2177,21 +2177,21 @@ class ExperimentBuilder(object):
         logger.debug('DSL string for the solvent: "{}"'.format(solvent_dsl))
 
         # Determine complex and solvent phase solvents while also getting regions
-        db_system = self._db.systems[system_id]
+        system_description = self._db.systems[system_id]
         try:  # binding free energy calculations
-            solvent_ids = [db_system['solvent'],
-                           db_system['solvent']]
-            ligand_regions = self._db.molecules.get(db_system.get('ligand'), {}).get('regions', {})
-            receptor_regions = self._db.molecules.get(db_system.get('receptor'), {}).get('regions', {})
+            system_description = [system_description['solvent'],
+                                  system_description['solvent']]
+            ligand_regions = self._db.molecules.get(system_description.get('ligand'), {}).get('regions', {})
+            receptor_regions = self._db.molecules.get(system_description.get('receptor'), {}).get('regions', {})
             # Name clashes have been resolved in the yaml validation
             regions = {**ligand_regions, **receptor_regions}
         except KeyError:  # partition/solvation free energy calculations
             try:
-                solvent_ids = [db_system['solvent1'],
-                               db_system['solvent2']]
-                regions = self._db.molecules.get(db_system.get('solute'), {}).get('regions', {})
+                solvent_ids = [system_description['solvent1'],
+                               system_description['solvent2']]
+                regions = self._db.molecules.get(system_description.get('solute'), {}).get('regions', {})
             except KeyError:  # from xml/pdb system files
-                assert 'phase1_path' in db_system
+                assert 'phase1_path' in system_description
                 solvent_ids = [None, None]
                 regions = {}
 

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2177,21 +2177,21 @@ class ExperimentBuilder(object):
         logger.debug('DSL string for the solvent: "{}"'.format(solvent_dsl))
 
         # Determine complex and solvent phase solvents while also getting regions
-        system = self._db.systems[system_id]
+        db_system = self._db.systems[system_id]
         try:  # binding free energy calculations
-            solvent_ids = [system['solvent'],
-                           system['solvent']]
-            ligand_regions = self._db.molecules.get(system['ligand'], {}).get('regions', {})
-            receptor_regions = self._db.molecules.get(system['receptor'], {}).get('regions', {})
+            solvent_ids = [db_system['solvent'],
+                           db_system['solvent']]
+            ligand_regions = self._db.molecules.get(db_system['ligand'], {}).get('regions', {})
+            receptor_regions = self._db.molecules.get(db_system['receptor'], {}).get('regions', {})
             # Name clashes have been resolved in the yaml validation
             regions = {**ligand_regions, **receptor_regions}
         except KeyError:  # partition/solvation free energy calculations
             try:
-                solvent_ids = [system['solvent1'],
-                               system['solvent2']]
-                regions = self._db.molecules.get(system['solute'], {}).get('regions', {})
+                solvent_ids = [db_system['solvent1'],
+                               db_system['solvent2']]
+                regions = self._db.molecules.get(db_system['solute'], {}).get('regions', {})
             except KeyError:  # from xml/pdb system files
-                assert 'phase1_path' in system
+                assert 'phase1_path' in db_system
                 solvent_ids = [None, None]
                 regions = {}
 

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -420,7 +420,24 @@ def test_validation_correct_molecules():
         {'filepath': paths['abl'], 'leap': {'parameters': 'leaprc.ff99SBildn'}, 'select': 1},
         {'filepath': paths['abl'], 'select': 'all'},
         {'filepath': paths['toluene'], 'leap': {'parameters': 'leaprc.gaff'}},
-        {'filepath': paths['benzene'], 'epik': {'select': 1, 'tautomerize': False}}
+        {'filepath': paths['benzene'], 'epik': {'select': 1, 'tautomerize': False}},
+        # Regions tests, make sure all other combos still work
+        {'name': 'toluene', 'regions': {'a_region': 4}},
+        {'name': 'toluene', 'regions': {'a_region': 'dsl string'}},
+        {'name': 'toluene', 'regions': {'a_region': [0, 2, 3]}},
+        {'name': 'toluene', 'regions': {'a_region': [0, 2, 3], 'another_region': [5, 4, 3]}},
+        {'smiles': 'Cc1ccccc1', 'regions': {'a_region': 4}},
+        {'smiles': 'Cc1ccccc1', 'regions': {'a_region': 'dsl string'}},
+        {'smiles': 'Cc1ccccc1', 'regions': {'a_region': [0, 2, 3]}},
+        {'smiles': 'Cc1ccccc1', 'regions': {'a_region': [0, 2, 3], 'another_region': [5, 4, 3]}},
+        {'filepath': paths['abl'], 'regions': {'a_region': 4}},
+        {'filepath': paths['abl'], 'regions': {'a_region': 'dsl string'}},
+        {'filepath': paths['abl'], 'regions': {'a_region': [0, 2, 3]}},
+        {'filepath': paths['abl'], 'regions': {'a_region': [0, 2, 3], 'another_region': [5, 4, 3]}},
+        {'filepath': paths['toluene'], 'regions': {'a_region': 4}},
+        {'filepath': paths['toluene'], 'regions': {'a_region': 'dsl string'}},
+        {'filepath': paths['toluene'], 'regions': {'a_region': [0, 2, 3]}},
+        {'filepath': paths['toluene'], 'regions': {'a_region': [0, 2, 3], 'another_region': [5, 4, 3]}}
     ]
     for molecule in molecules:
         yield ExperimentBuilder._validate_molecules, {'mol': molecule}

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -468,6 +468,8 @@ def test_validation_wrong_molecules():
         {'smiles': 'Cc1ccccc1', 'select': 1},
         {'name': 'Cc1ccccc1', 'select': 1},
         {'filepath': paths['abl'], 'leap': {'parameters': 'oldff/leaprc.ff14SB'}, 'select': 'notanoption'},
+        {'filepath': paths['abl'], 'regions': 5},
+        {'filepath': paths['abl'], 'regions': {'a_region': [-56, 5.23]}},
     ]
     for molecule in molecules:
         yield assert_raises, YamlParseError, ExperimentBuilder._validate_molecules, {'mol': molecule}
@@ -514,8 +516,10 @@ def test_validation_correct_systems():
     basic_script = """
     ---
     molecules:
-        rec: {{filepath: {}, leap: {{parameters: leaprc.ff14SB}}}}
+        rec: {{filepath: {0}, leap: {{parameters: leaprc.ff14SB}}}}
+        rec_reg: {{filepath: {0}, regions: {{receptregion: 'some dsl'}}, leap: {{parameters: leaprc.ff14SB}}}}
         lig: {{name: lig, leap: {{parameters: leaprc.gaff}}}}
+        lig_reg: {{name: lig, regions: {{ligregion: [143, 123]}}, leap: {{parameters: leaprc.gaff}}}}
     solvents:
         solv: {{nonbonded_method: NoCutoff}}
         solv2: {{nonbonded_method: NoCutoff, implicit_solvent: OBC2}}
@@ -526,6 +530,8 @@ def test_validation_correct_systems():
 
     systems = [
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv'},
+        {'receptor': 'rec_reg', 'ligand': 'lig_reg', 'solvent': 'solv'},
+        {'receptor': 'rec_reg', 'ligand': 'lig', 'solvent': 'solv'},
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv', 'pack': True},
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv3',
             'leap': {'parameters': ['leaprc.gaff', 'leaprc.ff14SB']}},
@@ -557,6 +563,7 @@ def test_validation_correct_systems():
          'ligand_dsl': 'resname TOL', 'solvent_dsl': 'not resname TOL'},
 
         {'solute': 'lig', 'solvent1': 'solv', 'solvent2': 'solv'},
+        {'solute': 'lig_reg', 'solvent1': 'solv', 'solvent2': 'solv'},
         {'solute': 'lig', 'solvent1': 'solv', 'solvent2': 'solv',
             'leap': {'parameters': 'leaprc.gaff'}}
     ]
@@ -573,8 +580,10 @@ def test_validation_wrong_systems():
     basic_script = """
     ---
     molecules:
-        rec: {{filepath: {}, leap: {{parameters: oldff/leaprc.ff14SB}}}}
+        rec: {{filepath: {0}, leap: {{parameters: oldff/leaprc.ff14SB}}}}
+        rec_region: {{filepath: {0}, regions: {{a_region: 'some string'}}, leap: {{parameters: oldff/leaprc.ff14SB}}}}
         lig: {{name: lig, leap: {{parameters: leaprc.gaff}}}}
+        lig_region: {{name: lig, regions: {{a_region: 'some string'}}, leap: {{parameters: leaprc.gaff}}}}
     solvents:
         solv: {{nonbonded_method: NoCutoff}}
         solv2: {{nonbonded_method: NoCutoff, implicit_solvent: OBC2}}
@@ -585,6 +594,7 @@ def test_validation_wrong_systems():
 
     systems = [
         {'receptor': 'rec', 'ligand': 'lig'},
+        {'receptor': 'rec_region', 'ligand': 'lig_region', 'solvent': 'solv'},
         {'receptor': 'rec', 'ligand': 1, 'solvent': 'solv'},
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': ['solv', 'solv']},
         {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'unknown'},

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -111,6 +111,7 @@ Detailed Options List
  
     * :ref:`leap <yaml_molecules_leap>`
     * :ref:`epik <yaml_molecules_epik>`
+    * :ref:`regions <yaml_molecules_regions>`
 
 * :doc:`solvents <solvents>`
 

--- a/docs/yamlpages/molecules.rst
+++ b/docs/yamlpages/molecules.rst
@@ -266,6 +266,50 @@ Filepaths are relative to either the AmberTools default paths or to the folder t
           ph_tolerance: 0.7
           tautomerize: no
 
-Run Schrodinger's tool Epik with to select the most likely protonation state for the molecule in solution. Parameters in this call are direct reflections of the function to invoke epik from OpenMolTools.
+Run Schrodinger's tool Epik with to select the most likely protonation state for the molecule in solution. Parameters
+in this call are direct reflections of the function to invoke ``epik`` from OpenMolTools.
+
+**OPTIONAL**
+
+
+.. _yaml_molecules_regions:
+
+.. rst-class:: html-toggle
+
+``regions``
+-----------
+.. code-block:: yaml
+
+   molecules:
+     {UserDefinedMolecule}:
+        regions:
+           {UserDefinedRegion}: region_string
+           ...
+
+Define molecular regions in the molecule which can be used in upcoming features such as defining restraint regions in
+more general ways, or specific atom subsets you want to track through the :class:`yank.yank.Topography` object which is
+stored as part of the simulation's metadata, accessible through :class:`yank.repex.Reporter`.
+
+Any number of user defined regions can be specified for every molecule, so long as their name is unique between all
+molecules which ultimately wind up in a :doc:`system <systems>`. E.g. If you have 2 ligands you want to bind to a
+receptor in a combinatorial setup, both ligands can have a region named "my_region" since they will never be in the
+same system together. However, the receptor cannot have a region named "my_region" as well, as that will
+be ambiguous as to which region, ligand or receptor, to define.
+
+It is possible to select regions with
+
+The regions right now apply to the **combined system**, although there are plans to have the region per molecule
+apply to only the subset molecule.
+
+The region definition supports multiple selection formats:
+
+* DSL String: An MDTraj DSL string which identifies will identify a region.
+* **Future Ability** SMARTS String: Molecular selection format similar to regular expression for strings, but for
+  molecules instead. This feature is not in yet, but is planned. The regions framework is the pre-cursor to this
+  feature. See
+  `Daylight's website for more information on SMARTS <http://www.daylight.com/dayhtml/doc/theory/theory.smarts.html>`_.
+* List of Ints: Select atoms by integers, this applies only to the final system, so numbers will probably not align
+  with the atom numbers from the input files.
+* Single Int: Same as the list of ints, but with a single entry, subject to same rules
 
 **OPTIONAL**


### PR DESCRIPTION
This PR adds arbitrary region identification to the YAML documentation in continuation of the abilities added by #793.

Regions can be defined for any `molecules` entry and as many as you would like can be defined. These regions are validated to accept ints, strings, or lists of ints, although only strings is non-ambiguous and even improvements could be made upon that as well, but the framework is here.

~Although functionally complete, this is a Work In Progress for the following reasons:~ *edit*: no longer a WIP after additions.
- [x] Error message when `check_regions_clash` raises a `YamlParseError` is absolute garbage and falls back to an incorrect error message, this is a larger problem with YamlParseError in general though 
- [x] Documentation on the `docs` pages have not been added yet. 

The one functional improvement we should make is to have each molecule's region's only apply to the subset of atoms that molecule makes up in the final Topography. I think this would require a small change to the `add_region` call of Topography + some logic in `_build_experiment`, but may not be too hard. Debate on whether we make that change here or in another PR after we merge this one since this feature set is suppose to be a series of smaller PR chunks, each adding new infrastructure an leading up to the full feature. Thoughts?
