### PR TITLE
Fix whatsnew docs for 0.20.0

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,10 +6,17 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
-0.20.0 Mutations and PDBFixer
------------------------------
-- Protein Mutations can be specified through PDBFixer calls
-- Generalized PDBFixer options through the YAML molecules with `pdbfixer` directive
+0.20.0 Support for processing proteins through PDBFixer
+-------------------------------------------------------
+- Adds an optional ``pdbfixer`` directive to the ``molecules`` section of the YAML file
+  through `PDBFixer <https://github.com/pandegroup/pdbfixer>`_, a simple OpenMM-based protein structure processing tool.
+- The following options are accessible through the ``pdbfixer`` directive. `[docs] <http://getyank.org/latest/yamlpages/molecules.html#pdbfixer>`_
+
+  - ``replace_nonstandard_residues``: Replace nonstandard amino acids. `[docs] <http://getyank.org/latest/yamlpages/molecules.html#replacing-nonstandard-residues>`_
+  - ``remove_heterogens``: Remove heterogens (such as ligands and waters). `[docs] <http://getyank.org/latest/yamlpages/molecules.html#removing-heterogens>`_
+  - ``add_missing_residues``: Add missing residues from the SEQRES block. `[docs] <http://getyank.org/latest/yamlpages/molecules.html#adding-missing-residues-and-atoms-atoms>`_
+  - ``add_missing_atoms``: Add missing heavy atoms. `[docs] <http://getyank.org/latest/yamlpages/molecules.html#adding-missing-residues-and-atoms-atoms>`_
+  - ``apply_mutations``: Specify protein mutations (e.g., T315I). `[docs] <http://getyank.org/latest/yamlpages/molecules.html#mutations>`_
 
 0.19.4 Schema and Parallel Setup Fixes
 --------------------------------------
@@ -191,4 +198,3 @@ v0.6.0 (development)
 v0.5.0 (development)
 --------------------
 - Release for deployment to collaborators
-

--- a/docs/yamlpages/molecules.rst
+++ b/docs/yamlpages/molecules.rst
@@ -176,8 +176,8 @@ This directs PDBFixer to remove some heterogen residues from the PDB file:
 
 Valid Options: [none]/water/all
 
-Adding missing residues and atoms atoms
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding missing residues and atoms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Add missing atoms (including entire residues, loops, and termini).
 


### PR DESCRIPTION
This improves the "what's new" docs for 0.20.0 since I had neglected to add these in the first place.