### PR TITLE
Switch analysis from u_kln to u_kn representation

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -567,7 +567,7 @@ class YankPhaseAnalyzer(ABC):
         raise NotImplementedError("This class has not implemented this function")
 
     @staticmethod
-    def sampler_state_sample_to_state_sample(u_kln: np.ndarray, n_k: Optional[np.ndarray]=None) -> np.ndarray:
+    def reformat_energies_for_mbar(u_kln: np.ndarray, n_k: Optional[np.ndarray]=None) -> np.ndarray:
         """
         Convert u_kln formatted energies into u_ln formatted energies.
 
@@ -910,11 +910,11 @@ class ReplicaExchangeAnalyzer(YankPhaseAnalyzer):
         N_k = np.zeros(nstates, np.int32)
         N = niterations  # number of uncorrelated samples
         N_k[:] = N
-        mbar_ready_energy_matrix = self.sampler_state_sample_to_state_sample(sampled_energy_matrix)
+        mbar_ready_energy_matrix = self.reformat_energies_for_mbar(sampled_energy_matrix)
         if nunsampled > 0:
             new_energy_matrix = np.zeros([nstates + 2, N_k.sum()])
             N_k_new = np.zeros(nstates + 2, np.int32)
-            unsampled_kn = self.sampler_state_sample_to_state_sample(unsampled_energy_matrix)
+            unsampled_kn = self.reformat_energies_for_mbar(unsampled_energy_matrix)
             # Add augmented unsampled energies to the new matrix
             new_energy_matrix[[0, -1], :] = unsampled_kn[[0, -1], :]
             # Fill in the old energies to the middle states

--- a/Yank/repex.py
+++ b/Yank/repex.py
@@ -1824,8 +1824,8 @@ class MultiStateSampler(object):
     # Main public interface.
     # -------------------------------------------------------------------------
 
-    title_template = 'Multi-state sampler simulation created using MultiStateSampler class '
-                     'of yank.repex on {}'
+    title_template = ('Multi-state sampler simulation created using MultiStateSampler class '
+                      'of yank.repex on {}')
 
     def create(self, thermodynamic_states, sampler_states, storage,
                initial_thermodynamic_states, unsampled_thermodynamic_states=None,
@@ -2768,8 +2768,8 @@ class ReplicaExchange(MultiStateSampler):
     replica_mixing_scheme = MultiStateSampler._StoredProperty('replica_mixing_scheme',
                                             validate_function=MultiStateSampler._StoredProperty._repex_mixing_scheme_validator)
 
-    title_template = 'Replica-exchange sampler simulation created using ReplicaExchange class '
-                     'of yank.repex.py on {}'
+    title_template = ('Replica-exchange sampler simulation created using ReplicaExchange class '
+                      'of yank.repex.py on {}')
 
     def create(self, thermodynamic_states, sampler_states, storage, **kwargs):
         """Create new multistate sampler simulation.


### PR DESCRIPTION
Simpler than I thought, but this is distinct from the pymbar assumption since the `k` is per sampler, and the `l` is thermodynamic state

All methods except the _prepare_mar_input_data use the u_kln since they only take the input data, truncate/decorrelate, then return it.