### PR TITLE
Cut the 0.19.0 release

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - netcdf4
     - openmm >=7.1
     - mdtraj >=1.7.2
-    - openmmtools >=0.13.2
+    - openmmtools >=0.13.3
     - pymbar
     - ambermini >=16.16.0
     - docopt
@@ -41,7 +41,7 @@ requirements:
     - netcdf4
     - openmm >=7.1
     - mdtraj >=1.7.2
-    - openmmtools >=0.13.2
+    - openmmtools >=0.13.3
     - pymbar
     - ambermini >=16.16.0
     - docopt

--- a/devtools/travis-ci/set_doc_version.py
+++ b/devtools/travis-ci/set_doc_version.py
@@ -17,12 +17,7 @@ shutil.copytree("docs/_build", "docs/_deploy/{docversion}"
 
 # Only update latest if we are on a release version
 if version.release:
-    # Create the directory
-    try:
-        os.mkdir("docs/_deploy/latest")
-    except:
-        # Directory exists, no need to make it
-        pass
     # Copy the most recent version to the latest build
+    # copytree will make the directory for us
     shutil.copytree("docs/_build", "docs/_deploy/latest"
                     .format(docversion=docversion))

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,8 +6,8 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
-0.19.0 In Development (Current)
--------------------------------
+0.19.0 Regions, Cerberus, and Errors
+------------------------------------
 - Added custom region selection to Topography
 - Custom regions can now be defined through YAML
 - Compound custom Topography regions can now be selected
@@ -16,6 +16,7 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 - Changed to Cerberus for data validation (was Schema), public facing validation schemas in the future
 - Added better error handling of known LEaP Errors
 - Fixed issue for ``start_frame`` and ``end_frame`` were ignored for trajectory extraction
+- OpenMMTools 0.13.3 now required to fix bug in ``SamplerState``
 
 0.18.0 Python 2 Dropped, Solute Only Trajectories, and Trailblaze Bugfixes
 --------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ DOCLINES = __doc__.split("\n")
 
 ########################
 VERSION = "0.19.0"  # Primary base version of the build
-DEVBUILD = "0"  # Dev build status, Either None or Integer as string
-ISRELEASED = False  # Are we releasing this as a full cut?
+DEVBUILD = None  # Dev build status, Either None or Integer as string
+ISRELEASED = True  # Are we releasing this as a full cut?
 __version__ = VERSION
 ########################
 CLASSIFIERS = """\
@@ -146,7 +146,7 @@ setup(
         'cython',
         'openmm>=7.1',
         'pymbar',
-        'openmmtools>=0.13.2',
+        'openmmtools>=0.13.3',
         'docopt>=0.6.1',
         'netcdf4',
         'cerberus',


### PR DESCRIPTION
* Requires minimum version of OpenMMTools 0.13.3 for critical fix in SamplerState
* Changed from Schema to Cerberus for YAML data validation
* Adds more general region selection schema for Topography and atom selection
    * Establishes the future framework for SMARTS selection

@andrrizzi could you double check this has all the features we want?