### PR TITLE
MPI exception handling

### DIFF
--- a/Yank/mpi.py
+++ b/Yank/mpi.py
@@ -111,14 +111,17 @@ def get_mpicomm():
     from mpi4py import MPI
     mpicomm = MPI.COMM_WORLD
 
-    # Override sys.excepthook to abort MPI on exception
+    # Override sys.excepthook to abort MPI on exception.
     def mpi_excepthook(type, value, traceback):
         sys.__excepthook__(type, value, traceback)
+        node_name = '{}/{}'.format(MPI.COMM_WORLD.rank+1, MPI.COMM_WORLD.size)
+        logger.exception('MPI node {} raised exception.'.format(node_name))
+        logger.critical('MPI node {} called Abort()!'.format(node_name))
         sys.stdout.flush()
         sys.stderr.flush()
-        if mpicomm.size > 1:
-            mpicomm.Abort(1)
-    # Use our eception handler
+        if MPI.COMM_WORLD.size > 1:
+            MPI.COMM_WORLD.Abort(1)
+    # Use our exception handler.
     sys.excepthook = mpi_excepthook
 
     # Catch sigterm signals

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1067,7 +1067,7 @@ class SetupDatabase:
         # Parallelize generation of all molecules among nodes.
         mpi.distribute(self._setup_molecules,
                        distributed_args=molecules_to_setup,
-                       group_nodes=1, sync_nodes=True)
+                       send_results_to=None, group_size=1, sync_nodes=True)
 
         # Find all systems that need to be set up.
         systems_to_setup = []
@@ -1078,7 +1078,7 @@ class SetupDatabase:
         # Parallelize generation of all systems among nodes.
         mpi.distribute(self.get_system,
                        distributed_args=systems_to_setup,
-                       group_nodes=1, sync_nodes=True)
+                       send_results_to=None, group_size=1, sync_nodes=True)
 
     def _generate_molecule(self, molecule_id):
         """Generate molecule using the OpenEye toolkit from name or smiles.

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -2323,7 +2323,7 @@ def test_automatic_alchemical_path():
 
 
 def test_experiment_nan():
-    """Test that when an experiment NaN's, it returns a formal error when things go wrong"""
+    """Test that eventual NaN's are handled and that experiment is signal as completed."""
     with mmtools.utils.temporary_directory() as tmp_dir:
         yaml_script = get_functionality_script(output_directory=tmp_dir, experiment_repeats=0, number_nan_repeats=1)
         exp_builder = ExperimentBuilder(script=yaml_script)
@@ -2332,8 +2332,8 @@ def test_experiment_nan():
             exp_builder._setup_experiments()
             exp_builder._generate_experiments_protocols()
             for experiment in exp_builder._expand_experiments():
-                output = exp_builder._run_experiment(experiment)
-                assert isinstance(output, utils.SimulationNaNError)
+                is_completed = exp_builder._run_experiment(experiment)
+                assert is_completed
 
 
 def test_multi_experiment_nan():


### PR DESCRIPTION
Fix #798 : NaN handling fails with MPI.

This adds exception handling support in the `mpi.py` module. Briefly, if a node's task raises an exception, it gets propagated the other nodes according to the `propagate_exceptions_to` argument that can assume the values `'all'`, `'group'` or `None`.

I've also added the `_MpiProcessingUnit` context manager. This will probably be the first step toward a more object-oriented API that separates the computational resources from the task execution.