### PR TITLE
Add support for amber rst7 files and make jobid 1-based

### DIFF
--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -35,7 +35,7 @@ Required Arguments:
 
 Optional Arguments:
   --jobid=INTEGER               You can run only a subset of the experiments by specifying jobid and njobs, where
-                                0 <= job_id <= n_jobs-1. In this case, njobs must be specified as well and YANK will
+                                1 <= job_id <= n_jobs. In this case, njobs must be specified as well and YANK will
                                 run only 1/n_jobs of the experiments. This can be used to run several separate YANK
                                 executions in parallel starting from the same script.
   --njobs=INTEGER               Specify the total number of parallel executions. jobid has to be specified too.

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1657,16 +1657,23 @@ class ExperimentBuilder(object):
             schema:
                 type: string
                 validator: file_exists
-            dependencies: phase2_path
-            coerce: sort_alphabetically_by_extension
+            validator: supported_system_files
+            coerce: sort_system_files_by_type
         phase2_path:
             required: no
             type: list
             schema:
                 type: string
                 validator: file_exists
-            validator: is_system_files_matching_phase1
-            coerce: sort_alphabetically_by_extension
+            validator: supported_system_files
+            coerce: sort_system_files_by_type
+        gromacs_include_dir:
+            required: no
+            type: string
+            dependencies: [phase1_path, phase2_path]
+            validator: directory_exists
+
+        # Solvents
         solvent:
             required: no
             type: string
@@ -1694,13 +1701,8 @@ class ExperimentBuilder(object):
             oneof:
                 - dependencies: [phase1_path, phase2_path, solvent1]
                 - dependencies: [solute, solvent1]
-        gromacs_include_dir:
-            required: no
-            type: string
-            dependencies: [phase1_path, phase2_path]
-            validator: directory_exists
 
-        # Non-Prebuilt setup
+        # Automatic pipeline
         receptor:
             required: no
             type: string

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1659,6 +1659,7 @@ class ExperimentBuilder(object):
             schema:
                 type: string
                 validator: file_exists
+            dependencies: phase2_path
             validator: supported_system_files
         phase2_path:
             required: no

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1657,7 +1657,6 @@ class ExperimentBuilder(object):
                 type: string
                 validator: file_exists
             validator: supported_system_files
-            coerce: sort_system_files_by_type
         phase2_path:
             required: no
             type: list
@@ -1665,7 +1664,6 @@ class ExperimentBuilder(object):
                 type: string
                 validator: file_exists
             validator: supported_system_files
-            coerce: sort_system_files_by_type
         gromacs_include_dir:
             required: no
             type: string

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1437,7 +1437,6 @@ class ExperimentBuilder(object):
         for solvent_id, solvent_descr in solvents_description.items():
             if solvent_validator.validate(solvent_descr):
                 validated_solvents[solvent_id] = solvent_validator.document
-                print(solvent_validator.document)
             else:
                 error = "Solvent '{}' did not validate! Check the schema error below for details\n{}"
                 raise YamlParseError(error.format(solvent_id, yaml.dump(solvent_validator.errors)))

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -502,7 +502,7 @@ class ExperimentBuilder(object):
         can load it later by using :func:`parse` (default is None).
     job_id : None or int
         If you want to split the experiments among different executions,
-        you can set this to an integer 0 <= job_id <= n_jobs-1, and this
+        you can set this to an integer 1 <= job_id <= n_jobs, and this
         :class:`ExperimentBuilder` will run only 1/n_jobs of the experiments.
     n_jobs : None or int
         If ``job_id`` is specified, this is the total number of jobs that
@@ -606,8 +606,8 @@ class ExperimentBuilder(object):
         if job_id is not None:
             if n_jobs is None:
                 raise ValueError('n_jobs must be specified together with job_id')
-            if not 0 <= job_id <= n_jobs:
-                raise ValueError('job_id must be between 0 and n_jobs ({})'.format(n_jobs))
+            if not 1 <= job_id <= n_jobs:
+                raise ValueError('job_id must be between 1 and n_jobs ({})'.format(n_jobs))
 
         self._job_id = job_id
         self._n_jobs = n_jobs
@@ -1021,7 +1021,10 @@ class ExperimentBuilder(object):
 
             # Loop over all combinations
             for name, combination in experiment.named_combinations(separator='_', max_name_length=50):
-                if self._job_id is None or experiment_id % self._n_jobs == self._job_id:
+                # Both self._job_id and self._job_id-1 work (self._job_id is 1-based),
+                # but we use the latter just because it makes it easier to identify in
+                # advance which job ids are associated to which experiments.
+                if self._job_id is None or experiment_id % self._n_jobs == self._job_id-1:
                     yield os.path.join(output_dir, name), combination
                 experiment_id += 1
 

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -857,6 +857,7 @@ class SetupDatabase:
         """
         Paths = collections.namedtuple('Paths', ['position_path', 'parameters_path'])
         system_dir = os.path.join(self.setup_dir, self.SYSTEMS_DIR, system_id)
+
         if 'receptor' in self.systems[system_id]:
             system_files_paths = [
                 Paths(position_path=os.path.join(system_dir, 'complex.inpcrd'),
@@ -872,13 +873,20 @@ class SetupDatabase:
                       parameters_path=os.path.join(system_dir, 'solvent2.prmtop'))
             ]
         else:
-            system_files_paths = [
-                Paths(position_path=self.systems[system_id]['phase1_path'][0],
-                      parameters_path=self.systems[system_id]['phase1_path'][1]),
-                Paths(position_path=self.systems[system_id]['phase2_path'][0],
-                      parameters_path=self.systems[system_id]['phase2_path'][1])
-            ]
+            parameter_file_extensions = {'prmtop', 'top', 'xml'}
+            system_files_paths = []
+            for phase_path_name in ['phase1_path', 'phase2_path']:
+                file_paths = self.systems[system_id][phase_path_name]
+                assert len(file_paths) == 2
 
+                # Make sure that the position file is first.
+                first_file_extension = os.path.splitext(file_paths[0])[1][1:]
+                if first_file_extension in parameter_file_extensions:
+                    file_paths = list(reversed(file_paths))
+
+                # Append Paths object.
+                system_files_paths.append(Paths(position_path=file_paths[0],
+                                                parameters_path=file_paths[1]))
         return system_files_paths
 
     def is_molecule_setup(self, molecule_id):

--- a/Yank/schema/validator.py
+++ b/Yank/schema/validator.py
@@ -24,17 +24,6 @@ class YANKCerberusValidator(cerberus.Validator):
         """Cast a single string to a list of string"""
         return [value] if isinstance(value, str) else value
 
-    def _normalize_coerce_sort_system_files_by_type(self, file_paths):
-        """Sort the system files path to have positions first and parameters second."""
-        file_extensions = [os.path.splitext(file_path)[1][1:] for file_path in file_paths]
-
-        # In all cases but for the pair (rst7, prmtop) we can just sort alphabetically.
-        sorted_file_paths = [file_path for ext, file_path in sorted(zip(file_extensions, file_paths))]
-        if 'rst7' not in file_extensions:
-            # reversed() return an iterator.
-            return list(reversed(sorted_file_paths))
-        return sorted_file_paths
-
     # ====================================================
     # DATA VALIDATORS
     # ====================================================
@@ -73,12 +62,6 @@ class YANKCerberusValidator(cerberus.Validator):
 
     def _validator_supported_system_files(self, field, file_paths):
         """Ensure the input system files are supported."""
-        # Check that this is a list of two file_paths.
-        if len(file_paths) != 2:
-            self._error(field, '{} must be a list of paths to the position '
-                               'and parameter files'.format(field))
-            return
-
         # Obtain the extension of the system files.
         file_extensions = {os.path.splitext(file_path)[1][1:] for file_path in file_paths}
 

--- a/Yank/schema/validator.py
+++ b/Yank/schema/validator.py
@@ -15,20 +15,30 @@ class YANKCerberusValidator(cerberus.Validator):
     Custom cerberus.Validator class for YANK extending the Validator to include all the methods needed
     by YANK
     """
+
     # ====================================================
     # DATA COERCION
     # ====================================================
+
     def _normalize_coerce_single_str_to_list(self, value):
         """Cast a single string to a list of string"""
         return [value] if isinstance(value, str) else value
 
-    def _normalize_coerce_sort_alphabetically_by_extension(self, files):
-        provided_extensions = [os.path.splitext(filepath)[1][1:] for filepath in files]
-        return [filepath for (ext, filepath) in sorted(zip(provided_extensions, files))]
+    def _normalize_coerce_sort_system_files_by_type(self, file_paths):
+        """Sort the system files path to have positions first and parameters second."""
+        file_extensions = [os.path.splitext(file_path)[1][1:] for file_path in file_paths]
+
+        # In all cases but for the pair (rst7, prmtop) we can just sort alphabetically.
+        sorted_file_paths = [file_path for ext, file_path in sorted(zip(file_extensions, file_paths))]
+        if 'rst7' not in file_extensions:
+            # reversed() return an iterator.
+            return list(reversed(sorted_file_paths))
+        return sorted_file_paths
 
     # ====================================================
     # DATA VALIDATORS
     # ====================================================
+
     def _validator_file_exists(self, field, filepath):
         """Assert that the file is in fact, a file!"""
         if not os.path.isfile(filepath):
@@ -61,47 +71,38 @@ class YANKCerberusValidator(cerberus.Validator):
         if value != 'all' and not isinstance(value, int):
             self._error(field, "{} must be an int or the string 'all'".format(value))
 
-    def _validator_is_system_files_matching_phase1(self, field, phase2):
-        """Ensure the phase2_filepaths match the type of the phase1 paths"""
-        phase1 = self.document.get('phase1_path')
-        # Handle non-existant
-        if phase1 is None:
-            self._error(field, "phase1_path must be present to use phase2_path")
-            return
-        # Handle the not iterable type
-        try:
-            _ = [f for f in phase1]
-            _ = [f for f in phase2]
-        except TypeError:
-            self._error(field, 'phase1_path and phase2_path must be a list of file paths')
-            return
-        # Now process
-        provided_phase1_extensions = [os.path.splitext(filepath)[1][1:] for filepath in phase1]
-        provided_phase2_extensions = [os.path.splitext(filepath)[1][1:] for filepath in phase2]
-        # Check phase1 extensions
-        phase1_type = None
-        valid_extensions = None
-        expected_extensions = {
-            'amber': ['inpcrd', 'prmtop'],
-            'gromacs': ['gro', 'top'],
-            'openmm': ['pdb', 'xml']
-        }
-        for extension_type, valid_extensions in expected_extensions.items():
-            if sorted(provided_phase1_extensions) == sorted(valid_extensions):
-                phase1_type = extension_type
-                break
-        if phase1_type is None:
-            self._error(field, 'phase1_path must have file extensions matching one of the following types: '
-                               '{}'.format(expected_extensions))
-            return
-        # Ensure phase 2 is of the same type
-        if sorted(provided_phase2_extensions) != sorted(valid_extensions):
-            self._error(field, 'phase2_path must have files of the same extensions as phase1_path ({}) to ensure '
-                               'phases came from the same setup pipeline.'.format(phase1_type))
+    def _validator_supported_system_files(self, field, file_paths):
+        """Ensure the input system files are supported."""
+        # Check that this is a list of two file_paths.
+        if len(file_paths) != 2:
+            self._error(field, '{} must be a list of paths to the position '
+                               'and parameter files'.format(field))
             return
 
-        logger.debug('Correctly recognized phase1_path files ({}) and phase2_path files ({}) '
-                     'as {} files'.format(phase1, phase2, phase1_type))
+        # Obtain the extension of the system files.
+        file_extensions = {os.path.splitext(file_path)[1][1:] for file_path in file_paths}
+
+        # Find a match for the extensions.
+        expected_extensions = [
+            ('amber', {'inpcrd', 'prmtop'}),
+            ('amber', {'rst7', 'prmtop'}),
+            ('gromacs', {'gro', 'top'}),
+            ('openmm', {'pdb', 'xml'})
+        ]
+        file_extension_type = None
+        for extension_type, valid_extensions in expected_extensions:
+            if file_extensions == valid_extensions:
+                file_extension_type = extension_type
+                break
+
+        # Verify we found a match.
+        if file_extension_type is None:
+            self._error(field, '{} must have file extensions matching one of the '
+                               'following types: {}'.format(field, expected_extensions))
+            return
+
+        logger.debug('Correctly recognized {}files ({}) as {} '
+                     'files'.format(field, file_paths, file_extension_type))
 
     # ====================================================
     # DATA TYPES

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -619,7 +619,7 @@ def test_validation_wrong_systems():
             {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv3',
              'parameters': 'leaprc.ff14SB'}),
 
-        ("list of paths",
+        ("phase1_path: \[must be of list type\]",
             {'phase1_path': data_paths['bentol-complex'][0],
              'phase2_path': data_paths['bentol-solvent'],
              'ligand_dsl': 'resname BEN', 'solvent': 'solv'}),

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -1875,11 +1875,11 @@ def test_expand_experiments():
     experiment_systems = utils.CombinatorialLeaf(['explicit-system', 'implicit-system', 'hydration-system'])
     template_script['experiments']['system'] = experiment_systems
 
-    exp_builder = ExperimentBuilder(script=template_script, job_id=0, n_jobs=2)
+    exp_builder = ExperimentBuilder(script=template_script, job_id=1, n_jobs=2)
     experiments = list(exp_builder._expand_experiments())
     assert len(experiments) == 2
 
-    exp_builder = ExperimentBuilder(script=template_script, job_id=1, n_jobs=2)
+    exp_builder = ExperimentBuilder(script=template_script, job_id=2, n_jobs=2)
     experiments = list(exp_builder._expand_experiments())
     assert len(experiments) == 1
 


### PR DESCRIPTION
- Fix #838: Support for amber rst7 system files.
- Fix #839: Make jobid 1-based.

After this is merged, I'd make a 0.19.3 release that we can refer to in the SAMPL paper, if there are no objections.