### PR TITLE
Fix bug experiment option and new status command

### DIFF
--- a/Yank/commands/status.py
+++ b/Yank/commands/status.py
@@ -36,11 +36,11 @@ Required Arguments:
 
 General Options:
   --status=STRING               Print only the jobs in a particular status. Accepted values
-                                are completed, running, and pending. This works only if
-                                --verbose is set.
+                                are "completed", "ongoing", and "pending". This works only
+                                if verbose is set.
   --njobs=INTEGER               Print the job id associated to each experiment assuming
                                 njobs to be the one specified here. This works only if
-                                --verbose is set.
+                                verbose is set.
   -v, --verbose                 Print status of each experiment individually. If this is
                                 not set, only a summary of the status of all experiments
                                 is printed.
@@ -72,24 +72,24 @@ def dispatch(args):
                 continue
 
             # Print experiment information.
-            exp_description = '{}: status {}'.format(exp_status.name,
+            exp_description = '{}: status={}'.format(exp_status.name,
                                                      exp_status.status)
             if n_jobs is not None:
-                exp_description += ', job_id {}'.format(exp_status.job_id)
+                exp_description += ', job_id={}'.format(exp_status.job_id)
             print(exp_description)
 
             # Print phases information.
             for phase_name, phase_status in exp_status.phases.items():
                 if phase_status.iteration is not None:
-                    iteration = ', iteration {}/{}'.format(phase_status.iteration,
+                    iteration = ', iteration={}/{}'.format(phase_status.iteration,
                                                            exp_status.number_of_iterations)
                 else:
                     iteration = ''
-                print('\t{}: status{}{}'.format(phase_status.status, iteration))
+                print('\t{}: status={}{}'.format(phase_name, phase_status.status, iteration))
 
     # Print summary.
     tot_n_experiments = sum(count for count in counter.values())
-    print('Total number of experiments: {} ({} completed, {} running, '
+    print('Total number of experiments: {} ({} completed, {} ongoing, '
           '{} pending)'.format(tot_n_experiments, counter['completed'],
-                               counter['running'], counter['pending']))
+                               counter['ongoing'], counter['pending']))
     return True

--- a/Yank/commands/status.py
+++ b/Yank/commands/status.py
@@ -79,7 +79,9 @@ def dispatch(args):
     else:
         n_jobs = None
 
+    # Turn off verbosity.
     exp_builder = experiment.ExperimentBuilder(args['--yaml'], n_jobs=n_jobs)
+    exp_builder.verbose = False
 
     # Count all experiment status.
     job_ids_by_status = {

--- a/Yank/commands/status.py
+++ b/Yank/commands/status.py
@@ -13,7 +13,9 @@ Query output files for quick status.
 # MODULE IMPORTS
 # =============================================================================================
 
-from .. import utils
+import collections
+
+from .. import experiment
 
 # =============================================================================================
 # COMMAND-LINE INTERFACE
@@ -23,16 +25,25 @@ usage = """
 YANK status
 
 Usage:
-  yank status (-s=STORE | --store=STORE) [-v | --verbose]
+  yank status (-y FILEPATH | --yaml=FILEPATH) [--status=STRING] [--njobs=INTEGER] [-v | --verbose]
 
 Description:
-  Get the current status of a running or completed simulation
+  Print the current status of the experiments.
 
 Required Arguments:
-  -s=STORE, --store=STORE       Storage directory for NetCDF data files.
+  -y, --yaml=FILEPATH           Path to the YAML script specifying options and/or how to
+                                set up and run the experiment.
 
 General Options:
-  -v, --verbose                 Print verbose output
+  --status=STRING               Print only the jobs in a particular status. Accepted values
+                                are completed, running, and pending. This works only if
+                                --verbose is set.
+  --njobs=INTEGER               Print the job id associated to each experiment assuming
+                                njobs to be the one specified here. This works only if
+                                --verbose is set.
+  -v, --verbose                 Print status of each experiment individually. If this is
+                                not set, only a summary of the status of all experiments
+                                is printed.
 
 """
 
@@ -40,9 +51,45 @@ General Options:
 # COMMAND DISPATCH
 # =============================================================================================
 
-
 def dispatch(args):
-    from .. import analyze
-    utils.config_root_logger(args['--verbose'])
-    success = analyze.print_status(args['--store'])
-    return success
+    # Handle optional arguments.
+    if args['--njobs']:
+        n_jobs = int(args['--njobs'])
+    else:
+        n_jobs = None
+
+    exp_builder = experiment.ExperimentBuilder(args['--yaml'], n_jobs=n_jobs)
+
+    # Count all experiment status.
+    counter = collections.Counter()
+    for exp_status in exp_builder.status():
+        counter[exp_status.status] += 1
+
+        # Print experiment and phases details.
+        if args['--verbose']:
+            # Filter by status if requested.
+            if args['--status'] and args['--status'] != exp_status.status:
+                continue
+
+            # Print experiment information.
+            exp_description = '{}: status {}'.format(exp_status.name,
+                                                     exp_status.status)
+            if n_jobs is not None:
+                exp_description += ', job_id {}'.format(exp_status.job_id)
+            print(exp_description)
+
+            # Print phases information.
+            for phase_name, phase_status in exp_status.phases.items():
+                if phase_status.iteration is not None:
+                    iteration = ', iteration {}/{}'.format(phase_status.iteration,
+                                                           exp_status.number_of_iterations)
+                else:
+                    iteration = ''
+                print('\t{}: status{}{}'.format(phase_status.status, iteration))
+
+    # Print summary.
+    tot_n_experiments = sum(count for count in counter.values())
+    print('Total number of experiments: {} ({} completed, {} running, '
+          '{} pending)'.format(tot_n_experiments, counter['completed'],
+                               counter['running'], counter['pending']))
+    return True

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -847,19 +847,30 @@ class ExperimentBuilder(object):
             self._setup_experiments()
 
     def status(self):
-        """Return the status of all experiments in dictionary form.
+        """Iterate over the status of all experiments in dictionary form.
+
+        The status of each experiment is set to "completed" if both phases
+        in the experiments have been completed, "pending" if they are both
+        pending, and "ongoing" otherwise.
 
         Yields
         ------
-        experiment_status : named_tuple
-            status[experiment_name][phase_name] is an ExperimentBuilder.Status
-            object containing the information about the status of a specific
-            phase of an experiment. The namedtuple exposes the fields
-            ``status``, ``iteration``, ``number_of_iterations`` and ``job_id``.
+        experiment_status : namedtuple
+            The status of the experiment. It contains the following fields:
 
-            status[experiment_name]['status'] is 'completed' if both phases
-            in the experiments have been completed, 'pending' if they are
-            both pending, and 'ongoing' otherwise.
+            name : str
+                The name of the experiment.
+            status : str
+                One between "completed", "ongoing", or "pending".
+            number_of_iterations : int
+                The total number of iteration set for this experiment.
+            job_id : int or None
+                If njobs is specified, this includes the job id associated
+                to this experiment.
+            phases : dict
+                phases[phase_name] is a namedtuple describing the status
+                of phase ``phase_name``. The namedtuple has two fields:
+                ``iteration`` and ``status``.
 
         """
         # TODO use Python 3.6 namedtuple syntax when we drop Python 3.5 support.

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -876,7 +876,8 @@ class ExperimentBuilder(object):
                    if name not in self.GENERAL_DEFAULT_OPTIONS}
 
         # Then update with specific experiment options.
-        options.update(experiment.get('options', {}))
+        options.update(self._validate_options(experiment.get('options', {}),
+                                              validate_general_options=False))
 
         def _filter_options(reference_options):
             return {name: value for name, value in options.items()
@@ -1803,7 +1804,7 @@ class ExperimentBuilder(object):
                     validated = ExperimentBuilder._validate_options({option:value}, validate_general_options=False)
                     coerced_and_validated = {**coerced_and_validated, **validated}
                 except YamlParseError as yaml_err:
-                    # collecte all errors
+                    # Collect all errors.
                     coerced_and_validated[option] = value
                     errors += "\n{}".format(yaml_err)
             if errors != "":

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -923,6 +923,16 @@ class ExperimentBuilder(object):
     # --------------------------------------------------------------------------
 
     @property
+    def verbose(self):
+        """bool: the log verbosity."""
+        return self._options['verbose']
+
+    @verbose.setter
+    def verbose(self, new_verbose):
+        self._options['verbose'] = new_verbose
+        utils.config_root_logger(self._options['verbose'], log_file_path=None)
+
+    @property
     def output_dir(self):
         """The path to the main output directory."""
         return self._options['output_dir']

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -859,7 +859,7 @@ class ExperimentBuilder(object):
 
             status[experiment_name]['status'] is 'completed' if both phases
             in the experiments have been completed, 'pending' if they are
-            both pending, and 'running' otherwise.
+            both pending, and 'ongoing' otherwise.
 
         """
         # TODO use Python 3.6 namedtuple syntax when we drop Python 3.5 support.
@@ -876,7 +876,7 @@ class ExperimentBuilder(object):
         ])
 
         status = collections.OrderedDict()
-        for experiment_idx, (exp_path, exp_description) in self._expand_experiments():
+        for experiment_idx, (exp_path, exp_description) in enumerate(self._expand_experiments()):
             # Determine the final number of iterations for this experiment.
             _, _, sampler_options, _ = self._determine_experiment_options(exp_description)
             number_of_iterations = sampler_options['number_of_iterations']
@@ -896,7 +896,7 @@ class ExperimentBuilder(object):
                     if _is_phase_completed(phase_status, number_of_iterations):
                         phase_status = 'completed'
                     else:
-                        phase_status = 'running'
+                        phase_status = 'ongoing'
                 phase_name = os.path.splitext(os.path.basename(phase_nc_path))[0]
                 phases[phase_name] = PhaseStatus(status=phase_status, iteration=iteration)
 
@@ -906,7 +906,7 @@ class ExperimentBuilder(object):
                 # This covers the completed and pending status.
                 exp_status = phase_statuses[0]
             else:
-                exp_status = 'running'
+                exp_status = 'ongoing'
 
             # Determine jobid if requested.
             if self._n_jobs is not None:

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -1692,7 +1692,7 @@ class ReplicaExchange(object):
         # Read iteration and online analysis info.
         reporter.open(mode='r')
         options = reporter.read_dict('options')
-        iteration = reporter.read_last_iteration()
+        iteration = reporter.read_last_iteration(full_iteration=False)
         # Search for last cached free energies only if online analysis is activated.
         if options['online_analysis_interval'] is not None:
             target_error = options['online_analysis_target_error']

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -2197,6 +2197,8 @@ def test_run_experiment():
                 well_radius: 5.2*nanometers
                 restrained_receptor_atoms: 1644
                 restrained_ligand_atoms: 2609
+            options:
+                temperature: 302.0*kelvin
         """.format(tmp_dir, examples_paths()['lysozyme'], examples_paths()['p-xylene'],
                    indent(standard_protocol))
 

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -1223,7 +1223,7 @@ class TestReplicaExchange(object):
             repex.run()
 
             # The stored values of online analysis should be up to date.
-            last_written_free_energy = ReplicaExchange._get_last_written_free_energy(repex._reporter, repex.iteration)
+            last_written_free_energy = ReplicaExchange._read_last_free_energy(repex._reporter, repex.iteration)
             last_mbar_f_k, (last_free_energy, last_err_free_energy) = last_written_free_energy
 
             assert len(repex._last_mbar_f_k) == len(thermodynamic_states)

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -8,8 +8,11 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 
 0.19.4 Schema and Parallel Setup Fixes
 --------------------------------------
-- Fixed bug in parallel molecule setup which caused the same molecule to be setup multiple times
-- Fixed bug in Cerberus schema for LEaP where molecule parameters accumulated
+- Fixed bug in parallel molecule setup which caused the same molecule to be setup multiple times.
+- Fixed bug in Cerberus schema for LEaP where molecule parameters accumulated.
+- Fixed bug where options in experiment section were not coerced.
+- Fixed status command to print information about all combinatorial experiments.
+- Faster restart with combinatorial experiments.
 
 0.19.3 Support for Amber restart files
 --------------------------------------


### PR DESCRIPTION
@Lnaden I ended up implementing the new `status` command too for the release because it would be incredibly useful to have it for the benchmark calculations.

- Fixed bug where options in experiment section were not coerced.
- It is possible to save dictionaries on the netcdf file in nested format now. This makes it possible to retrieve dictionary keywords from disk without loading the entire dictionary. We could use this in the future to retrieve the `temperature` very quickly from the thermodynamic state dictionary and speed up the analysis!
- Fix #852: faster restart and fix  `status` command to print information about all combinatorial experiments.