### PR TITLE
Additional fixes for the pre-YAML hooks to SAMS branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
 branches:
   only:
     - master
+    - sams  # Temporary, TODO: Remove this when we're ready to merge SAMS branch
 
 install:
   - source devtools/travis-ci/install.sh

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1333,6 +1333,9 @@ class ExperimentBuilder(object):
             required: no
             type: boolean
             dependencies: filepath
+        pdbfixer:
+            required: no
+            dependencies: filepath
         openeye:
             required: no
             excludes: filepath

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - cerberus
     - matplotlib
     - jupyter
+    - pdbfixer
     #- gcc 4.8.2 # [linux]
     #- gcc 4.8.2 # [osx]
 
@@ -53,6 +54,7 @@ requirements:
     - cerberus
     - matplotlib
     - jupyter
+    - pdbfixer
     #- libgcc
 
 test:

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,18 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.20.0 Support for processing proteins through PDBFixer
+-------------------------------------------------------
+- Adds an optional ``pdbfixer`` directive to the ``molecules`` section of the YAML file
+  through `PDBFixer <https://github.com/pandegroup/pdbfixer>`_, a simple OpenMM-based protein structure processing tool.
+- The following options are accessible through the ``pdbfixer`` directive. `[docs] <http://getyank.org/latest/yamlpages/molecules.html#pdbfixer>`_
+
+  - ``replace_nonstandard_residues``: Replace nonstandard amino acids. `[docs] <http://getyank.org/latest/yamlpages/molecules.html#replacing-nonstandard-residues>`_
+  - ``remove_heterogens``: Remove heterogens (such as ligands and waters). `[docs] <http://getyank.org/latest/yamlpages/molecules.html#removing-heterogens>`_
+  - ``add_missing_residues``: Add missing residues from the SEQRES block. `[docs] <http://getyank.org/latest/yamlpages/molecules.html#adding-missing-residues-and-atoms-atoms>`_
+  - ``add_missing_atoms``: Add missing heavy atoms. `[docs] <http://getyank.org/latest/yamlpages/molecules.html#adding-missing-residues-and-atoms-atoms>`_
+  - ``apply_mutations``: Specify protein mutations (e.g., T315I). `[docs] <http://getyank.org/latest/yamlpages/molecules.html#mutations>`_
+
 0.19.4 Schema and Parallel Setup Fixes
 --------------------------------------
 - Fixed bug in parallel molecule setup which caused the same molecule to be setup multiple times.
@@ -186,4 +198,3 @@ v0.6.0 (development)
 v0.5.0 (development)
 --------------------
 - Release for deployment to collaborators
-

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -95,21 +95,22 @@ Detailed Options List
 
 * :doc:`molecules <molecules>`
 
-  * :ref:`Specifying Molecule Names <yaml_molecules_specify_names>`
+  * :ref:`Specifying Molecules <yaml_molecules_specify_names>`
 
-    * :ref:`filepath <yaml_molecules_filepath>` 
+    * :ref:`filepath <yaml_molecules_filepath>`
     * :ref:`smiles <yaml_molecules_smiles>`
     * :ref:`name <yaml_molecules_name>`
     * :ref:`strip_protons <yaml_molecules_strip_protons>`
+    * :ref:`pdbfixer <yaml_molecules_pdbfixer>`
     * :ref:`select <yaml_molecules_select>`
-  
+
   * :ref:`Assigning Missing Parameters <yaml_molecules_assign_charges>`
 
     * :ref:`antechamber <yaml_molecules_antechamber>`
     * :ref:`openeye <yaml_molecules_openeye>`
 
   * :ref:`Assigning Extra Information <yaml_molecules_extras>`
- 
+
     * :ref:`leap <yaml_molecules_leap>`
     * :ref:`epik <yaml_molecules_epik>`
     * :ref:`regions <yaml_molecules_regions>`
@@ -138,13 +139,13 @@ Detailed Options List
 * :doc:`systems <systems>`
 
   * :ref:`Ligand/Receptor Free Energies Setup by YANK <yaml_systems_receptor_ligand>`
-    
+
     * :ref:`ligand <yaml_systems_receptor_ligand>`
     * :ref:`receptor <yaml_systems_receptor_ligand>`
     * :ref:`solvent <yaml_systems_receptor_ligand>`
     * :ref:`pack <yaml_systems_receptor_ligand>`
     * :ref:`leap <yaml_systems_receptor_ligand>`
- 
+
       * :ref:`parameters <yaml_systems_receptor_ligand>`
 
   * :ref:`Hydration Free Energies Setup by YANK <yaml_systems_hydration>`
@@ -166,7 +167,7 @@ Detailed Options List
 * :doc:`protocols <protocols>`
 
   * :ref:`Protocols Syntax <yaml_protocols_example>`
-  
+
     * :ref:`alchemical_path <yaml_protocols_example>`
 
       * :ref:`lambda_electrostatics <yaml_protocols_alchemical_path>`
@@ -175,11 +176,11 @@ Detailed Options List
     * :ref:`Automatic alchemical path Generation <yaml_protocols_auto>`
 
   * :ref:`How-To Video <yaml_protocols_video>`
-    
+
 * :doc:`experiements <experiments>`
 
   * :ref:`Experiments Syntax <yaml_experiments_syntax>`
- 
+
     * :ref:`system <yaml_experiments_syntax>`
     * :ref:`protocol <yaml_experiments_syntax>`
     * :ref:`options <yaml_experiments_syntax>`

--- a/docs/yamlpages/molecules.rst
+++ b/docs/yamlpages/molecules.rst
@@ -3,16 +3,16 @@
 Molecules Header for YAML Files
 *******************************
 
-Everything under the ``molecules`` defines what molecules are in your systems. 
-You can specify your own molecule names. 
+Everything under the ``molecules`` defines what molecules are in your systems.
+You can specify your own molecule names.
 Because of this user defined names in the syntax examples are marked as ``{UserDefinedMolecule}``.
 
-You can define as many ``{UserDefinedMolecule}`` as you like. 
+You can define as many ``{UserDefinedMolecule}`` as you like.
 These molecules will be used in other YAML headed sections.
 
-Unlike the primary :doc:`options <options>` for YAML files, 
-many of these settings are optional and do nothing if not specified. 
-The mandatory/optional of each setting (and what conditionals), 
+Unlike the primary :doc:`options <options>` for YAML files,
+many of these settings are optional and do nothing if not specified.
+The mandatory/optional of each setting (and what conditionals),
 as well as the default behavior of each setting is explicitly stated in the setting's description.
 
 All of the molecules will be built, even if they are not used in a later system, so ensure your molecules do not
@@ -22,8 +22,8 @@ have errors or are commented out.
 
 .. _yaml_molecules_specify_names:
 
-Specifying Molecule Names
-=========================
+Specifying Molecules
+====================
 
 .. _yaml_molecules_filepath:
 
@@ -45,8 +45,8 @@ way to specify the charges, proteins however can rely on built in force field pa
 
 Valid Filetypes: PDB, mol2, sdf, cvs
 
-**Note:** If CVS is specified and there is only one moleucle, the first column must be a SMILES string. 
-If multiple molecules are to be used (for the :doc:`!Combinatorial <combinatorial>` ability), 
+**Note:** If CVS is specified and there is only one moleucle, the first column must be a SMILES string.
+If multiple molecules are to be used (for the :doc:`!Combinatorial <combinatorial>` ability),
 then each row is its own molecule where the second column is the SMILES string.
 
 
@@ -63,7 +63,7 @@ then each row is its own molecule where the second column is the SMILES string.
      {UserDefinedMolecule}:
        smiles: c1ccccc1
 
-YANK can process SMILES stings to build the molecule as well. Usually only recommended for small ligands. 
+YANK can process SMILES stings to build the molecule as well. Usually only recommended for small ligands.
 Requires that the OpenEye Toolkits are installed.
 
 **MANDATORY** but exclusive with :ref:`filepath <yaml_molecules_filepath>` and :ref:`name <yaml_molecules_name>`
@@ -101,14 +101,143 @@ YANK can process raw molecule name if the OpenEye Toolkits are installed
      {UserDefinedMolecule}:
        strip_protons: no
 
-Specifies if LEaP will re-add all hydrogen atoms. 
-This is helpful if the PDB contains atom names for hydrogens that AMBER does not recognize. 
+Specifies if LEaP will re-add all hydrogen atoms.
+This is helpful if the PDB contains atom names for hydrogens that AMBER does not recognize.
 Primarily for proteins, not small molecules.
 
 **OPTIONAL** and defaults to ``no``
 
 Valid Options: [no]/yes
 
+
+
+
+.. _yaml_molecules_pdbfixer:
+
+.. rst-class:: html-toggle
+
+``pdbfixer``
+------------
+
+.. code-block:: yaml
+
+   molecules:
+     {UserDefinedMolecule}:
+       pdbfixer:
+         replace_nonstandard_residues: no
+         remove_heterogens: none
+         add_missing_residues: no
+         add_missing_atoms: none
+         apply_mutations:
+           mutations: T315I
+           chain_id: A
+
+Specifies whether PDBFixer should be used to modify the molecule.
+Can only be used on proteins, on files with ``.pdb`` file extensions.
+
+Replacing nonstandard residues
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+   molecules:
+     {UserDefinedMolecule}:
+       pdbfixer:
+         replace_nonstandard_residues: yes
+
+Options are:
+
+* ``yes`` : replace nonstandard amino acid residues will be replaced with one of the 20 standard amino acids according to the scheme used by `PDBFixer <http://htmlpreview.github.io/?https://raw.github.com/pandegroup/pdbfixer/master/Manual.html>`_
+* ``no`` : don't replace residues
+
+**OPTIONAL** with default value of ``no``
+
+Valid Options: [no]/yes
+
+Removing heterogens
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+   molecules:
+     {UserDefinedMolecule}:
+       pdbfixer:
+         remove_heterogens: all
+
+Valid options: ``[none] | water | all``
+
+This directs PDBFixer to remove some heterogen residues from the PDB file:
+
+* ``all`` : all heterogens (residues that are not one of the standard amino acids) will be removed
+* ``water`` : only water residues will be removed
+* ``none`` : no residues will be removed
+
+**OPTIONAL** with default value of ``none``
+
+Valid Options: [none]/water/all
+
+Adding missing residues and atoms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add missing atoms (including entire residues, loops, and termini).
+
+**WARNING:** PDBFixer uses a very simple approach to adding missing residues that will only
+produce sensible geometries in the simplest of cases. Use this option with caution.
+
+.. code-block:: yaml
+
+   molecules:
+     {UserDefinedMolecule}:
+       pdbfixer:
+         add_missing_residues: yes
+         add_missing_atoms: heavy
+         ph: 7.4
+
+``add_missing_residues`` specifies whether missing residues should be added
+
+* ``no`` : only missing atoms in existing residues will be added (DEFAULT)
+* ``yes`` : missing residues specified in SEQRES will be added
+
+``add_missing_atoms`` specifies which detected missing atoms should be added:
+
+* ``none`` : no missing atoms will be added
+* ``heavy`` : only heavy atoms will be added (DEFAULT)
+* ``hydrogens`` : add only hydrogens (not recommended)
+* ``all`` : all missing atoms (including hydrogens) will be added (not recommended)
+
+``ph`` specifies the pH to be used for adding hydrogens (default: 7.4)
+
+**OPTIONAL**
+
+Mutations
+^^^^^^^^^
+
+Make the directed mutations to amino acid residues.
+
+.. code-block:: yaml
+
+   molecules:
+     {UserDefinedMolecule}:
+       pdbfixer:
+         apply_mutations:
+           mutations: T315I
+           chain_id: A
+
+Mutations are specified using the format ``<original-one-letter-code><resid><new-one-letter-code>``,
+with the character ``/`` being an optional separator if multiple mutations are desired.
+
+The initial PDB file numbering is used for residue identifier ``resid``.
+
+Examples for specifying ``mutations:``:
+
+* ``T315I`` : a single mutation that changes Thr at resid 315 to Ile
+* ``L858R/T790M`` : a double mutation
+
+If ``chain_id`` is not specified, it defaults to ``null`` (no chain designator).
+
+PDBFixer is applied after ``strip_protons`` if both are requested.
+
+**OPTIONAL**
 
 
 
@@ -126,8 +255,8 @@ Valid Options: [no]/yes
        antechamber:
            charge_method: bcc
        select: !Combinatorial [0, 3]
-       
-The "select" keyword works the same way if you specify a 
+
+The "select" keyword works the same way if you specify a
 pdb, mol2, sdf, or cvs file containing multiple structures.
 ``select`` has 3 modes:
 
@@ -234,17 +363,17 @@ Assigning Extra Information
        leap:
          parameters: [mymol.frcmod, mymol.off]
 
-Load molecule-specific force field parameters into the molecule. 
-These can be created from any source so long as leap can parse them. 
-It is possible to assign partial charges with the files read in this way, 
-which would supersede the options of 
-:ref:`antechamber <yaml_molecules_antechamber>` 
+Load molecule-specific force field parameters into the molecule.
+These can be created from any source so long as leap can parse them.
+It is possible to assign partial charges with the files read in this way,
+which would supersede the options of
+:ref:`antechamber <yaml_molecules_antechamber>`
 and :ref:`openeye <yaml_molecules_openeye>`.
 
-This command has only one mandatory subargument ``parameters``, 
-which can accept both single files as a string, 
-or can accept a comma separated list of files enclosed by [ ]. 
-Filepaths are relative to either the AmberTools default paths or to the folder the YAML script is in. 
+This command has only one mandatory subargument ``parameters``,
+which can accept both single files as a string,
+or can accept a comma separated list of files enclosed by [ ].
+Filepaths are relative to either the AmberTools default paths or to the folder the YAML script is in.
 
 *Note*: Proteins do not necessarily   need this command if the force fields given to the :ref:`leap argument in systems <yaml_systems_head>` will fully describe them.
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.20.1"  # Primary base version of the build
+VERSION = "0.21.0"  # Primary base version of the build
 DEVBUILD = 0  # Dev build status, Either None or Integer
 ISRELEASED = False  # Are we releasing this as a full cut?
 __version__ = VERSION

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.19.5"  # Primary base version of the build
-DEVBUILD = "0"  # Dev build status, Either None or Integer as string
+VERSION = "0.20.1"  # Primary base version of the build
+DEVBUILD = 0  # Dev build status, Either None or Integer
 ISRELEASED = False  # Are we releasing this as a full cut?
 __version__ = VERSION
 ########################
@@ -80,7 +80,7 @@ release = {isrelease:s}
     # otherwise the import of numpy.version messes up the build under Python 3.
     base_version = VERSION
     if DEVBUILD is not None and DEVBUILD != "None":
-        local_version = base_version + ".dev" + DEVBUILD
+        local_version = base_version + ".dev{}".format(DEVBUILD)
     else:
         local_version = base_version
     full_version = local_version
@@ -153,6 +153,7 @@ setup(
         'openmoltools>=0.7.5',
         'mdtraj',
         'pyyaml',
+        'pdbfixer'
         ],
     ext_modules=cythonize(mixing_ext),
     entry_points={'console_scripts': ['yank = yank.cli:main']})


### PR DESCRIPTION
* Fix `n_states` > `n_samplers`
* Bring ParallelTempering up to a working state again
* Auto-test ParallelTempering
* Add test for `n_states` > `n_samplers`
* Add test for `n_states` < `n_samplers`
* Change default state distribution among samplers to all conditions.
* Update setup.py for 0.21.0
* Merged the PDB fixer changes in master to this branch
* Added special condition travis branch to test PR's into `SAMS` branch (remove when done)

@jchodera if you want to give this a quick look over (changes in `repex.py` and `test_repex` only, the rest are all the PDBFIxer feature)