### PR TITLE
Copy the latest release docs to `latest`

### DIFF
--- a/devtools/travis-ci/set_doc_version.py
+++ b/devtools/travis-ci/set_doc_version.py
@@ -17,12 +17,12 @@ shutil.copytree("docs/_build", "docs/_deploy/{docversion}"
 
 # Only update latest if we are on a release version
 if version.release:
-    # Update the "latest" index file
-    base_index_string = """<html><head><meta http-equiv="refresh" content="0;URL='/{WHEREISLATEST}'"/></head></html>"""
-    index_html = base_index_string.format(WHEREISLATEST=docversion)
+    # Create the directory
     try:
         os.mkdir("docs/_deploy/latest")
     except:
+        # Directory exists, no need to make it
         pass
-    with open("docs/_deploy/latest/index.html", 'w') as index_file:
-        index_file.write(index_html)
+    # Copy the most recent version to the latest build
+    shutil.copytree("docs/_build", "docs/_deploy/latest"
+                    .format(docversion=docversion))

--- a/devtools/travis-ci/update_versions_json.py
+++ b/devtools/travis-ci/update_versions_json.py
@@ -1,10 +1,6 @@
 import json
 
-try:
-    # Only works in Python 3
-    from urllib.request import urlopen
-except ImportError:
-    from urllib2 import urlopen
+from urllib.request import urlopen
 from yank import version
 
 if not version.release:


### PR DESCRIPTION
This copies stable releases to an additional doc folder called `latest` so links at `getyank.org/latest/...` resolve correctly.

Previous attempts which only used an HTML pointer to the correct URL only worked for `...org/latest` and did not pass additional page info. S3 does not support such a feature (e.g. HTTP_REDIRECT) and making it do so would have emulated a man-in-the-middle attack, so I abandoned that path. (See #601 for the implementation of this)

This fix has the problem in that Travis' deploy will only *add* files to the S3 bucket, and not remove the files if they don't exist. So removing/renaming pages will stick around. We would only want this for the `latest` folder so even if they [do enable a full `--sync`](https://github.com/travis-ci/dpl/issues/661) flag, we will have to be careful as to not delete old versions of the site.

I had considered using a [Travis Deploy `before_deploy`](https://docs.travis-ci.com/user/deployment/s3/#Running-commands-before-and-after-release) flag to execute an S3 command to empty out the `latest` folder on the bucket before deploy. But that will require some tests using `--dry-run` flags locally before I feel safe implementing this. @jchodera, we can talk about using the `s3cmd` in person for testing this since it involves the AWS keys which should not be shared here.

 For now though, this PR would need to happen regardless of file-cleanup.

 Fixes #810