### PR TITLE
Add in Region selected atoms to the Restraint class

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -492,27 +492,28 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         """
         Descriptor of restrained atoms.
         """
+
+        _CENTROID_COMPUTE_STRING = ("You are specifying {} {} atoms, "
+                                    "the final atoms will be chosen as the centroid of this set.")
+
         def __init__(self, atoms_type):
             self._atoms_type = atoms_type
+            self._attribute_name = '_restrained_' + self._atoms_type + '_atoms'
 
         def __get__(self, instance, owner_class=None):
-            attribute_name = self._full_atoms_type
-            return getattr(instance, attribute_name)
+            return getattr(instance, self._attribute_name)
 
         def __set__(self, instance, new_restrained_atoms):
-            attribute_name = self._full_atoms_type
 
             # If we set the restrained attributes to None, no reason to check things.
             if new_restrained_atoms is None:
-                setattr(instance, attribute_name, new_restrained_atoms)
+                setattr(instance, self._attribute_name, new_restrained_atoms)
                 return
             new_restrained_atoms = self._cast_atoms(new_restrained_atoms)
             # Make sure this is a list to support concatenation.
 
-            setattr(instance, attribute_name, new_restrained_atoms)
+            setattr(instance, self._attribute_name, new_restrained_atoms)
 
-        _centroid_compute_string = ("You are specifying {} {} atoms, "
-                                    "the final atoms will be chosen as the centroid of this set.")
 
         @methoddispatch
         def _cast_atoms(self, restrained_atoms):
@@ -521,12 +522,12 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
             except AttributeError:
                 restrained_atoms = list(restrained_atoms)
             if len(restrained_atoms) > 1:
-                logger.debug(self._centroid_compute_string.format("more than one", self._atoms_type))
+                logger.debug(self._CENTROID_COMPUTE_STRING.format("more than one", self._atoms_type))
             return restrained_atoms
 
         @_cast_atoms.register(str)
         def _cast_atom_string(self, restrained_atoms):
-            warn_string = self._centroid_compute_string.format("a string for", self._atoms_type)
+            warn_string = self._CENTROID_COMPUTE_STRING.format("a string for", self._atoms_type)
             warn_string += "but you MUST run \"determine_missing_parameters\" to process the string"
             logger.warning(warn_string)
             return restrained_atoms
@@ -534,10 +535,6 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         @_cast_atoms.register(int)
         def _cast_atom_int(self, restrained_atoms):
             return restrained_atoms
-
-        @property
-        def _full_atoms_type(self):
-            return '_restrained_' + self._atoms_type + '_atoms'
 
     restrained_receptor_atoms = _RestrainedAtomsProperty('receptor')
     restrained_ligand_atoms = _RestrainedAtomsProperty('ligand')
@@ -963,14 +960,14 @@ class Harmonic(RadiallySymmetricRestraint):
     restrained_receptor_atoms : list of int or str, optional
         The indices of the receptor atoms to restrain, an MDTraj DSL expression, or a
         :class:`Topography <yank.Topography>` region name,
-        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
+        or :func:`Topography Select String <yank.Topography.select>`.
         This can temporarily be left undefined, but ``determine_missing_parameters()``
         must be called before using the Restraint object. The same if a DSL
         expression or Topography region is provided (default is None).
     restrained_ligand_atoms : list of int or str, optional
         The indices of the ligand atoms to restrain, an MDTraj DSL expression.
         or a :class:`Topography <yank.Topography>` region name,
-        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
+        or :func:`Topography Select String <yank.Topography.select>`.
         This can temporarily be left undefined, but ``determine_missing_parameters()``
         must be called before using the Restraint object. The same if a DSL
         expression or Topography region is provided (default is None).
@@ -1116,14 +1113,14 @@ class FlatBottom(RadiallySymmetricRestraint):
     restrained_receptor_atoms : list of int or str, optional
         The indices of the receptor atoms to restrain, an MDTraj DSL expression, or a
         :class:`Topography <yank.Topography>` region name,
-        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
+        or :func:`Topography Select String <yank.Topography.select>`.
         This can temporarily be left undefined, but ``determine_missing_parameters()``
         must be called before using the Restraint object. The same if a DSL
         expression or Topography region is provided (default is None).
     restrained_ligand_atoms : list of int or str, optional
         The indices of the ligand atoms to restrain, an MDTraj DSL expression.
         or a :class:`Topography <yank.Topography>` region name,
-        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
+        or :func:`Topography Select String <yank.Topography.select>`.
         This can temporarily be left undefined, but ``determine_missing_parameters()``
         must be called before using the Restraint object. The same if a DSL
         expression or Topography region is provided (default is None).
@@ -1329,7 +1326,7 @@ class Boresch(ReceptorLigandRestraint):
     restrained_receptor_atoms : iterable of int, str, or None; Optional
         The indices of the receptor atoms to restrain, an MDTraj DSL expression, or a
         :class:`Topography <yank.Topography>` region name,
-        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
+        or :func:`Topography Select String <yank.Topography.select>`.
         If this is a list of three ints, the receptor atoms will be restrained in order, r1, r2, r3. If there are more
         than three entries or the selection string resolves more than three atoms, the three restrained atoms will
         be chosen at random from the selection.
@@ -1339,7 +1336,7 @@ class Boresch(ReceptorLigandRestraint):
     restrained_ligand_atoms : iterable of int, str, or None; Optional
         The indices of the ligand atoms to restrain, an MDTraj DSL expression, or a
         :class:`Topography <yank.Topography>` region name,
-        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
+        or :func:`Topography Select String <yank.Topography.select>`.
         If this is a list of three ints, the receptor atoms will be restrained in order, l1, l2, l3. If there are more
         than three entries or the selection string resolves more than three atoms, the three restrained atoms will
         be chosen at random from the selection.
@@ -1438,7 +1435,7 @@ class Boresch(ReceptorLigandRestraint):
         self.theta_A0, self.theta_B0 = theta_A0, theta_B0
         self.K_phiA, self.K_phiB, self.K_phiC = K_phiA, K_phiB, K_phiC
         self.phi_A0, self.phi_B0, self.phi_C0 = phi_A0, phi_B0, phi_C0
-        self._standard_state_correction_method = standard_state_correction_method
+        self.standard_state_correction_method = standard_state_correction_method
 
     # -------------------------------------------------------------------------
     # Public properties.
@@ -1451,28 +1448,27 @@ class Boresch(ReceptorLigandRestraint):
         It guarantees that the property is a list of ints to support concatenation or a string which must be computed.
 
         """
+
+        _MUST_COMPUTE_STRING = ("You are specifying {} {} atoms, "
+                                "the final atoms will be chosen at from this set but you MUST "
+                                "run \"determine_missing_parameters\"")
+
         def __init__(self, atoms_type):
             self._atoms_type = atoms_type
+            self._attribute_name = '_restrained_' + self._atoms_type + '_atoms'
 
         def __get__(self, instance, owner_class=None):
-            attribute_name = self._full_atoms_type
-            return getattr(instance, attribute_name)
+            return getattr(instance, self._attribute_name)
 
         def __set__(self, instance, new_restrained_atoms):
-            attribute_name = self._full_atoms_type
-
             # If we set the restrained attributes to None, no reason to check things.
             if new_restrained_atoms is None:
-                setattr(instance, attribute_name, new_restrained_atoms)
+                setattr(instance, self._attribute_name, new_restrained_atoms)
                 return
             new_restrained_atoms = self._cast_atoms(new_restrained_atoms)
             # Make sure this is a list to support concatenation.
 
-            setattr(instance, attribute_name, new_restrained_atoms)
-
-        _must_compute_string = ("You are specifying {} {} atoms, "
-                                "the final atoms will be chosen at from this set but you MUST "
-                                "run \"determine_missing_parameters\"")
+            setattr(instance, self._attribute_name, new_restrained_atoms)
 
         @methoddispatch
         def _cast_atoms(self, restrained_atoms):
@@ -1484,17 +1480,13 @@ class Boresch(ReceptorLigandRestraint):
                 raise ValueError('At least three {} atoms are required to impose a '
                                  'Boresch-style restraint.'.format(self._atoms_type))
             elif len(restrained_atoms) > 3:
-                logger.warning(self._must_compute_string.format("more than three", self._atoms_type))
+                logger.warning(self._MUST_COMPUTE_STRING.format("more than three", self._atoms_type))
             return restrained_atoms
 
         @_cast_atoms.register(str)
         def _cast_atom_string(self, restrained_atoms):
-            logger.warning(self._must_compute_string.format("a string for", self._atoms_type))
+            logger.warning(self._MUST_COMPUTE_STRING.format("a string for", self._atoms_type))
             return restrained_atoms
-
-        @property
-        def _full_atoms_type(self):
-            return '_restrained_' + self._atoms_type + '_atoms'
 
     restrained_receptor_atoms = _RestrainedAtomsProperty('receptor')
     restrained_ligand_atoms = _RestrainedAtomsProperty('ligand')

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -444,23 +444,28 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
     Parameters
     ----------
     restrained_receptor_atoms : list of int or str, optional
-        The indices of the receptor atoms to restrain, or an MDTraj DSL expression.
+        The indices of the receptor atoms to restrain, an MDTraj DSL expression, a
+        :class:`Topography <yank.Topography>` region name,
+        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
         This can temporarily be left undefined, but :func:`determine_missing_parameters`
         must be called before using the Restraint object. The same if a DSL
-        expression is provided without passing the topology (default is None).
+        expression or Topography region is provided (default is None).
     restrained_ligand_atoms : list of int or str, optional
-        The indices of the ligand atoms to restrain, or an MDTraj DSL expression.
+        The indices of the ligand atoms to restrain, an MDTraj DSL expression, or a
+        :class:`Topography <yank.Topography>`  region name,
+        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
         This can temporarily be left undefined, but :func:`determine_missing_parameters`
         must be called before using the Restraint object. The same if a DSL
-        expression is provided without passing the topology (default is None).
+        expression or Topography region is provided (default is None).
 
     Attributes
     ----------
-    restrained_receptor_atoms : list of int or None
-        The indices of the receptor atoms to restrain.
-    restrained_ligand_atoms : list of int or None
-        The indieces of the ligand atoms to restrain.
-    topology : mdtraj.Topology
+    restrained_receptor_atoms : list of int, str, or None
+        The indices of the receptor atoms to restrain, an MDTraj selection string, or a Topography region selection
+        string.
+    restrained_ligand_atoms : list of int, str, None
+        The indices of the receptor atoms to restrain, an MDTraj selection string, or a Topography region selection
+        string.
 
     Notes
     -----
@@ -486,9 +491,6 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
     class _RestrainedAtomsProperty(object):
         """
         Descriptor of restrained atoms.
-
-        Evaluate DSL atoms selections at runtime to allow partially specified restraints.
-
         """
         def __init__(self, atoms_type):
             self._atoms_type = atoms_type
@@ -728,7 +730,7 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         sampler_state : openmmtools.states.SamplerState
             The sampler state holding the positions of all atoms.
         topography : yank.Topography
-            The topography with labeled receptor and ligand atoms.
+            The topography with labeled receptor, ligand atoms, and any regions defined.
 
         """
         # Raise exception only if the subclass doesn't already defines parameters.
@@ -761,7 +763,7 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         sampler_state : openmmtools.states.SamplerState, optional
             The sampler state holding the positions of all atoms.
         topography : yank.Topography, optional
-            The topography with labeled receptor and ligand atoms.
+            The topography with labeled receptor, ligand atoms, and any regions defined.
 
         """
         debug_msg = ('Restraint {}: Automatically picked restrained '
@@ -781,7 +783,7 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         @functools.singledispatch
         def compute_atom_set(input_atoms, topography_key, mapping_function):
             """
-            Helper function for doing set operations on heavy ligand atoms of all other types
+            Helper function for doing set operations on generic atom types.
             mapping_function not used in the generic catch-all, but is used in the None register
             """
             # Ensure the input atoms are only part of the topography_key atoms. Make no changes if they are
@@ -978,7 +980,7 @@ class Harmonic(RadiallySymmetricRestraint):
     can be used to control the strength of the restraint. You can control
     ``lambda_restraints`` through :class:`RestraintState` class.
 
-    The class supports automatic determination of the parameters left undefined
+    The class supports automatic determination of the parameters left undefined or defined by strings
     in the constructor through :func:`determine_missing_parameters`.
 
     With OpenCL, groups with more than 1 atom are supported only on 64bit
@@ -990,26 +992,28 @@ class Harmonic(RadiallySymmetricRestraint):
         The spring constant K (see energy expression above) in units compatible
         with joule/nanometer**2/mole (default is None).
     restrained_receptor_atoms : list of int or str, optional
-        The indices of the receptor atoms to restrain, or an MDTraj DSL expression.
+        The indices of the receptor atoms to restrain, an MDTraj DSL expression, or a
+        :class:`Topography <yank.Topography>` region name,
+        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
         This can temporarily be left undefined, but ``determine_missing_parameters()``
         must be called before using the Restraint object. The same if a DSL
-        expression is provided without passing the topology (default is None).
+        expression or Topography region is provided (default is None).
     restrained_ligand_atoms : list of int or str, optional
-        The indices of the ligand atoms to restrain, or an MDTraj DSL expression.
+        The indices of the ligand atoms to restrain, an MDTraj DSL expression.
+        or a :class:`Topography <yank.Topography>` region name,
+        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
         This can temporarily be left undefined, but ``determine_missing_parameters()``
         must be called before using the Restraint object. The same if a DSL
-        expression is provided without passing the topology (default is None).
-    topology : simtk.openmm.app.Topology or mdtraj.Topology, optional
-        The topology used to resolve the DSL string. If not provided, the atom
-        selection expressions will be resolved by ``determine_missing_parameters()``.
+        expression or Topography region is provided (default is None).
 
     Attributes
     ----------
-    restrained_receptor_atoms : list of int or None
-        The indices of the receptor atoms to restrain.
-    restrained_ligand_atoms : list of int or None
-        The indieces of the ligand atoms to restrain.
-    topology : mdtraj.Topology
+    restrained_receptor_atoms : list of int, str, or None
+        The indices of the receptor atoms to restrain, an MDTraj selection string, or a Topography region selection
+        string.
+    restrained_ligand_atoms : list of int, str, or None
+        The indices of the ligand atoms to restrain, an MDTraj selection string, or a Topography region selection
+        string.
 
     Examples
     --------
@@ -1141,26 +1145,28 @@ class FlatBottom(RadiallySymmetricRestraint):
         The distance r0 (see energy expression above) at which the harmonic
         restraint is imposed in units of distance (default is None).
     restrained_receptor_atoms : list of int or str, optional
-        The indices of the receptor atoms to restrain, or an MDTraj DSL expression.
+        The indices of the receptor atoms to restrain, an MDTraj DSL expression, or a
+        :class:`Topography <yank.Topography>` region name,
+        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
         This can temporarily be left undefined, but ``determine_missing_parameters()``
         must be called before using the Restraint object. The same if a DSL
-        expression is provided without passing the topology (default is None).
+        expression or Topography region is provided (default is None).
     restrained_ligand_atoms : list of int or str, optional
-        The indices of the ligand atoms to restrain, or an MDTraj DSL expression.
+        The indices of the ligand atoms to restrain, an MDTraj DSL expression.
+        or a :class:`Topography <yank.Topography>` region name,
+        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
         This can temporarily be left undefined, but ``determine_missing_parameters()``
         must be called before using the Restraint object. The same if a DSL
-        expression is provided without passing the topology (default is None).
-    topology : simtk.openmm.app.Topology or mdtraj.Topology, optional
-        The topology used to resolve the DSL string. If not provided, the atom
-        selection expressions will be resolved by ``determine_missing_parameters()``.
+        expression or Topography region is provided (default is None).
 
     Attributes
     ----------
     restrained_receptor_atoms : list of int or None
-        The indices of the receptor atoms to restrain.
+        The indices of the receptor atoms to restrain, an MDTraj selection string, or a Topography region selection
+        string.
     restrained_ligand_atoms : list of int or None
-        The indieces of the ligand atoms to restrain.
-    topology : mdtraj.Topology
+        The indices of the ligand atoms to restrain, an MDTraj selection string, or a Topography region selection
+        string.
 
     Examples
     --------
@@ -1347,14 +1353,30 @@ class Boresch(ReceptorLigandRestraint):
     *Warning*: Symmetry corrections for symmetric ligands are not automatically applied.
     See Ref [1] and [2] for more information on correcting for ligand symmetry.
 
+    *Warning*: Only heavy atoms can be restrained. Hydrogens will automatically be excluded.
+
     Parameters
     ----------
-    restrained_receptor_atoms : iterable of int, optional
-        The indices of the receptor atoms to restrain, in order r1, r2, r3.
-        If there are more than 3 entires, they will be randomly selected
-    restrained_ligand_atoms : iterable of int, optional
-        The indices of the ligand atoms to restrain, in order l1, l2, l3.
-        If there are more than 3 entires, they will be randomly selected
+    restrained_receptor_atoms : iterable of int, str, or None; Optional
+        The indices of the receptor atoms to restrain, an MDTraj DSL expression, or a
+        :class:`Topography <yank.Topography>` region name,
+        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
+        If this is a list of three ints, the receptor atoms will be restrained in order, r1, r2, r3. If there are more
+        than three entries or the selection string resolves more than three atoms, the three restrained atoms will
+        be chosen at random from the selection.
+        This can temporarily be left undefined, but ``determine_missing_parameters()``
+        must be called before using the Restraint object. The same if a DSL
+        expression or Topography region is provided (default is None).
+    restrained_ligand_atoms : iterable of int, str, or None; Optional
+        The indices of the ligand atoms to restrain, an MDTraj DSL expression, or a
+        :class:`Topography <yank.Topography>` region name,
+        or :func:`Topography Region Set <yank.Topography.get_region_set>`.
+        If this is a list of three ints, the receptor atoms will be restrained in order, l1, l2, l3. If there are more
+        than three entries or the selection string resolves more than three atoms, the three restrained atoms will
+        be chosen at random from the selection.
+        This can temporarily be left undefined, but ``determine_missing_parameters()``
+        must be called before using the Restraint object. The same if a DSL
+        expression or Topography region is provided (default is None).
     K_r : simtk.unit.Quantity, optional
         The spring constant for the restrained distance ``|r3 - l1|`` (units
         compatible with kilocalories_per_mole/angstrom**2).
@@ -1383,7 +1405,6 @@ class Boresch(ReceptorLigandRestraint):
         The indices of the 3 receptor atoms to restrain [r1, r2, r3].
     restrained_ligand_atoms : list of int
         The indices of the 3 ligand atoms to restrain [l1, l2, l3].
-    restrained_atoms
     standard_state_correction_method
 
     References
@@ -1829,8 +1850,8 @@ class Boresch(ReceptorLigandRestraint):
         """
         result = False
         for i in range(len(atoms)-2):
-            v1 = positions[atoms[i+1],:] - positions[atoms[i],:]
-            v2 = positions[atoms[i+2],:] - positions[atoms[i+1],:]
+            v1 = positions[atoms[i+1], :] - positions[atoms[i], :]
+            v2 = positions[atoms[i+2], :] - positions[atoms[i+1], :]
             normalized_inner_product = np.dot(v1, v2) / np.sqrt(np.dot(v1, v1) * np.dot(v2, v2))
             result = result or (normalized_inner_product > threshold)
 

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -264,14 +264,14 @@ def test_restraint_dsl_selection():
     thermodynamic_state = states.ThermodynamicState(test_system.system,
                                                     temperature=300.0*unit.kelvin)
 
-    # Iniialize with DSL and without topology raises an error.
+    # Iniialize with DSL and without processing the string raises an error.
     restraint = yank.restraints.Harmonic(spring_constant=2.0*unit.kilojoule_per_mole/unit.nanometer**2,
                                          restrained_receptor_atoms="(resname CUC) and (name =~ 'O[0-9]+')",
                                          restrained_ligand_atoms='resname B2')
     with nose.tools.assert_raises(yank.restraints.RestraintParameterError):
             restraint.restrain_state(thermodynamic_state)
 
-    # After oarameter determination, the indices of the restrained atoms are correct.
+    # After parameter determination, the indices of the restrained atoms are correct.
     restraint.determine_missing_parameters(thermodynamic_state, sampler_state, topography)
     assert len(restraint.restrained_receptor_atoms) == 14
     assert len(restraint.restrained_ligand_atoms) == 30

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -102,22 +102,22 @@ def test_topography_region_ordering():
     region_set = topography.select('region_A and region_B', as_set=True)
     assert region_set == set(region_A) & set(region_B)
     # Test ordered sorting
-    region_A_and_B_ordered = topography.select('region_A and region_B', sort_by='ordered')
-    region_B_and_A_ordered = topography.select('region_B and region_A', sort_by='ordered')
+    region_A_and_B_ordered = topography.select('region_A and region_B', sort_by='index')
+    region_B_and_A_ordered = topography.select('region_B and region_A', sort_by='index')
     assert region_A_and_B_ordered == [2, 3]
     assert region_A_and_B_ordered == region_B_and_A_ordered
     # Test by region
-    region_A_and_B_inferred = topography.select('region_A and region_B', sort_by='inferred_by_region')
-    region_B_and_A_inferred = topography.select('region_B and region_A', sort_by='inferred_by_region')
+    region_A_and_B_inferred = topography.select('region_A and region_B', sort_by='region_order')
+    region_B_and_A_inferred = topography.select('region_B and region_A', sort_by='region_order')
     assert region_A_and_B_inferred == [2, 3]
     assert region_B_and_A_inferred == [3, 2]
     # Test the or sorting
-    region_A_or_B_ordered = topography.select('region_A or region_B', sort_by='ordered')
-    region_B_or_A_ordered = topography.select('region_B or region_A', sort_by='ordered')
+    region_A_or_B_ordered = topography.select('region_A or region_B', sort_by='index')
+    region_B_or_A_ordered = topography.select('region_B or region_A', sort_by='index')
     assert region_A_or_B_ordered == sorted(list(set(region_A) | set(region_B)))
     assert region_A_or_B_ordered == region_B_or_A_ordered
-    region_A_or_B_inferred = topography.select('region_A or region_B', sort_by='inferred_by_region')
-    region_B_or_A_inferred = topography.select('region_B or region_A', sort_by='inferred_by_region')
+    region_A_or_B_inferred = topography.select('region_A or region_B', sort_by='region_order')
+    region_B_or_A_inferred = topography.select('region_B or region_A', sort_by='region_order')
     assert region_A_or_B_inferred == region_A + [i for i in region_B if i not in region_A]
     assert region_B_or_A_inferred == region_B + [i for i in region_A if i not in region_B]
 

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -91,6 +91,37 @@ def test_topography_regions():
     assert 'failure' not in topography
 
 
+def test_topography_region_ordering():
+    """Test that the region sorting algorithm is working as intended"""
+    toluene_vacuum = testsystems.TolueneVacuum()
+    topography = Topography(toluene_vacuum.topology)
+    region_A = [2, 3, 1, 0]
+    region_B = [3, 2, 4, 5]
+    topography.add_region('region_A', region_A)
+    topography.add_region('region_B', region_B)
+    region_set = topography.select('region_A and region_B', as_set=True)
+    assert region_set == set(region_A) & set(region_B)
+    # Test ordered sorting
+    region_A_and_B_ordered = topography.select('region_A and region_B', sort_by='ordered')
+    region_B_and_A_ordered = topography.select('region_B and region_A', sort_by='ordered')
+    assert region_A_and_B_ordered == [2, 3]
+    assert region_A_and_B_ordered == region_B_and_A_ordered
+    # Test by region
+    region_A_and_B_inferred = topography.select('region_A and region_B', sort_by='inferred_by_region')
+    region_B_and_A_inferred = topography.select('region_B and region_A', sort_by='inferred_by_region')
+    assert region_A_and_B_inferred == [2, 3]
+    assert region_B_and_A_inferred == [3, 2]
+    # Test the or sorting
+    region_A_or_B_ordered = topography.select('region_A or region_B', sort_by='ordered')
+    region_B_or_A_ordered = topography.select('region_B or region_A', sort_by='ordered')
+    assert region_A_or_B_ordered == sorted(list(set(region_A) | set(region_B)))
+    assert region_A_or_B_ordered == region_B_or_A_ordered
+    region_A_or_B_inferred = topography.select('region_A or region_B', sort_by='inferred_by_region')
+    region_B_or_A_inferred = topography.select('region_B or region_A', sort_by='inferred_by_region')
+    assert region_A_or_B_inferred == region_A + [i for i in region_B if i not in region_A]
+    assert region_B_or_A_inferred == region_B + [i for i in region_A if i not in region_B]
+
+
 def test_topography_serialization():
     """Correct serialization of Topography objects."""
     test_system = testsystems.AlanineDipeptideImplicit()

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -252,7 +252,7 @@ def _with_profile(output_file='profile.log'):
 
 
 # =======================================================================================
-# Methoddispatch wrapping to better handle cyclomatic complexity with input types
+# Method dispatch wrapping to better handle cyclomatic complexity with input types
 # Relies on functools.singledispatch (Python 3.5+ only)
 # https://stackoverflow.com/questions/24601722/how-can-i-use-functools-singledispatch-with-instance-methods/24602374#24602374
 # And the comment to use update_wrapper(wrapper, dispatcher) instead

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -552,6 +552,7 @@ class Topography(object):
         parsed_output = mmtools.utils.math_eval(region_set_string, variables=variables)
         return parsed_output
 
+
 # ==============================================================================
 # Class that define a single thermodynamic leg (phase) of the calculation
 # ==============================================================================

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -351,7 +351,7 @@ class Topography(object):
             # TODO: Handle SMIRKS in the future
             pass
         raise ValueError("Either your atoms_description was messed up or you don't have OpenEye OEChem installed! "
-                         "String based atom description could not be processed")
+                         "String based atom description {} could not be processed".format(atoms_description))
 
 # ==============================================================================
 # Class that define a single thermodynamic leg (phase) of the calculation

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -250,7 +250,7 @@ class Topography(object):
         # Return a copy to ensure people cant tweak the region outside of the api
         return copy.copy(self._regions[region_name])
 
-    def select(self, selection, as_set=False, sort_by='auto') -> Union[List[int, ...], Set[int, ...]]:
+    def select(self, selection, as_set=False, sort_by='auto') -> Union[List[int], Set[int]]:
         """
         Select atoms based on selection format which can be a number of formats:
 
@@ -344,12 +344,12 @@ class Topography(object):
 
             @classmethod
             @abc.abstractmethod
-            def select(cls, selection_input) -> Union[Tuple[List[int, ...], None], Tuple[None, Exception]]:
+            def select(cls, selection_input) -> Union[Tuple[List[int], None], Tuple[None, Exception]]:
                 """Implement this to convert select_string to the output, returning both the output, and the error"""
                 return [0], None
 
             @classmethod
-            def sort_selection(cls, selected_atoms) -> Union[List[int, ...], Set[int, ...]]:
+            def sort_selection(cls, selected_atoms) -> Union[List[int], Set[int]]:
                 if as_set:
                     return set(selected_atoms)
                 elif sort_by in cls.SORT_PRIORITY:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - netcdf4
     - openmm >=7.1
     - mdtraj >=1.7.2
-    - openmmtools >=0.13.1
+    - openmmtools >=0.13.2
     - pymbar
     - ambermini >=16.16.0
     - docopt
@@ -41,7 +41,7 @@ requirements:
     - netcdf4
     - openmm >=7.1
     - mdtraj >=1.7.2
-    - openmmtools >=0.13.1
+    - openmmtools >=0.13.2
     - pymbar
     - ambermini >=16.16.0
     - docopt

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -12,6 +12,7 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 - Custom regions can now be defined through YAML
 - Compound custom Topography regions can now be selected
 - Restraints atom selection can now use Topography Regions
+- Topography now can select from arbitrary string, either complex regions, DSL strings, and in the future SMARTS strings
 
 0.18.0 Python 2 Dropped, Solute Only Trajectories, and Trailblaze Bugfixes
 --------------------------------------------------------------------------

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,13 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.19.0 In Development (Current)
+-------------------------------
+- Added custom region selection to Topography
+- Custom regions can now be defined through YAML
+- Compound custom Topography regions can now be selected
+- Restraints atom selection can now use Topography Regions
+
 0.18.0 Python 2 Dropped, Solute Only Trajectories, and Trailblaze Bugfixes
 --------------------------------------------------------------------------
 - Python 2.X Support officially *removed*

--- a/docs/yamlpages/experiments.rst
+++ b/docs/yamlpages/experiments.rst
@@ -49,6 +49,11 @@ are accepted as arguments in the YAML file:
 The ``options`` directive lets you overwrite :doc:`any global setting <options>` specified in the header ``options`` for
 this specific experiment.
 
+One option is to select restrained atoms through :class:`Topgraphical Regions <yank.Topography>` defined as part of your
+:ref:`molecule's regions <yaml_molecules_regions>`. You can also select atoms through a
+:func:`compound region <yank.Topography.get_region_set>` where regions are combined through set operators
+``and``/``or``.
+
 **Note:** The Boresch restraints require that the ligand and receptor are close to eachother to make sure the standard
 state correction computation is stable. We recommend only using the ``Boresch`` options if you know the binding mode of
 your system already!

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.18.1"  # Primary base version of the build
+VERSION = "0.19.0"  # Primary base version of the build
 DEVBUILD = "0"  # Dev build status, Either None or Integer as string
 ISRELEASED = False  # Are we releasing this as a full cut?
 __version__ = VERSION
@@ -146,7 +146,7 @@ setup(
         'cython',
         'openmm>=7.1',
         'pymbar',
-        'openmmtools>=0.13.1',
+        'openmmtools>=0.13.2',
         'docopt>=0.6.1',
         'netcdf4',
         'schema',


### PR DESCRIPTION
This PR adds a number of changes to the restraint functionality as continuation of #793 and #794

This PR adds the ability for Restraint classes to accept Topography Region-based logic as part of the selection string, as well MDTraj strings. This also extends the Topography to handle complex region selection through the `and` and `or` operators.

Main logical question: Should we *remove* the ability for DSL strings to be passed as direct atom selections in Restraints and force it to use Topography Regions? That would clean up the code, but then offload the DSL processing exclusively to Topology and remove the functionality from restraints as a standalone.

There is a break to the `RadiallySymetricRestraint` class API which went unused for the most part, but still a break so version updated to 0.19.0.

~This is a WIP for the following reasons, although the functionality changes should all be in now, allowing discussion and review~ No longer a WIP as all items have been checked off.
* [x] OpenMMTools 0.13.2 is required (not released)  due to extended `math_eval`, tests will not run until thats released
 * [x] I'm considering extending the Schema validation for restraints to ensure Regions are previously defined, but that will be hard considering that the current Schema accepts any input so arbitrary parameters can be passed. Not sure how to check
 * [x] The tests should be extended to test the Region selection code
 * [x] The logic should be reviewed to ensure I am not missing corner cases
 * [x] The Restraints doc-strings need updated
 * [x] The website docs need the "whats new" updated

 Next on the list is how do we parse SMILES strings