### PR TITLE
Handle cases in which NetCDF file is not readable

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -854,6 +854,10 @@ class ExperimentBuilder(object):
         in the experiments have been completed, "pending" if they are both
         pending, and "ongoing" otherwise.
 
+        Sometimes the netcdf file can't be read while the simulation is
+        running. In this case, the status of the phase (n.b., not the
+        experiment) is set to "unavailable".
+
         Yields
         ------
         experiment_status : namedtuple
@@ -902,6 +906,10 @@ class ExperimentBuilder(object):
                 except FileNotFoundError:
                     iteration = None
                     phase_status = 'pending'
+                except OSError:
+                    # The simulation is probably running.
+                    iteration = None
+                    phase_status = 'unavailable'
                 else:
                     iteration = phase_status.iteration
                     if _is_phase_completed(phase_status, number_of_iterations):


### PR DESCRIPTION
While the simulation is running, it is sometimes temporarily impossible to read the NetCDF file, causing the `status` command to crash. This handles that case.

Before merging, I still want to test this works on the cluster. I'll have to wait for this case to crop up.