### PR TITLE
Bugfix and add replica state index statistical inefficiency to analysis

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -785,8 +785,8 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
             )
 
         # Print information about replica state index statistical efficiency.
-        logger.info('Replica state index statistical efficiency is '
-                    '{:.3f}'.format(mixing_statistics.statistical_efficiency))
+        logger.info('Replica state index statistical inefficiency is '
+                    '{:.3f}'.format(mixing_statistics.statistical_inefficiency))
 
     def get_states_energies(self):
         """

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -1614,10 +1614,11 @@ def extract_trajectory(nc_path, nc_checkpoint_file=None, state_index=None, repli
                 n_equil_frames = n_equil_iterations
             frame_indices = frame_indices[n_equil_frames:-1]
 
-        # Extract state positions and box vectors
-        positions = np.zeros((len(frame_indices), n_atoms, 3))
+        # Extract state positions and box vectors.
+        # MDTraj Cython code expects float32 positions.
+        positions = np.zeros((len(frame_indices), n_atoms, 3), dtype=np.float32)
         if is_periodic:
-            box_vectors = np.zeros((len(frame_indices), 3, 3))
+            box_vectors = np.zeros((len(frame_indices), 3, 3), dtype=np.float32)
         if state_index is not None:
             logger.info('Extracting positions of state {}...'.format(state_index))
 

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -1408,20 +1408,20 @@ def analyze_directory(source_directory):
             calculation_type = ' of solvation'
 
     # Print energies
-    logger.info("")
-    logger.info("Free energy{}: {:16.3f} +- {:.3f} kT ({:16.3f} +- {:.3f} kcal/mol)".format(
+    logger.info('')
+    logger.info('Free energy{:<13}: {:9.3f} +- {:.3f} kT ({:.3f} +- {:.3f} kcal/mol)'.format(
         calculation_type, DeltaF, dDeltaF, DeltaF * kT / units.kilocalories_per_mole,
         dDeltaF * kT / units.kilocalories_per_mole))
-    logger.info("")
+    logger.info('')
 
     for phase in phase_names:
-        logger.info("DeltaG {:<25} : {:16.3f} +- {:.3f} kT".format(phase, data[phase]['DeltaF'],
-                                                                   data[phase]['dDeltaF']))
+        logger.info('DeltaG {:<17}: {:9.3f} +- {:.3f} kT'.format(phase, data[phase]['DeltaF'],
+                                                                 data[phase]['dDeltaF']))
         if data[phase]['DeltaF_standard_state_correction'] != 0.0:
-            logger.info("DeltaG {:<25} : {:25.3f} kT".format('restraint',
-                                                             data[phase]['DeltaF_standard_state_correction']))
-    logger.info("")
-    logger.info("Enthalpy{}: {:16.3f} +- {:.3f} kT ({:16.3f} +- {:.3f} kcal/mol)".format(
+            logger.info('DeltaG {:<17}: {:18.3f} kT'.format('restraint',
+                                                            data[phase]['DeltaF_standard_state_correction']))
+    logger.info('')
+    logger.info('Enthalpy{:<16}: {:9.3f} +- {:.3f} kT ({:.3f} +- {:.3f} kcal/mol)'.format(
         calculation_type, DeltaH, dDeltaH, DeltaH * kT / units.kilocalories_per_mole,
         dDeltaH * kT / units.kilocalories_per_mole))
 

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -21,10 +21,11 @@ Fully extensible to support new samplers and observables.
 # =============================================================================================
 
 import os
-import os.path
-
 import abc
 import copy
+import typing
+from typing import Union
+
 import yaml
 import numpy as np
 
@@ -666,25 +667,36 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
 
     """
 
-    def generate_mixing_statistics(self, number_equilibrated=None):
+    # TODO use class syntax and add docstring after dropping python 3.5 support.
+    _MixingStatistics = typing.NamedTuple('MixingStatistics', [
+        ('transition_matrix', np.ndarray),
+        ('eigenvalues', np.ndarray),
+        ('statistical_inefficiency', np.ndarray)
+    ])
+
+    def generate_mixing_statistics(self, number_equilibrated: Union[int, None] = None) -> typing.NamedTuple:
         """
-        Generate the Transition state matrix and sorted eigenvalues
+        Compute and return replica mixing statistics.
+
+        Compute the transition state matrix, its eigenvalues sorted from
+        greatest to least, and the state index correlation function.
 
         Parameters
         ----------
         number_equilibrated : int, optional, default=None
-           If specified, only samples number_equilibrated:end will be used in analysis
-           If not specified, automatically retrieves the number from equilibration data or generates it from the
-           internal energy.
+            If specified, only samples ``number_equilibrated:end`` will
+            be used in analysis. If not specified, automatically retrieves
+            the number from equilibration data or generates it from the
+            internal energy.
 
         Returns
         -------
-        mixing_stats : np.array of shape [nstates, nstates]
-            Transition matrix estimate
-        mu : np.array
-            Eigenvalues of the Transition matrix sorted in descending order
+        mixing_statistics : namedtuple
+            A namedtuple containing the following attributes:
+            - ``transition_matrix``: (nstates by nstates ``np.array``)
+            - ``eigenvalues``: (nstates-dimensional ``np.array``)
+            - ``statistical_inefficiency``: float
         """
-
         # Read data from disk
         if number_equilibrated is None:
             if self._equilibration_data is None:
@@ -717,7 +729,14 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
         mu = np.linalg.eigvals(t_ij)
         mu = -np.sort(-mu)  # Sort in descending order
 
-        return t_ij, mu
+        # Compute state index statistical inefficiency of stationary data.
+        # states[n][k] is the state index of replica k at iteration n, but
+        # the functions wants a list of timeseries states[k][n].
+        states_kn = np.transpose(states[number_equilibrated:])
+        g = timeseries.statisticalInefficiencyMultiple(states_kn)
+
+        return self._MixingStatistics(transition_matrix=t_ij, eigenvalues=mu,
+                                      statistical_inefficiency=g)
 
     def show_mixing_statistics(self, cutoff=0.05, number_equilibrated=None):
         """
@@ -734,10 +753,10 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
 
         """
 
-        Tij, mu = self.generate_mixing_statistics(number_equilibrated=number_equilibrated)
+        mixing_statistics = self.generate_mixing_statistics(number_equilibrated=number_equilibrated)
 
         # Print observed transition probabilities.
-        nstates = Tij.shape[1]
+        nstates = mixing_statistics.transition_matrix.shape[1]
         logger.info("Cumulative symmetrized state mixing transition matrix:")
         str_row = "{:6s}".format("")
         for jstate in range(nstates):
@@ -748,7 +767,7 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
             str_row = ""
             str_row += "{:-6d}".format(istate)
             for jstate in range(nstates):
-                P = Tij[istate, jstate]
+                P = mixing_statistics.transition_matrix[istate, jstate]
                 if P >= cutoff:
                     str_row += "{:6.3f}".format(P)
                 else:
@@ -756,12 +775,18 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
             logger.info(str_row)
 
         # Estimate second eigenvalue and equilibration time.
-        if mu[1] >= 1:
-            logger.info("Perron eigenvalue is unity; Markov chain is decomposable.")
+        perron_eigenvalue = mixing_statistics.eigenvalues[1]
+        if perron_eigenvalue >= 1:
+            logger.info('Perron eigenvalue is unity; Markov chain is decomposable.')
         else:
-            logger.info("Perron eigenvalue is {0:9.5f}; state equilibration timescale is ~ {1:.1f} iterations".format(
-                mu[1], 1.0 / (1.0 - mu[1]))
+            equilibration_timescale = 1.0 / (1.0 - perron_eigenvalue)
+            logger.info('Perron eigenvalue is {0:.5f}; state equilibration timescale '
+                        'is ~ {1:.1f} iterations'.format(perron_eigenvalue, equilibration_timescale)
             )
+
+        # Print information about replica state index statistical efficiency.
+        logger.info('Replica state index statistical efficiency is '
+                    '{:.3f}'.format(mixing_statistics.statistical_efficiency))
 
     def get_states_energies(self):
         """

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1819,10 +1819,10 @@ class ExperimentBuilder(object):
 
         """
         # Create setup directory if it doesn't exist.
-        os.makedirs(self.setup_dir, exist_ok=True)
+        os.makedirs(self._db.setup_dir, exist_ok=True)
 
         # Configure log file for setup.
-        setup_log_file_path = os.path.join(self.setup_dir, 'setup.log')
+        setup_log_file_path = os.path.join(self._db.setup_dir, 'setup.log')
         utils.config_root_logger(self._options['verbose'], setup_log_file_path)
 
         # Setup all systems.

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1435,7 +1435,7 @@ class SetupDatabase:
         # ------------------------------------
         tleap.new_section('Load molecules')
         for mol_id in molecule_ids:
-            tleap.load_unit(name=mol_id, file_path=self.molecules[mol_id]['filepath'])
+            tleap.load_unit(unit_name=mol_id, file_path=self.molecules[mol_id]['filepath'])
 
         if len(molecule_ids) > 1:
             # Check that molecules don't have clashing atoms. Also, if the ligand
@@ -1489,7 +1489,7 @@ class SetupDatabase:
             solvent_model = solvent['solvent_model']
             leap_solvent_model = _OPENMM_LEAP_SOLVENT_MODELS_MAP[solvent_model]
             clearance = float(solvent['clearance'].value_in_unit(unit.angstroms))
-            tleap.solvate(leap_unit=unit_to_solvate, solvent_model=leap_solvent_model, clearance=clearance)
+            tleap.solvate(unit_name=unit_to_solvate, solvent_model=leap_solvent_model, clearance=clearance)
 
             # First, determine how many ions we need to add for the ionic strength.
             if not ignore_ionic_strength and solvent['ionic_strength'] != 0.0*unit.molar:
@@ -1523,24 +1523,24 @@ class SetupDatabase:
                                'solvent {}').format(solvent_id)
                     logger.error(err_msg)
                     raise RuntimeError(err_msg)
-                tleap.add_ions(leap_unit=unit_to_solvate, ion=ion,
+                tleap.add_ions(unit_name=unit_to_solvate, ion=ion,
                                num_ions=n_alchemical_ions, replace_solvent=True)
                 logging.debug('Adding {} {} ion to neutralize ligand charge of {}'
                               ''.format(n_alchemical_ions, ion, alchemical_charge))
 
             # Neutralizing solvation box
             if 'positive_ion' in solvent:
-                tleap.add_ions(leap_unit=unit_to_solvate, ion=solvent['positive_ion'],
+                tleap.add_ions(unit_name=unit_to_solvate, ion=solvent['positive_ion'],
                                replace_solvent=True)
             if 'negative_ion' in solvent:
-                tleap.add_ions(leap_unit=unit_to_solvate, ion=solvent['negative_ion'],
+                tleap.add_ions(unit_name=unit_to_solvate, ion=solvent['negative_ion'],
                                replace_solvent=True)
 
             # Ions for the ionic strength must be added AFTER neutralization.
             if n_ions_ionic_strength != 0:
-                tleap.add_ions(leap_unit=unit_to_solvate, ion=solvent['positive_ion'],
+                tleap.add_ions(unit_name=unit_to_solvate, ion=solvent['positive_ion'],
                                num_ions=n_ions_ionic_strength, replace_solvent=True)
-                tleap.add_ions(leap_unit=unit_to_solvate, ion=solvent['negative_ion'],
+                tleap.add_ions(unit_name=unit_to_solvate, ion=solvent['negative_ion'],
                                num_ions=n_ions_ionic_strength, replace_solvent=True)
 
         # Check charge

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -358,7 +358,7 @@ class HealthReportData(object):
             # Without vmin/vmax, the image normalizes the values to mixing_data.max
             # which screws up the warning colormap.
             # Can also use norm=NoNorm(), but that makes the colorbar manipulation fail.
-            output_image = subplot.imshow(mixing_statistics.transition_matrix, aspect='equal',
+            output_image = subplot.imshow(transition_matrix, aspect='equal',
                                           cmap=cmap, vmin=0, vmax=1)
             # Add colorbar.
             decimal = 2  # Precision setting

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -472,18 +472,18 @@ class HealthReportData(object):
             elif 'solvent1' in phase:
                 calculation_type = ' of solvation'
 
-        print("Free energy{}: {:16.3f} +- {:.3f} kT ({:16.3f} +- {:.3f} kcal/mol)".format(
+        print('Free energy{:<13}: {:9.3f} +- {:.3f} kT ({:.3f} +- {:.3f} kcal/mol)'.format(
             calculation_type, DeltaF, dDeltaF, DeltaF * kT / units.kilocalories_per_mole,
                                                dDeltaF * kT / units.kilocalories_per_mole))
 
         for phase in self.phase_names:
-            print("DeltaG {:<25} : {:16.3f} +- {:.3f} kT".format(phase, data[phase]['DeltaF'],
-                                                                 data[phase]['dDeltaF']))
+            print('DeltaG {:<17}: {:9.3f} +- {:.3f} kT'.format(phase, data[phase]['DeltaF'],
+                                                               data[phase]['dDeltaF']))
             if data[phase]['DeltaF_standard_state_correction'] != 0.0:
-                print("DeltaG {:<25} : {:25.3f} kT".format('standard state correction',
-                                                           data[phase]['DeltaF_standard_state_correction']))
+                print('DeltaG {:<17}: {:18.3f} kT'.format('standard state correction',
+                                                          data[phase]['DeltaF_standard_state_correction']))
         print('')
-        print("Enthalpy{}: {:16.3f} +- {:.3f} kT ({:16.3f} +- {:.3f} kcal/mol)".format(
+        print('Enthalpy{:<16}: {:9.3f} +- {:.3f} kT ({:.3f} +- {:.3f} kcal/mol)'.format(
             calculation_type, DeltaH, dDeltaH, DeltaH * kT / units.kilocalories_per_mole,
                                                dDeltaH * kT / units.kilocalories_per_mole))
         self._free_energy_run = True

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -182,7 +182,7 @@ class TestPhaseAnalyzer(object):
     def test_repex_mixing_stats(self):
         """Test that the Repex Phase yields mixing stats that make sense"""
         phase = analyze.ReplicaExchangeAnalyzer(self.reporter, name=self.repex_name)
-        t, mu = phase.generate_mixing_statistics()
+        t, mu, g = phase.generate_mixing_statistics()
         # Output is the correct number of states
         assert t.shape == (self.n_states, self.n_states)
         # Assert transition matrix values are all 0 <= x <= 1

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -772,8 +772,9 @@ def test_validation_correct_experiments():
         {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {
             'type': 'FlatBottom', 'well_radius': '5.2*nanometers', 'restrained_receptor_atom': 1644}},
         {'system': 'sys', 'protocol': 'absolute-binding', 'restraint': {
-            'type': 'Boresch', 'restrained_atoms': [1335, 1339, 1397, 2609, 2607, 2606],
-            'K_r': '20.0*kilocalories_per_mole/angstrom**2', 'r_aA0': '0.35*nanometer'}},
+            'type': 'Boresch', 'restrained_receptor_atoms': [1335, 1339, 1397],
+            'restrained_ligand_atoms': [2609, 2607, 2606], 'r_aA0': '0.35*nanometer',
+            'K_r': '20.0*kilocalories_per_mole/angstrom**2'}},
     ]
     for experiment in experiments:
         modified_script = basic_script.copy()
@@ -2170,8 +2171,8 @@ def test_run_experiment():
                 type: FlatBottom
                 spring_constant: 0.6*kilocalorie_per_mole/angstroms**2
                 well_radius: 5.2*nanometers
-                restrained_receptor_atom: 1644
-                restrained_ligand_atom: 2609
+                restrained_receptor_atoms: 1644
+                restrained_ligand_atoms: 2609
         """.format(tmp_dir, examples_paths()['lysozyme'], examples_paths()['p-xylene'],
                    indent(standard_protocol))
 

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -183,7 +183,7 @@ def test_harmonic_standard_state():
     LJ_fluid = testsystems.LennardJonesFluid()
 
     # Create Harmonic restraint.
-    restraint = yank.restraints.create_restraint('Harmonic', restrained_receptor_atoms=[1])
+    restraint = yank.restraints.create_restraint('Harmonic', restrained_receptor_atoms=1)
 
     # Determine other parameters.
     ligand_atoms = [3, 4, 5]

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -251,11 +251,11 @@ def test_TLeap_script():
     expected_script = """
     source oldff/leaprc.ff99SBildn
     source leaprc.gaff
-    receptor = loadPdb receptor.pdbfixer.pdb
+    M5receptor = loadPdb receptor.pdbfixer.pdb
     loadAmberParams ligand.gaff.frcmod
     ligand = loadMol2 path/to/ligand.gaff.mol2
     transform ligand {{ 1 0 0 6} { 0 -1 0 0} { 0 0 1 0} { 0 0 0 1}}
-    complex = combine { receptor ligand }
+    complex = combine { M5receptor ligand }
     solvateBox complex TIP3PBOX 10.0 iso
     check complex
     charge complex
@@ -273,20 +273,21 @@ def test_TLeap_script():
 
     tleap = TLeap()
     tleap.load_parameters('oldff/leaprc.ff99SBildn', 'leaprc.gaff')
-    tleap.load_unit(name='receptor', file_path='receptor.pdbfixer.pdb')
+    # TLeap should prepend a character to names starting with a digit.
+    tleap.load_unit(unit_name='5receptor', file_path='receptor.pdbfixer.pdb')
     tleap.load_parameters('ligand.gaff.frcmod')
     tleap.load_parameters('ligand.gaff.frcmod')  # tLeap should not load this twice
-    tleap.load_unit(name='ligand', file_path='path/to/ligand.gaff.mol2')
+    tleap.load_unit(unit_name='ligand', file_path='path/to/ligand.gaff.mol2')
     tleap.transform('ligand', np.array([[1, 0, 0, 6], [0, -1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]))
-    tleap.combine('complex', 'receptor', 'ligand')
-    tleap.solvate(leap_unit='complex', solvent_model='TIP3PBOX', clearance=10.0)
+    tleap.combine('complex', '5receptor', 'ligand')
+    tleap.solvate(unit_name='complex', solvent_model='TIP3PBOX', clearance=10.0)
     tleap.add_commands('check complex', 'charge complex')
     tleap.new_section('New section')
-    tleap.save_unit(leap_unit='complex', output_path='complex.prmtop')
-    tleap.save_unit(leap_unit='complex', output_path='complex.pdb')
-    tleap.solvate(leap_unit='ligand', solvent_model='TIP3PBOX', clearance=10.0)
-    tleap.save_unit(leap_unit='ligand', output_path='solvent.inpcrd')
-    tleap.save_unit(leap_unit='ligand', output_path='solvent.pdb')
+    tleap.save_unit(unit_name='complex', output_path='complex.prmtop')
+    tleap.save_unit(unit_name='complex', output_path='complex.pdb')
+    tleap.solvate(unit_name='ligand', solvent_model='TIP3PBOX', clearance=10.0)
+    tleap.save_unit(unit_name='ligand', output_path='solvent.inpcrd')
+    tleap.save_unit(unit_name='ligand', output_path='solvent.pdb')
 
     assert tleap.script == expected_script
 
@@ -297,14 +298,17 @@ def test_TLeap_export_run():
     benzene_gaff = os.path.join(setup_dir, 'benzene.gaff.mol2')
     benzene_frcmod = os.path.join(setup_dir, 'benzene.frcmod')
 
+    # Leap has problems with unit names that contain too many numbers.
+    # Test if we are able to run even with something like this.
+    unit_name = '534E56'
     tleap = TLeap()
     tleap.load_parameters('oldff/leaprc.ff99SB', 'leaprc.gaff')
-    tleap.load_unit(name='benzene', file_path=benzene_gaff)
+    tleap.load_unit(unit_name=unit_name, file_path=benzene_gaff)
     tleap.load_parameters(benzene_frcmod)
 
     with omt.utils.temporary_directory() as tmp_dir:
         output_path = os.path.join(tmp_dir, 'benzene')
-        tleap.save_unit(leap_unit='benzene', output_path=output_path + '.prmtop')
+        tleap.save_unit(unit_name=unit_name, output_path=output_path + '.prmtop')
 
         export_path = os.path.join(tmp_dir, 'leap.in')
         tleap.export_script(export_path)

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1506,6 +1506,23 @@ def get_oe_mol_positions(molecule, conformer_idx=0):
     return molecule_pos
 
 
+def _sanitize_tleap_unit_name(func):
+    """Decorator version of TLeap._sanitize_unit_name.
+
+    This takes as unit name a keyword argument called "unit_name" or the
+    second sequential argument (skipping self).
+    """
+    @functools.wraps(func)
+    def _wrapper(*args, **kwargs):
+        try:
+            kwargs['unit_name'] = TLeap._sanitize_unit_name(kwargs['unit_name'])
+        except KeyError:
+            # Tuples are immutable so we need to use concatenation.
+            args = args[:1] + (TLeap._sanitize_unit_name(args[1]), ) + args[2:]
+        func(*args, **kwargs)
+    return _wrapper
+
+
 class TLeap:
     """
     Programmatic interface to write and run AmberTools' ``tLEaP`` scripts.
@@ -1591,7 +1608,8 @@ class TLeap:
             # Update loaded parameters cache
             self._loaded_parameters.add(par_file)
 
-    def load_unit(self, name, file_path):
+    @_sanitize_tleap_unit_name
+    def load_unit(self, unit_name, file_path):
         """
         Load a Unit into LEaP, this is typically a molecule or small complex.
 
@@ -1601,7 +1619,7 @@ class TLeap:
 
         Parameters
         ----------
-        name : str
+        unit_name : str
             Name of the unit as it should be represented in LEaP
         file_path : str
             Full file path with extension of the file to read into LEaP as a new unit
@@ -1614,12 +1632,13 @@ class TLeap:
         else:
             raise ValueError('cannot load format {} in tLeap'.format(extension))
         local_name = 'moli{}'.format(len(self._file_paths))
-        self.add_commands('{} = {} {{{}}}'.format(name, load_command, local_name))
+        self.add_commands('{} = {} {{{}}}'.format(unit_name, load_command, local_name))
 
         # Update list of input files to copy in temporary folder before run
         self._file_paths[local_name] = file_path
 
-    def combine(self, leap_unit, *args):
+    @_sanitize_tleap_unit_name
+    def combine(self, unit_name, *args):
         """
         Combine units in LEaP
 
@@ -1627,15 +1646,19 @@ class TLeap:
 
         Parameters
         ----------
-        leap_unit : str
+        unit_name : str
             Name of LEaP unit to assign the combination to
         args : iterable of strings
             Name of LEaP units to combine into a single unit called leap_name
-        """
-        components = ' '.join(args)
-        self.add_commands('{} = combine {{{{ {} }}}}'.format(leap_unit, components))
 
-    def add_ions(self, leap_unit, ion, num_ions=0, replace_solvent=False):
+        """
+        # Sanitize unit names.
+        args = [self._sanitize_unit_name(arg) for arg in args]
+        components = ' '.join(args)
+        self.add_commands('{} = combine {{{{ {} }}}}'.format(unit_name, components))
+
+    @_sanitize_tleap_unit_name
+    def add_ions(self, unit_name, ion, num_ions=0, replace_solvent=False):
         """
         Add ions to a unit in LEaP
 
@@ -1643,23 +1666,24 @@ class TLeap:
 
         Parameters
         ----------
-        leap_unit : str
+        unit_name : str
             Name of the existing LEaP unit which Ions will be added into
         ion : str
             LEaP recognized name of ion to add
         num_ions : int, optional
-            Number of ions of type ion to add to leap_unit. If 0, the unit
+            Number of ions of type ion to add to unit_name. If 0, the unit
             is neutralized (default is 0).
         replace_solvent : bool, optional
             If True, ions will replace solvent molecules rather than being
             added.
         """
         if replace_solvent:
-            self.add_commands('addIonsRand {} {} {}'.format(leap_unit, ion, num_ions))
+            self.add_commands('addIonsRand {} {} {}'.format(unit_name, ion, num_ions))
         else:
-            self.add_commands('addIons2 {} {} {}'.format(leap_unit, ion, num_ions))
+            self.add_commands('addIons2 {} {} {}'.format(unit_name, ion, num_ions))
 
-    def solvate(self, leap_unit, solvent_model, clearance):
+    @_sanitize_tleap_unit_name
+    def solvate(self, unit_name, solvent_model, clearance):
         """
         Solvate a unit in LEaP isometrically
 
@@ -1667,17 +1691,18 @@ class TLeap:
 
         Parameters
         ----------
-        leap_unit : str
+        unit_name : str
             Name of the existing LEaP unit which will be solvated
         solvent_model : str
             LEaP recognized name of the solvent model to use, e.g. "TIP3PBOX"
         clearance : float
-            Add solvent up to clearance distance away from the leap_unit (radial)
+            Add solvent up to clearance distance away from the unit_name (radial)
         """
-        self.add_commands('solvateBox {} {} {} iso'.format(leap_unit, solvent_model,
+        self.add_commands('solvateBox {} {} {} iso'.format(unit_name, solvent_model,
                                                            str(clearance)))
 
-    def save_unit(self, leap_unit, output_path):
+    @_sanitize_tleap_unit_name
+    def save_unit(self, unit_name, output_path):
         """
         Write a LEaP unit to file.
 
@@ -1687,7 +1712,7 @@ class TLeap:
 
         Parameters
         ----------
-        leap_unit : str
+        unit_name : str
             Name of the unit to save
         output_path : str
             Full file path with extension to save.
@@ -1703,7 +1728,7 @@ class TLeap:
         # Add command
         if extension == '.prmtop' or extension == '.inpcrd':
             local_name2 = 'molo{}'.format(len(self._file_paths))
-            command = 'saveAmberParm ' + leap_unit + ' {{{}}} {{{}}}'
+            command = 'saveAmberParm ' + unit_name + ' {{{}}} {{{}}}'
 
             # Update list of output files with the one not explicit
             if extension == '.inpcrd':
@@ -1717,13 +1742,14 @@ class TLeap:
 
             self.add_commands(command)
         elif extension == '.pdb':
-            self.add_commands('savePDB {} {{{}}}'.format(leap_unit, local_name))
+            self.add_commands('savePDB {} {{{}}}'.format(unit_name, local_name))
         else:
             raise ValueError('cannot export format {} from tLeap'.format(extension[1:]))
 
-    def transform(self, leap_unit, transformation):
+    @_sanitize_tleap_unit_name
+    def transform(self, unit_name, transformation):
         """Transformation is an array-like representing the affine transformation matrix."""
-        command = 'transform {} {}'.format(leap_unit, transformation)
+        command = 'transform {} {}'.format(unit_name, transformation)
         command = command.replace(r'[', '{{').replace(r']', '}}')
         command = command.replace('\n', '').replace('  ', ' ')
         self.add_commands(command)
@@ -1807,6 +1833,20 @@ class TLeap:
 
             # Check for and return warnings
             return re.findall('WARNING: (.+)', leap_output)
+
+    @staticmethod
+    def _sanitize_unit_name(unit_name):
+        """Sanitize tleap unit names.
+
+        Leap doesn't like names that start with digits so, in this case, we
+        prepend an arbitrary character.
+
+        This takes as unit name a keyword argument called "unit_name" or the
+        second sequential argument (skipping self).
+        """
+        if unit_name[0].isdigit():
+            unit_name = 'M' + unit_name
+        return unit_name
 
 
 # =============================================================================================


### PR DESCRIPTION
In this PR:
* Fix #816: Setup logs are saved in the wrong folder.
* Fix #818: crash with single FlatBottom/Harmonic restrained atom.
  - I've slightly refactored the descriptor `_RestrainedAtomsProperty` to remove shared code between Boresch-style and radially symmetric restraints and to always casts integers to a list so that we don't need to worry about this extra case in the internal logic.
* Fix #815: Better way to generate residue name for SMILES and sdf molecules.
  - We now generate a residue name in the form `YXX` where `Y` is an uppercase letter and `XX` are two digits. This gives us a total of 2600 unique residue names. The algorithm fails to maintain unique residue names if the list of molecules is updated in the middle of the setup, but I couldn't find a better solution to keep supporting parallel setup. Suggestions are welcomed. We never use the `SetupPipeline` class this way anyway, so this should not be a problem.
* Fix #817: Compute statistical inefficiency of replica state index in analysis.
  - I've added this to both the text analysis and the notebook.
* I've also fixed the alignment of the final printed free energy. I broke it several months ago and it was driving me crazy.