### PR TITLE
Decouple number of replicas and states for Reporter

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -217,7 +217,7 @@ class AlchemicalPhaseFactory(object):
     thermodynamic_state : openmmtools.states.ThermodynamicState
         Reference thermodynamic state without any alchemical modifications
     sampler_states : openmmtools.states.SamplerState
-        Sampler state to initilize from, including the positions of the atoms
+        Sampler state to initialize from, including the positions of the atoms
     topography : yank.yank.Topography
         Topography defining the ligand atoms and other atoms
     protocol : dict of lists

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -222,7 +222,7 @@ class Reporter(object):
                 open_check_list.append(storage.isopen())
         return np.all(open_check_list)
 
-    def open(self, mode='r', convention='ReplicaExchange'):
+    def open(self, mode='r', convention='ReplicaExchange', netcdf_format='NETCDF4'):
         """
         Open the storage file for reading/writing.
 
@@ -234,8 +234,10 @@ class Reporter(object):
         ----------
         mode : str, Optional, Default: 'r'
             The mode of the file between 'r', 'w', and 'a' (or equivalently 'r+').
-        converntion : str, Optional, Default: 'ReplicaExchange'
+        convention : str, Optional, Default: 'ReplicaExchange'
             NetCDF convention to write
+        netcdf_format : str, Optional, Default: 'NETCDF4'
+            The NetCDF file format to use
 
         """
         # Ensure we don't have already another file
@@ -260,13 +262,13 @@ class Reporter(object):
         sub_ncfiles = {}
         # TODO: Figure out how to move around the analysis file without the checkpoint file
         # Cast this to a common name space for operation below
-        primary_ncfiles['analysis'] = netcdf.Dataset(self._storage_file_analysis, mode, version='NETCDF4')
+        primary_ncfiles['analysis'] = netcdf.Dataset(self._storage_file_analysis, mode, version=netcdf_format)
         if mode == 'w':
-            sub_ncfiles['checkpoint'] = netcdf.Dataset(self._storage_file_checkpoint, mode, version='NETCDF4')
+            sub_ncfiles['checkpoint'] = netcdf.Dataset(self._storage_file_checkpoint, mode, version=netcdf_format)
         else:  # Read/append mode
             # Try to open the files in read mode, its okay if they are not there
             try:
-                sub_ncfiles['checkpoint'] = netcdf.Dataset(self._storage_file_checkpoint, mode, version='NETCDF4')
+                sub_ncfiles['checkpoint'] = netcdf.Dataset(self._storage_file_checkpoint, mode, version=netcdf_format)
                 primary_uuid = primary_ncfiles['analysis'].UUID
                 assert primary_uuid == sub_ncfiles['checkpoint'].UUID
             except IOError:  # Trap the "not on disk" warning

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -320,7 +320,7 @@ class Reporter(object):
                 ncfile.DataUsedFor = nc_name
                 ncfile.CheckpointInterval = checkpoint_interval
 
-                # Create and initilize the global variables
+                # Create and initialize the global variables
                 nc_last_good_iter = ncfile.createVariable('last_iteration', int, 'scalar')
                 nc_last_good_iter[0] = 0
                 return True
@@ -1183,7 +1183,7 @@ class Reporter(object):
         return cast_iteration
 
     @staticmethod
-    def _initilize_sampler_variables_on_file(dataset, n_atoms, n_replicas):
+    def _initialize_sampler_variables_on_file(dataset, n_atoms, n_replicas):
         """
         Initialize the NetCDF variables on the storage file needed to store sampler states.
         Does nothing if file already initilzied
@@ -1250,7 +1250,7 @@ class Reporter(object):
 
         storage = self._storage_dict[storage_file]
         # Check if the schema must be initialized, do this regardless of the checkpoint_interval for consistency
-        self._initilize_sampler_variables_on_file(storage, sampler_states[0].n_particles, len(sampler_states))
+        self._initialize_sampler_variables_on_file(storage, sampler_states[0].n_particles, len(sampler_states))
         if obey_checkpoint_interval:
             write_iteration = self._calculate_checkpoint_iteration(iteration)
         else:

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -244,10 +244,10 @@ class Reporter(object):
             dimension = self._storage_analysis.dimensions[dimname]
             if dimsize == 0:
                 if not dimension.isunlimited():
-                    raise ValueError("NetCDF dimension '%s' already exists: was previously unlimited, but tried to declare it with size %d" % (dimension.name, dimsize))
+                    raise ValueError("NetCDF dimension {} already exists: was previously unlimited, but tried to redeclare it with size {}".format(dimension.name, dimsize))
             else:
                 if not int(dimension.size) == int(dimsize):
-                    raise ValueError("NetCDF dimension '%s' already exists: was previously size %d, but tried to declare it with dimension %d" % (dimension.name, dimension.size, dimsize))
+                    raise ValueError("NetCDF dimension {} already exists: was previously size {}, but tried to redeclare it with dimension {}".format(dimension.name, dimension.size, dimsize))
 
     def open(self, mode='r', convention='ReplicaExchange', netcdf_format='NETCDF4'):
         """

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -1201,7 +1201,8 @@ class Reporter(object):
 
             # Create dimensions. Replica dimension could have been created before.
             dataset.createDimension('atom', n_atoms)
-            self._create_dimension_if_needed('replica', n_replicas)
+            if 'replica' not in dataset.dimensions:
+                dataset.createDimension('replica', n_replicas)
 
             # Create variables.
             ncvar_positions = dataset.createVariable('positions', 'f4',

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -173,7 +173,7 @@ class TestPhaseAnalyzer(object):
     def teardown_class(cls):
         shutil.rmtree(cls.tmp_dir)
 
-    def test_repex_phase_initilize(self):
+    def test_repex_phase_initialize(self):
         """Test that the Repex Phase analyzer initializes correctly"""
         phase = analyze.ReplicaExchangeAnalyzer(self.reporter, name=self.repex_name)
         assert phase.reporter is self.reporter
@@ -304,4 +304,3 @@ class TestPhaseAnalyzer(object):
         solute_trajectory = analyze.extract_trajectory(self.reporter.filepath, state_index=0, keep_solvent=False)
         assert len(solute_trajectory) == self.n_steps - 1
         assert solute_trajectory.n_atoms == len(self.analysis_atoms)
-

--- a/Yank/tests/test_repex.py
+++ b/Yank/tests/test_repex.py
@@ -460,6 +460,16 @@ class TestReporter(object):
             assert np.all(thermodynamic_states_energies == restored_ts)
             assert np.all(unsampled_states_energies == restored_us)
 
+    def test_ensure_dimension_exists(self):
+        """Test ensuring that a dimension exists works as expected."""
+        with self.temporary_reporter() as reporter:
+            # These should work fine
+            reporter._ensure_dimension_exists('dim1', 0)
+            reporter._ensure_dimension_exists('dim2', 1)
+            # These should raise an exception
+            assert_raises(ValueError, reporter._ensure_dimension_exists, 'dim1', 1)
+            assert_raises(ValueError, reporter._ensure_dimension_exists, 'dim2', 2)
+
     def test_store_dict(self):
         """Check correct storage and restore of dictionaries."""
 


### PR DESCRIPTION
This PR makes minor changes to `Reporter` so that an arbitrary number of replicas can be used.

This is the first step in implementing the SAMS sampler, but it useful to review and merge on its own.

This PR also contains some minor refactoring to reduce duplicated code, leading to overall -13 lines!