### PR TITLE
AbsoluteAlchemicalFactory options and CUDA deterministic forces

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2260,6 +2260,10 @@ class ExperimentBuilder(object):
         else:
             platform = openmm.Platform.getPlatformByName(platform_name)
 
+        # Set CUDA DeterministicForces (necessary for MBAR).
+        if platform_name == 'CUDA':
+            platform.setPropertyDefaultValue('DeterministicForces', 'true')
+
         # Use only a single CPU thread if we are using the CPU platform.
         # TODO: Since there is an environment variable that can control this,
         # TODO: we may want to avoid doing this.

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -889,7 +889,7 @@ class ExperimentBuilder(object):
 
         for experiment_idx, (exp_path, exp_description) in enumerate(self._expand_experiments()):
             # Determine the final number of iterations for this experiment.
-            _, _, sampler_options, _ = self._determine_experiment_options(exp_description)
+            _, _, sampler_options, _, _ = self._determine_experiment_options(exp_description)
             number_of_iterations = sampler_options['number_of_iterations']
 
             # Determine the phases status.
@@ -991,6 +991,8 @@ class ExperimentBuilder(object):
             The options to pass to the ReplicaExchange constructor.
         alchemical_region_options : dict
             The options to pass to AlchemicalRegion.
+        alchemical_factory_options : dict
+            The options to pass to AlchemicalFactory.
 
         """
         # First discard general options.
@@ -1009,8 +1011,11 @@ class ExperimentBuilder(object):
         phase_options = _filter_options(AlchemicalPhaseFactory.DEFAULT_OPTIONS)
         sampler_options = _filter_options(utils.get_keyword_args(repex.ReplicaExchange.__init__))
         alchemical_region_options = _filter_options(mmtools.alchemy._ALCHEMICAL_REGION_ARGS)
+        alchemical_factory_options = _filter_options(utils.get_keyword_args(
+            mmtools.alchemy.AbsoluteAlchemicalFactory.__init__))
 
-        return experiment_options, phase_options, sampler_options, alchemical_region_options
+        return (experiment_options, phase_options, sampler_options,
+                alchemical_region_options, alchemical_factory_options)
 
     # --------------------------------------------------------------------------
     # Combinatorial expansion
@@ -1197,6 +1202,8 @@ class ExperimentBuilder(object):
         template_options.update(AlchemicalPhaseFactory.DEFAULT_OPTIONS)
         template_options.update(mmtools.alchemy._ALCHEMICAL_REGION_ARGS)
         template_options.update(utils.get_keyword_args(repex.ReplicaExchange.__init__))
+        template_options.update(utils.get_keyword_args(
+            mmtools.alchemy.AbsoluteAlchemicalFactory.__init__))
 
         if validate_general_options is True:
             template_options.update(cls.GENERAL_DEFAULT_OPTIONS.copy())
@@ -1207,6 +1214,7 @@ class ExperimentBuilder(object):
         template_options.pop('alchemical_bonds')
         template_options.pop('alchemical_angles')
         template_options.pop('alchemical_torsions')
+        template_options.pop('switch_width')  # AbsoluteAlchemicalFactory
 
         # Some options need to be treated differently.
         def integer_or_infinity(value):
@@ -2635,11 +2643,15 @@ class ExperimentBuilder(object):
 
         # Get and validate experiment sub-options and divide them by class.
         exp_opts = self._determine_experiment_options(experiment)
-        exp_opts, phase_opts, sampler_opts, alchemical_region_opts = exp_opts
+        (exp_opts, phase_opts, sampler_opts,
+         alchemical_region_opts, alchemical_factory_opts) = exp_opts
 
         # Configure logger file for this experiment.
         experiment_log_file_path = self._get_experiment_log_path(experiment_path)
         utils.config_root_logger(self._options['verbose'], experiment_log_file_path)
+
+        # Initialize alchemical factory.
+        alchemical_factory = mmtools.alchemy.AbsoluteAlchemicalFactory(**alchemical_factory_opts)
 
         # Get ligand resname for alchemical atom selection. If we can't
         # find it, this is a solvation free energy calculation.
@@ -2825,7 +2837,7 @@ class ExperimentBuilder(object):
             phases[phase_idx] = AlchemicalPhaseFactory(sampler, thermodynamic_state, sampler_state,
                                                        topography, phase_protocol, storage=phase_path,
                                                        restraint=restraint, alchemical_regions=alchemical_region,
-                                                       **phase_opts)
+                                                       alchemical_factory=alchemical_factory, **phase_opts)
 
         # Dump analysis script
         results_dir = self._get_experiment_dir(experiment_path)

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -452,6 +452,8 @@ class Experiment(object):
         # Handle case in which we don't alternate between phases.
         if self.switch_phase_interval <= 0:
             switch_phase_interval = self.number_of_iterations
+        else:
+            switch_phase_interval = self.switch_phase_interval
 
         # Count down the iterations to run.
         iterations_left = [None, None]

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -280,8 +280,8 @@ def find_alchemical_counterions(system, topography, region_name):
     ions_net_charges = [(ion_id, compute_net_charge(system, [ion_id]))
                         for ion_id in topography.ions_atoms]
     topology = topography.topology
-    ions_names_charges = [(topology.atom(ion_id).residue.name, ions_net_charges[ion_id])
-                          for ion_id in ions_net_charges]
+    ions_names_charges = [(topology.atom(ion_id).residue.name, ion_net_charge)
+                          for ion_id, ion_net_charge in ions_net_charges]
     logger.debug('Ions net charges: {}'.format(ions_names_charges))
 
     # Find minimal subset of counterions whose charges sums to -mol_net_charge.

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -277,8 +277,8 @@ def find_alchemical_counterions(system, topography, region_name):
         return []
 
     # Find net charge of all ions in the system.
-    ions_net_charges = {ion_id: compute_net_charge(system, [ion_id])
-                        for ion_id in topography.ions_atoms}
+    ions_net_charges = [(ion_id, compute_net_charge(system, [ion_id]))
+                        for ion_id in topography.ions_atoms]
     topology = topography.topology
     ions_names_charges = [(topology.atom(ion_id).residue.name, ions_net_charges[ion_id])
                           for ion_id in ions_net_charges]
@@ -286,7 +286,7 @@ def find_alchemical_counterions(system, topography, region_name):
 
     # Find minimal subset of counterions whose charges sums to -mol_net_charge.
     for n_ions in range(1, len(ions_net_charges) + 1):
-        for ion_subset in itertools.combinations(ions_net_charges.items(), n_ions):
+        for ion_subset in itertools.combinations(ions_net_charges, n_ions):
             counterions_indices, counterions_charges = zip(*ion_subset)
             if sum(counterions_charges) == -mol_net_charge:
                 return counterions_indices

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -1891,7 +1891,7 @@ def test_setup_multiple_parameters_system():
 # Platform configuration tests
 # ==============================================================================
 
-def test_platform_precision_configuration():
+def test_platform_configuration():
     """Test that the precision for platform is configured correctly."""
     available_platforms = [openmm.Platform.getPlatform(i).getName()
                            for i in range(openmm.Platform.getNumPlatforms())]
@@ -1913,6 +1913,7 @@ def test_platform_precision_configuration():
                 platform = exp_builder._configure_platform(platform_name=platform_name,
                                                             platform_precision=precision)
                 assert platform.getPropertyDefaultValue('CudaPrecision') == precision
+                assert platform.getPropertyDefaultValue('DeterministicForces') == 'true'
             elif platform_name == 'OpenCL':
                 if ExperimentBuilder._opencl_device_support_precision(precision):
                     platform = exp_builder._configure_platform(platform_name=platform_name,

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -356,10 +356,12 @@ def test_yaml_parsing():
         replica_mixing_scheme: null
         annihilate_sterics: no
         annihilate_electrostatics: true
+        alchemical_pme_treatment: direct-space
+        disable_alchemical_dispersion_correction: no
     """
 
     exp_builder = ExperimentBuilder(textwrap.dedent(yaml_content))
-    assert len(exp_builder._options) == 33
+    assert len(exp_builder._options) == 35
 
     # Check correct types
     assert exp_builder._options['output_dir'] == '/path/to/output/'
@@ -1943,6 +1945,32 @@ def test_default_platform_precision():
                 assert platform.getPropertyDefaultValue('OpenCLPrecision') == 'mixed'
             else:
                 assert platform.getPropertyDefaultValue('OpenCLPrecision') == 'single'
+
+
+# ==============================================================================
+# Experiment building
+# ==============================================================================
+
+def test_alchemical_phase_factory_building():
+    """Test that options are passed to AlchemicalPhaseFactory correctly."""
+    with mmtools.utils.temporary_directory() as tmp_dir:
+        template_script = get_template_script(tmp_dir)
+
+        # Remove systems we don't need to setup.
+        del template_script['systems']['explicit-system']
+        del template_script['systems']['hydration-system']
+        template_script['experiments']['system'] = 'implicit-system'
+
+        # AbsoluteAlchemicalFactory options.
+        template_script['options']['alchemical_pme_treatment'] = 'exact'
+        template_script['options']['disable_alchemical_dispersion_correction'] = True
+
+        # Test that options are passed to AlchemicalPhaseFactory correctly.
+        exp_builder = ExperimentBuilder(script=template_script)
+        for experiment in exp_builder.build_experiments():
+            for phase_factory in experiment.phases:
+                assert phase_factory.alchemical_factory.alchemical_pme_treatment == 'exact'
+                assert phase_factory.alchemical_factory.disable_alchemical_dispersion_correction == True
 
 
 # ==============================================================================

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -1333,7 +1333,8 @@ class AlchemicalPhase(object):
         # counterions to make sure that the solvation box is always neutral.
         if system.usesPeriodicBoundaryConditions():
             alchemical_counterions = mpi.run_single_node(0, pipeline.find_alchemical_counterions,
-                                                         system, topography, alchemical_region_name)
+                                                         system, topography, alchemical_region_name,
+                                                         broadcast_result=True)
             alchemical_atoms += alchemical_counterions
 
             # Sort them by index for safety. We don't want to

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -1332,8 +1332,8 @@ class AlchemicalPhase(object):
         # In periodic systems, we alchemically modify the ligand/solute
         # counterions to make sure that the solvation box is always neutral.
         if system.usesPeriodicBoundaryConditions():
-            alchemical_counterions = pipeline.find_alchemical_counterions(
-                system, topography, alchemical_region_name)
+            alchemical_counterions = mpi.run_single_node(0, pipeline.find_alchemical_counterions,
+                                                         system, topography, alchemical_region_name)
             alchemical_atoms += alchemical_counterions
 
             # Sort them by index for safety. We don't want to


### PR DESCRIPTION
I still have to update the `whatsnew` file and the docs, but the implementation is ready for review.
- Add `AbsoluteAlchemicalFactory` options to YAML
- Fix #849: Set CUDA platform to use deterministic forces
- Fixes a bug that we missed when transitioning to Python3 where parallel MPI processes may pick a different counterion to alchemically modify due to the non-deterministic order of dictionaries.