### PR TITLE
Add check for solvent_model vs parameter mismatch

### DIFF
--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1741,8 +1741,9 @@ class TLeap:
             leap_output = subprocess.check_output(['tleap', '-f', 'leap.in']).decode()
 
             # Save leap.log in directory of first output file
+            log_path = ''
             if len(output_files) > 0:
-                #Get first output path in Py 3.X way that is also thread-safe
+                # Get first output path in Py 3.X way that is also thread-safe
                 for val in output_files.values():
                     first_output_path = val
                     break
@@ -1752,23 +1753,34 @@ class TLeap:
                 create_dirs_and_copy('leap.log', log_path)
 
             # Copy back output files. If something goes wrong, some files may not exist
-            error_msg = ''
+            known_error_msg = []
             try:
                 for local_file, file_path in output_files.items():
                     create_dirs_and_copy(local_file, file_path)
             except IOError:
-                error_msg = "Could not create one of the system files."
+                known_error_msg.append("Could not create one of the system files.")
 
             # Look for errors in log that don't raise CalledProcessError
             error_patterns = ['Argument #\d+ is type \S+ must be of type: \S+']
             for pattern in error_patterns:
                 m = re.search(pattern, leap_output)
                 if m is not None:
-                    error_msg = m.group(0)
+                    known_error_msg.append(m.group(0))
                     break
 
-            if error_msg != '':
-                raise RuntimeError(error_msg + ' Check log file {}'.format(log_path))
+            # Analyze log file for water mismatch
+            m = re.search("Could not find bond parameter for: EP - \w+W", leap_output)
+            if m is not None:
+                # Found mismatch water and missing parameters
+                known_error_msg.append('It looks like the water used has virtual sites, but '
+                                       'missing parameters.\nMake sure your leap parameters '
+                                       'use the correct water model as specified by '
+                                       'solvent_model.')
+
+            if len(known_error_msg) > 0:
+                final_error = ('Some things went wrong with LEaP\nWe caught a few but their may be more.\n'
+                               'Please see the log file for LEaP for more info:\n{}\n============\n{}')
+                raise RuntimeError(final_error.format(log_path, '\n---------\n'.join(known_error_msg)))
 
             # Check for and return warnings
             return re.findall('WARNING: (.+)', leap_output)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -8,6 +8,14 @@ Frequently Asked Questions (FAQ)
    Yes! Either specify the :ref:`yaml_options_resume_simulation` in the YAML file, or use the
    :func:`yank.yank.AlchemicalPhase.from_storage` function to resume from existing file.
 
+#. My setup keeps saying the system failed to create and my logfile says a bunch of things about missing "EP - OW" parameters
+
+   The likely cause is you did choose a :ref:`solvent_model <yaml_solvents_solvent_model>` which was supported by
+   the LEaP Parameters you loaded. You probably need to choose a LEaP parameter file to support your solvent model.
+   E.g. the ``solvent_model`` ``tip4pew`` should have a ``leaprc.water.tip4pew`` parameter set by either a
+   :ref:`molecule <yaml_molecules_leap>`, :ref:`solvent <yaml_solvents_leap>`,
+   or :ref:`system wide parameter's <yaml_systems_head>` file. YANK uses the TIP4P-EW model by default.
+
 #. Which MPI program should I use?
 
    We recommend the ``mpich`` and ``mpi4py`` packages that come from the ``conda-forge`` channel of ``conda``.

--- a/docs/yamlpages/solvents.rst
+++ b/docs/yamlpages/solvents.rst
@@ -189,7 +189,7 @@ Valid Options (0.0 * moles / liter): <Quantity Moles / Volume> OR <Quantity Temp
 .. rst-class:: html-toggle
 
 ``solute_dielectric``
-----------------------
+---------------------
 .. code-block:: yaml
    
    solvents:
@@ -371,7 +371,7 @@ Valid Options (0 * molar): <Quantity Concentration> [1]_
    solvents:
      {UserDefinedSolvent}:
        leap:
-         parameters: [leaprc.water.tip3p]
+         parameters: [leaprc.water.tip4pew]
 
 Load solvent-specific force field parameters. This is useful if you plan to run a combinatorial experiment over
 multiple solvent models that require different parameters.


### PR DESCRIPTION
This adds a check for the solvent_model parameter vs what files were loaded to TLEaP. Its a bit crude, but provides better handling of the error and tries to inspect the LEaP log for the error it knows.

Its a 2-fold trap:
First it warns the user if they have not loaded the expected leaprc file, warning looks like:
```
WARNING - yank.pipeline - WARNING: The solvent_model tip4pew may not work for loaded leaprc.water.X files.
 We expected leaprc.water.tip4pew to make your solvent model work, but did not find it.
 This is okay for tip4pew leaprc file with tip3p solvent_model, but not the other way around.
 ```

 Second, if the system fails to build, the logfile is searched for a common match error an throws an error with the following message:
 ```
 RuntimeError: Solvent {SOLVENT_ID}: It looks like the water used has virtual sites, but missing parameters.
Make sure your leap parameters use the correct water model as specified by solvent_model.
Please see the log file for LEaP for more info as there may be more wrong:
{ORIGINAL_MESSAGE}
 ```
 Where ORIGINAL_MESSAGE is filled in with the actual error thrown by the `telap.run()` function in `utils`, and SOLVENT_ID is the name of the solvent as it appears in YAML

 I have also updated the FAQ and the example in the yaml pages to use the default. cc @jchodera since this has come up a few times

 Thoughts?

 Fixes #776
 cc #759 as its a related bug, since this sets up the framework for catching other errors like the one there.
