### PR TITLE
Add neighborhood support to MultiStateSampler and ReplicaExchange

### DIFF
--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -183,7 +183,7 @@ class ObservablesRegistry(object):
     # Define the observables
     ########################
     @property
-    def observables(self) -> tuple:
+    def observables(self):
         """
         Set of observables which are derived from the subsets below
         """
@@ -198,21 +198,21 @@ class ObservablesRegistry(object):
     # ------------------------------------------------
 
     @property
-    def observables_defined_by_two_states(self) -> tuple:
+    def observables_defined_by_two_states(self):
         """
         Observables that require an i and a j state to define the observable accurately between phases
         """
         return self._get_observables('two_state')
 
     @property
-    def observables_defined_by_single_state(self) -> tuple:
+    def observables_defined_by_single_state(self):
         """
         Defined observables which are fully defined by a single state, and not by multiple states such as differences
         """
         return self._get_observables('one_state')
 
     @property
-    def observables_defined_by_phase(self) -> tuple:
+    def observables_defined_by_phase(self):
         """
         Observables which are defined by the phase as a whole, and not defined by any 1 or more states
         e.g. Standard State Correction
@@ -225,7 +225,7 @@ class ObservablesRegistry(object):
     ##########################################
 
     @property
-    def observables_with_error(self) -> tuple:
+    def observables_with_error(self):
         """Determine which observables have error by inspecting the the error subsets"""
         observables = set()
         for subset_key in self._errors:
@@ -239,27 +239,27 @@ class ObservablesRegistry(object):
     # ------------------------------------------------
 
     @property
-    def observables_with_error_adding_quadrature(self) -> tuple:
+    def observables_with_error_adding_quadrature(self):
         """Observable C = A + B, Error eC = sqrt(eA**2 + eB**2)"""
         return self._get_errors('quad')
 
     @property
-    def observables_with_error_adding_linear(self) -> tuple:
+    def observables_with_error_adding_linear(self):
         """Observable C = A + B, Error eC = eA + eB"""
         return self._get_errors('linear')
 
     @property
-    def observables_without_error(self) -> tuple:
+    def observables_without_error(self):
         return self._get_errors(None)
 
     # ------------------
     # Internal functions
     # ------------------
 
-    def _get_observables(self, key) -> tuple:
+    def _get_observables(self, key):
         return tuple(self._observables[key])
 
-    def _get_errors(self, key) -> tuple:
+    def _get_errors(self, key):
         return tuple(self._errors[key])
 
     @staticmethod

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -829,7 +829,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         """
         logger.info("Reading energies...")
         # Returns the energies in kln format
-        energy_thermodynamic_states, energy_unsampled_states = self._reporter.read_energies()
+        energy_thermodynamic_states, neighborhoods, energy_unsampled_states = self._reporter.read_energies()
         n_iterations, n_replicas, n_states = energy_thermodynamic_states.shape
         _, _, n_unsampled_states = energy_unsampled_states.shape
         energy_matrix_replica = np.zeros([n_replicas, n_states, n_iterations], np.float64)

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -545,7 +545,7 @@ class PhaseAnalyzer(ABC):
         raise NotImplementedError("This class has not implemented this function")
 
     @staticmethod
-    def reformat_energies_for_mbar(u_kln: np.ndarray, n_k: Optional[np.ndarray]=None) -> np.ndarray:
+    def reformat_energies_for_mbar(u_kln: np.ndarray, n_k: Optional[np.ndarray]=None):
         """
         Convert u_kln formatted energies into u_ln formatted energies.
 

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -163,17 +163,18 @@ class ObservablesRegistry(object):
         ----------
         name: str
             Name of the observable, will be cast to all lower case and spaces replaced with underscores
-        error_class: "quad", "linear", or None
+        error_class: 'quad', 'linear', or None
             How the error of the observable is computed when added with other errors from the same observable.
 
-            * "quad": Adds in the quadrature, Observable C = A + B, Error eC = sqrt(eA**2 + eB**2)
+            * 'quad': Adds in the quadrature, Observable C = A + B, Error eC = sqrt(eA**2 + eB**2)
 
-            * "linear": Adds linearly,  Observable C = A + B, Error eC = eA + eB
+            * 'linear': Adds linearly,  Observable C = A + B, Error eC = eA + eB
 
             * None: Does not carry error
 
         re_register: bool, optional, Default: False
             Re-register an existing observable
+
         """
 
         self._register_observable(name, "phase", error_class, re_register=re_register)

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -54,6 +54,8 @@ logger = logging.getLogger(__name__)
 # MULTISTATE SAMPLER REPORTER
 # ==============================================================================
 
+MISSING_VALUE = np.NaN # value for populating missing/masked values
+
 class MultiStateReporter(object):
     """Handle storage write/read operations and different format conventions.
 
@@ -707,7 +709,6 @@ class MultiStateReporter(object):
         """
         iteration = self._calculate_last_iteration(iteration)
         energy_thermodynamic_states = self._storage_analysis.variables['energies'][iteration, :, :]
-        energy_thermodynamic_states = self._storage_analysis.variables['energies'][iteration, :, :]
         try:
             energy_unsampled_states = self._storage_analysis.variables['unsampled_energies'][iteration, :, :]
         except KeyError:
@@ -745,6 +746,8 @@ class MultiStateReporter(object):
                                                                    ('iteration', 'replica', 'state'),
                                                                    zlib=False,
                                                                    chunksizes=(1, n_replicas, n_states))
+            ncvar_energies.missing_value = MISSING_VALUE
+            ncvar_energies.set_auto_mask(True)
             ncvar_energies.units = 'kT'
             ncvar_energies.long_name = ("energies[iteration][replica][state] is the reduced (unitless) "
                                         "energy of replica 'replica' from iteration 'iteration' evaluated "

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # MULTISTATE SAMPLER REPORTER
 # ==============================================================================
 
-MISSING_VALUE = np.NaN # value for populating missing/masked values
+MISSING_VALUE = np.inf # value for populating missing values
 
 class MultiStateReporter(object):
     """Handle storage write/read operations and different format conventions.
@@ -749,7 +749,7 @@ class MultiStateReporter(object):
                                                                    'f8',
                                                                    ('iteration', 'replica', 'state'),
                                                                    zlib=False,
-                                                                   fill_value=0.0,
+                                                                   fill_value=MISSING_VALUE,
                                                                    chunksizes=(1, n_replicas, n_states))
             ncvar_energies.units = 'kT'
             ncvar_energies.long_name = ("energies[iteration][replica][state] is the reduced (unitless) "
@@ -1116,9 +1116,9 @@ class MultiStateReporter(object):
             online_group = analysis_nc.createGroup('online_analysis')
             # larger chunks, faster operations, small matrix anyways
             online_group.createVariable('f_k', float, dimensions=('iteration', 'f_k_length'),
-                                        zlib=True, chunksizes=(1, len(f_k)), fill_value=np.inf)
+                                        zlib=True, chunksizes=(1, len(f_k)), fill_value=MISSING_VALUE)
             online_group.createVariable('free_energy', float, dimensions=('iteration', 'Df'),
-                                        zlib=True, chunksizes=(1, 2), fill_value=np.inf)
+                                        zlib=True, chunksizes=(1, 2), fill_value=MISSING_VALUE)
         online_group = analysis_nc.groups['online_analysis']
         online_group.variables['f_k'][iteration] = f_k
         online_group.variables['free_energy'][iteration, :] = free_energy

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -710,9 +710,16 @@ class MultiStateReporter(object):
             ``sampler_states[iteration, i]`` and ThermodynamicState ``unsampled_thermodynamic_states[iteration, j]``.
 
         """
+        # Determine last consistent iteration
         iteration = self._calculate_last_iteration(iteration)
+        # Retrieve energies at all thermodynamic states
         energy_thermodynamic_states = np.array(self._storage_analysis.variables['energies'][iteration, :, :], np.float64)
-        energy_neighborhoods = np.array(self._storage_analysis.variables['neighborhoods'][iteration, :, :], 'i1')
+        # Retrieve neighborhoods, assuming global neighborhoods if reading a pre-neighborhoods file
+        try:
+            energy_neighborhoods = np.array(self._storage_analysis.variables['neighborhoods'][iteration, :, :], 'i1')
+        except KeyError:
+            energy_neighborhoods = np.ones(energy_thermodynamic_states.shape, 'i1')
+        # Read energies at unsampled states, if present
         try:
             energy_unsampled_states = np.array(self._storage_analysis.variables['unsampled_energies'][iteration, :, :], np.float64)
         except KeyError:

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -707,6 +707,7 @@ class MultiStateReporter(object):
         """
         iteration = self._calculate_last_iteration(iteration)
         energy_thermodynamic_states = self._storage_analysis.variables['energies'][iteration, :, :]
+        energy_thermodynamic_states = self._storage_analysis.variables['energies'][iteration, :, :]
         try:
             energy_unsampled_states = self._storage_analysis.variables['unsampled_energies'][iteration, :, :]
         except KeyError:

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # MULTISTATE SAMPLER REPORTER
 # ==============================================================================
 
-MISSING_VALUE = np.inf # value for populating missing values
+MISSING_VALUE = np.NaN # value for populating missing values
 
 class MultiStateReporter(object):
     """Handle storage write/read operations and different format conventions.

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -702,22 +702,26 @@ class MultiStateReporter(object):
         energy_thermodynamic_states : n_replicas x n_states numpy.ndarray
             ``energy_thermodynamic_states[iteration, i, j]`` is the reduced potential computed at
             SamplerState ``sampler_states[iteration, i]`` and ThermodynamicState ``thermodynamic_states[iteration, j]``.
+        energy_neighborhoods : n_replicas x n_states numpy.ndarray
+            energy_neighborhoods[replica_index, state_index] is 1 if the energy was computed for this state,
+            0 otherwise
         energy_unsampled_states : n_replicas x n_unsampled_states numpy.ndarray
             ``energy_unsampled_states[iteration, i, j]`` is the reduced potential computed at SamplerState
             ``sampler_states[iteration, i]`` and ThermodynamicState ``unsampled_thermodynamic_states[iteration, j]``.
 
         """
         iteration = self._calculate_last_iteration(iteration)
-        energy_thermodynamic_states = self._storage_analysis.variables['energies'][iteration, :, :]
+        energy_thermodynamic_states = np.array(self._storage_analysis.variables['energies'][iteration, :, :], np.float64)
+        energy_neighborhoods = np.array(self._storage_analysis.variables['neighborhoods'][iteration, :, :], 'i1')
         try:
-            energy_unsampled_states = self._storage_analysis.variables['unsampled_energies'][iteration, :, :]
+            energy_unsampled_states = np.array(self._storage_analysis.variables['unsampled_energies'][iteration, :, :], np.float64)
         except KeyError:
             # There are no unsampled thermodynamic states.
             unsampled_shape = energy_thermodynamic_states.shape[:-1] + (0,)
             energy_unsampled_states = np.zeros(unsampled_shape)
-        return energy_thermodynamic_states, energy_unsampled_states
+        return energy_thermodynamic_states, energy_neighborhoods, energy_unsampled_states
 
-    def write_energies(self, energy_thermodynamic_states, energy_unsampled_states, iteration):
+    def write_energies(self, energy_thermodynamic_states, energy_neighborhoods, energy_unsampled_states, iteration):
         """Store the energy matrix at the given iteration on the analysis file
 
         Parameters
@@ -725,6 +729,9 @@ class MultiStateReporter(object):
         energy_thermodynamic_states : n_replicas x n_states numpy.ndarray
             ``energy_thermodynamic_states[i][j]`` is the reduced potential computed at
             SamplerState ``sampler_states[i]`` and ThermodynamicState ``thermodynamic_states[j]``.
+        energy_neighborhoods : n_replicas x n_states numpy.ndarray
+            energy_neighborhoods[replica_index, state_index] is 1 if the energy was computed for this state,
+            0 otherwise
         energy_unsampled_states : n_replicas x n_unsampled_states numpy.ndarray
             ``energy_unsampled_states[i][j]`` is the reduced potential computed at SamplerState
             ``sampler_states[i]`` and ThermodynamicState ``unsampled_thermodynamic_states[j]``.
@@ -732,34 +739,40 @@ class MultiStateReporter(object):
             The iteration at which to store the data.
 
         """
-        # Initialize schema if needed.
+        n_replicas, n_states = energy_thermodynamic_states.shape
+
+        # Create dimensions and variables if they weren't created by other functions.
+        self._ensure_dimension_exists('replica', n_replicas)
+        self._ensure_dimension_exists('state', n_states)
         if 'energies' not in self._storage_analysis.variables:
-            n_replicas, n_states = energy_thermodynamic_states.shape
-
-            # Create dimensions if they weren't created by other functions.
-            self._ensure_dimension_exists('replica', n_replicas)
-            self._ensure_dimension_exists('state', n_states)
-
-            # Create variable for thermodynamic state energies with units and descriptions.
             ncvar_energies = self._storage_analysis.createVariable('energies',
                                                                    'f8',
                                                                    ('iteration', 'replica', 'state'),
                                                                    zlib=False,
+                                                                   fill_value=0.0,
                                                                    chunksizes=(1, n_replicas, n_states))
-            ncvar_energies.missing_value = MISSING_VALUE
-            ncvar_energies.set_auto_mask(True)
             ncvar_energies.units = 'kT'
             ncvar_energies.long_name = ("energies[iteration][replica][state] is the reduced (unitless) "
                                         "energy of replica 'replica' from iteration 'iteration' evaluated "
                                         "at the thermodynamic state 'state'.")
 
+        if 'neighborhoods' not in self._storage_analysis.variables:
+            ncvar_neighborhoods = self._storage_analysis.createVariable('neighborhoods',
+                                                                   'i1',
+                                                                   ('iteration', 'replica', 'state'),
+                                                                   zlib=False,
+                                                                   fill_value=1, # old-style files will be upgraded to have all states
+                                                                   chunksizes=(1, n_replicas, n_states))
+            ncvar_neighborhoods.long_name = ("neighborhoods[iteration][replica][state] is 1 if this energy was computed "
+                                             "during this iteration.")
+
+        if 'unsampled_energies' not in self._storage_analysis.variables:
             # Check if we have unsampled states.
             if energy_unsampled_states.shape[1] > 0:
-                if 'unsampled_energies' not in self._storage_analysis.variables:
-                    n_unsampled_states = len(energy_unsampled_states[0])
+                n_unsampled_states = len(energy_unsampled_states[0])
+                self._ensure_dimension_exists('unsampled', n_unsampled_states)
 
-                    # Create replica dimension if it wasn't created by other functions.
-                    self._ensure_dimension_exists('unsampled', n_unsampled_states)
+                if 'unsampled_energies' not in self._storage_analysis.variables:
 
                     # Create variable for thermodynamic state energies with units and descriptions.
                     ncvar_unsampled = self._storage_analysis.createVariable('unsampled_energies',
@@ -775,8 +788,9 @@ class MultiStateReporter(object):
                                                  "(unitless) energy of replica 'replica' from iteration 'iteration' "
                                                  "evaluated at unsampled thermodynamic state 'state'.")
 
-        # Store states energy.
-        self._storage_analysis.variables['energies'][iteration, :, :] = energy_thermodynamic_states[:, :]
+        # Store values
+        self._storage_analysis.variables['energies'][iteration,:,:] = energy_thermodynamic_states
+        self._storage_analysis.variables['neighborhoods'][iteration,:,:] = energy_neighborhoods
         if energy_unsampled_states.shape[1] > 0:
             self._storage_analysis.variables['unsampled_energies'][iteration, :, :] = energy_unsampled_states[:, :]
 

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1351,7 +1351,7 @@ class MultiStateSampler(object):
         logZ[:] -= logZ[0]
 
         self._last_mbar_f_k = -logZ
-        free_energy = free_energy[idx, jdx]
+        free_energy = self._last_mbar_f_k[-1] - self._last_mbar_f_k[0]
         self._last_err_free_energy = np.Inf
 
         # Store free energy estimate

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1199,7 +1199,7 @@ class MultiStateSampler(object):
         neighborhood = self._neighborhood(state_index)
 
         # Compute energy for all thermodynamic states.
-        for energies, states in [(energy_thermodynamic_states, self._thermodynamic_states[neighborhood]),
+        for energies, states in [(energy_thermodynamic_states[neighborhood], self._thermodynamic_states[neighborhood]),
                                  (energy_unsampled_states, self._unsampled_states)]:
             # Group thermodynamic states by compatibility.
             compatible_groups, original_indices = mmtools.states.group_by_compatibility(states)

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1337,14 +1337,13 @@ class MultiStateSampler(object):
 
         logZ = - self._last_mbar_f_k
 
-        for (replica_index, state_index) in self._replica_thermodynamic_states:
+        for (replica_index, state_index) in enumerate(self._replica_thermodynamic_states):
             neighborhood = self._neighborhood(state_index)
             u_k = self._energy_thermodynamic_states[state_index,:]
             log_P_k = np.zeros([self.n_states], np.float64)
             log_pi_k = np.zeros([self.n_states], np.float64)
             log_weights = np.zeros([self.n_states], np.float64)
-            for j in neighborhood:
-                log_P_k[j] = log_weights[j] - u_k[j]
+            log_P_k[neighborhood] = log_weights[neighborhood] - u_k[neighborhood]
             log_P_k[neighborhood] -= logsumexp(log_P_k[neighborhood])
             logZ[neighborhood] += gamma * np.exp(log_P_k[neighborhood] - log_pi_k[neighborhood])
 

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -101,6 +101,10 @@ class MultiStateSampler(object):
         Since the initial samples likely not to yield a good estimate of free energy, save time and just skip them
         If ``online_analysis_interval`` is None, this does nothing
 
+    locality : int > 0, optional, default None
+        If None, the energies at all states will be computed for every replica each iteration.
+        If int > 0, energies will only be computed for states ``range(max(0, state-locality), min(n_states, state+locality))``.
+
     Attributes
     ----------
     n_replicas
@@ -127,7 +131,8 @@ class MultiStateSampler(object):
 
     def __init__(self, mcmc_moves=None, number_of_iterations=1,
                  online_analysis_interval=None, online_analysis_target_error=0.2,
-                 online_analysis_minimum_iterations=50):
+                 online_analysis_minimum_iterations=50,
+                 locality=None):
         # These will be set on initialization. See function
         # create() for explanation of single variables.
         self._thermodynamic_states = None
@@ -156,6 +161,9 @@ class MultiStateSampler(object):
         # usage because any change to these attribute implies a change
         # in the storage file as well. Use properties for checks.
         self.number_of_iterations = number_of_iterations
+
+        # Store locality
+        self.locality = locality
 
         # Online analysis options.
         self.online_analysis_interval = online_analysis_interval
@@ -218,6 +226,7 @@ class MultiStateSampler(object):
         logger.debug("Reading storage file {}...".format(reporter.filepath))
         thermodynamic_states, unsampled_states = reporter.read_thermodynamic_states()
         sampler_states = reporter.read_sampler_states(iteration=iteration)
+        # TODO: Read self._replica_neighborhoods
         state_indices = reporter.read_replica_thermodynamic_states(iteration=iteration)
         energy_thermodynamic_states, energy_unsampled_states = reporter.read_energies(iteration=iteration)
         n_accepted_matrix, n_proposed_matrix = reporter.read_mixing_statistics(iteration=iteration)
@@ -451,6 +460,14 @@ class MultiStateSampler(object):
                 raise ValueError("online_analysis_minimum_iterations must be an integer >= 0")
             return online_analysis_minimum_iterations
 
+        @staticmethod
+        def _locality_validator(instance, locality):
+            if instance.locality is not None:
+                if instance.locality <= 0:
+                    raise ValueError("locality must be an int > 0")
+            return locality
+
+
     number_of_iterations = _StoredProperty('number_of_iterations',
                                            validate_function=_StoredProperty._number_of_iterations_validator)
     online_analysis_interval = _StoredProperty('online_analysis_interval',
@@ -459,7 +476,8 @@ class MultiStateSampler(object):
                                                    validate_function=_StoredProperty._oa_target_error_validator)
     online_analysis_minimum_iterations = _StoredProperty('online_analysis_minimum_iterations',
                                                          validate_function=_StoredProperty._oa_min_iter_validator)
-
+    locality = _StoredProperty('locality',
+                               validate_function=_StoredProperty._locality_validator)
     @property
     def metadata(self):
         """A copy of the metadata dictionary passed on creation (read-only)."""
@@ -578,6 +596,8 @@ class MultiStateSampler(object):
 
         # Deep copy sampler states.
         self._sampler_states = [copy.deepcopy(sampler_state) for sampler_state in sampler_states]
+
+        # TODO: Create replica neighborhoods.
 
         # Make sure all sampler states have box vectors defined; add dummies if needed.
         default_box_vectors = thermodynamic_states[0].system.getDefaultPeriodicBoxVectors()
@@ -761,10 +781,14 @@ class MultiStateSampler(object):
 
             # Attempt replica swaps to sample from equilibrium permuation of
             # states associated with replicas. This step synchronizes replicas.
+            # TODO: Can we just have self._mix_replicas() update self._replica_thermodynamic_states directly?
             self._replica_thermodynamic_states = self._mix_replicas()
 
             # Propagate replicas.
             self._propagate_replicas()
+
+            # Update the list of states for which energies are to be computed
+            self._update_neighbors()
 
             # Compute energies of all replicas at all states.
             self._compute_energies()
@@ -978,6 +1002,7 @@ class MultiStateSampler(object):
         """
         self._reporter.write_sampler_states(self._sampler_states, self._iteration)
         self._reporter.write_replica_thermodynamic_states(self._replica_thermodynamic_states, self._iteration)
+        # TODO: Store self._replica_neighbors
         self._reporter.write_mcmc_moves(self._mcmc_moves)  # MCMCMoves can store internal statistics.
         self._reporter.write_energies(self._energy_thermodynamic_states, self._energy_unsampled_states,
                                       self._iteration)
@@ -1020,6 +1045,35 @@ class MultiStateSampler(object):
         """Store __init__ parameters (beside MCMCMoves) in storage file."""
         logger.debug("Storing general ReplicaExchange options...")
         self._reporter.write_dict('options', self.options)
+
+    # -------------------------------------------------------------------------
+    # Locality
+    # -------------------------------------------------------------------------
+
+    def _neighborhood(self, state_index):
+        """Compute the states in the local neighborhood determined by self.locality
+
+        Parameters
+        ----------
+        current_state_index : int
+            The currrent state
+
+        Returns
+        -------
+        neighborhood : list of int
+            The states in the local neighborhood
+        """
+        if self.locality == None:
+            # Global neighborhood
+            return range(self.n_states)
+        else:
+            # Local neighborhood specified by 'locality'
+            return range(max(0, state_index - self.locality), min(self.n_states, state_index + self.locality + 1))
+
+    def _update_neighbors(self):
+        """Update the neighbors for each state."""
+        for (replica_index, state_index) in enumerate(self._replica_thermodynamic_states):
+            self._replica_neighbors[replica_index] = self._neighborhood(state_index)
 
     # -------------------------------------------------------------------------
     # Internal-usage: Distributed tasks.
@@ -1146,8 +1200,12 @@ class MultiStateSampler(object):
         # Retrieve sampler state associated to this replica.
         sampler_state = self._sampler_states[replica_id]
 
+        # Retrieve neighborhood of thermodynamic states for which energies are to be computed
+        state_id = self._replica_thermodynamic_states[replica_id]
+        neighborhood = self._neighbors(state_id)
+
         # Compute energy for all thermodynamic states.
-        for energies, states in [(energy_thermodynamic_states, self._thermodynamic_states),
+        for energies, states in [(energy_thermodynamic_states, self._thermodynamic_states[neighborhood]),
                                  (energy_unsampled_states, self._unsampled_states)]:
             # Group thermodynamic states by compatibility.
             compatible_groups, original_indices = mmtools.states.group_by_compatibility(states)

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1339,7 +1339,7 @@ class MultiStateSampler(object):
 
         for (replica_index, state_index) in enumerate(self._replica_thermodynamic_states):
             neighborhood = self._neighborhood(state_index)
-            u_k = self._energy_thermodynamic_states[state_index,:]
+            u_k = self._energy_thermodynamic_states[replica_index,:]
             log_P_k = np.zeros([self.n_states], np.float64)
             log_pi_k = np.zeros([self.n_states], np.float64)
             log_weights = np.zeros([self.n_states], np.float64)

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1188,7 +1188,7 @@ class MultiStateSampler(object):
     def _compute_replica_energies(self, replica_id):
         """Compute the energy for the replica in every ThermodynamicState."""
         # Initialize replica energies for each thermodynamic state.
-        energy_thermodynamic_states = np.ma.zeros(self.n_states)
+        energy_thermodynamic_states = np.zeros(self.n_states)
         energy_unsampled_states = np.zeros(len(self._unsampled_states))
 
         # Retrieve sampler state associated to this replica.

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -141,6 +141,7 @@ class MultiStateSampler(object):
         self._replica_thermodynamic_states = None
         self._iteration = None
         self._energy_thermodynamic_states = None
+        self._neighborhoods = None
         self._energy_unsampled_states = None
         self._n_accepted_matrix = None
         self._n_proposed_matrix = None

--- a/Yank/multistate/paralleltempering.py
+++ b/Yank/multistate/paralleltempering.py
@@ -226,7 +226,7 @@ class ParallelTemperingAnalyzer(ReplicaExchangeAnalyzer):
     See Also
     --------
     ReplicaExchangeAnalyzer
-    PhaseAnalyzer
+    MultiStateSamplerAnalyzer
 
     """
     pass

--- a/Yank/multistate/paralleltempering.py
+++ b/Yank/multistate/paralleltempering.py
@@ -90,6 +90,7 @@ class ParallelTemperingSampler(ReplicaExchangeSampler):
 
     See Also
     --------
+    MultiStateSampler
     ReplicaExchangeSampler
 
     """
@@ -225,8 +226,8 @@ class ParallelTemperingAnalyzer(ReplicaExchangeAnalyzer):
 
     See Also
     --------
+    PhaseAnalyzer
     ReplicaExchangeAnalyzer
-    MultiStateSamplerAnalyzer
 
     """
     pass

--- a/Yank/multistate/replicaexchange.py
+++ b/Yank/multistate/replicaexchange.py
@@ -209,6 +209,9 @@ class ReplicaExchangeSampler(MultiStateSampler):
             if replica_mixing_scheme not in supported_schemes:
                 raise ValueError("Unknown replica mixing scheme '{}'. Supported values "
                                  "are {}.".format(replica_mixing_scheme, supported_schemes))
+            if instance.locality != None:
+                if replica_mixing_scheme not in ['swap-neighbors']:
+                    raise ValueError("replica_mixing_scheme must be 'swap_neighbors' if locality is used")
             return replica_mixing_scheme
 
     replica_mixing_scheme = _StoredProperty('replica_mixing_scheme',
@@ -348,6 +351,8 @@ class ReplicaExchangeSampler(MultiStateSampler):
     def _mix_neighboring_replicas(self):
         """Attempt exchanges between neighboring replicas only."""
         logger.debug("Will attempt to swap only neighboring replicas.")
+
+        # TODO: Extend this to allow more remote swaps or more thorough mixing if locality > 1.
 
         # Attempt swaps of pairs of replicas using traditional scheme (e.g. [0,1], [2,3], ...).
         offset = np.random.randint(2)  # Offset is 0 or 1.

--- a/Yank/multistate/replicaexchange.py
+++ b/Yank/multistate/replicaexchange.py
@@ -312,9 +312,6 @@ class ReplicaExchangeSampler(MultiStateSampler):
         logger.debug("Accepted {}/{} attempted swaps ({:.1f}%)".format(n_swaps_accepted, n_swaps_proposed,
                                                                        swap_fraction_accepted * 100.0))
 
-        # Return new states indices for MPI broadcasting.
-        return self._replica_thermodynamic_states
-
     def _mix_all_replicas_cython(self):
         """Exchange all replicas with Cython-accelerated code."""
         from .mixing._mix_replicas import _mix_replicas_cython
@@ -411,11 +408,11 @@ class ReplicaExchangeAnalyzer(MultiStateSamplerAnalyzer):
 
     """
     The ReplicaExchangeAnalyzer is the analyzer for a simulation generated from a Replica Exchange sampler simulation,
-    implemented as an instance of the :class:`PhaseAnalyzer`.
+    implemented as an instance of the :class:`MultiStateSamplerAnalyzer`.
 
     See Also
     --------
-    PhaseAnalyzer
+    MultiStateSamplerAnalyzer
 
     """
     pass

--- a/Yank/multistate/replicaexchange.py
+++ b/Yank/multistate/replicaexchange.py
@@ -417,6 +417,7 @@ class ReplicaExchangeAnalyzer(MultiStateSamplerAnalyzer):
 
     See Also
     --------
+    PhaseAnalyzer
     MultiStateSamplerAnalyzer
 
     """

--- a/Yank/multistate/replicaexchange.py
+++ b/Yank/multistate/replicaexchange.py
@@ -211,7 +211,7 @@ class ReplicaExchangeSampler(MultiStateSampler):
                                  "are {}.".format(replica_mixing_scheme, supported_schemes))
             if instance.locality != None:
                 if replica_mixing_scheme not in ['swap-neighbors']:
-                    raise ValueError("replica_mixing_scheme must be 'swap_neighbors' if locality is used")
+                    raise ValueError("replica_mixing_scheme must be 'swap-neighbors' if locality is used")
             return replica_mixing_scheme
 
     replica_mixing_scheme = _StoredProperty('replica_mixing_scheme',

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -576,8 +576,7 @@ class TestMultiStateSampler(object):
     def call_sampler_create(cls, sampler, reporter,
                             thermodynamic_states,
                             sampler_states,
-                            unsampled_states,
-                            locality):
+                            unsampled_states):
         """Helper function to call the create method for the sampler"""
         # Allows initial thermodynamic states to be handled by the built in methods
         sampler.create(thermodynamic_states, sampler_states, reporter, unsampled_thermodynamic_states=unsampled_states)
@@ -740,6 +739,8 @@ class TestMultiStateSampler(object):
         with self.temporary_storage_path() as storage_path:
             reporter = self.REPORTER(storage_path, checkpoint_interval=1)
             sampler = self.SAMPLER(locality=1)
+            if hasattr(sampler, 'replica_mixing_scheme'):
+                sampler.replica_mixing_scheme = 'swap-neighbors' # required for non-global locality
             self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states,
                                      sampler_states, unsampled_states)
@@ -850,7 +851,7 @@ class TestMultiStateSampler(object):
         with self.temporary_storage_path() as storage_path:
             number_of_iterations = 3
             move = mmtools.mcmc.LangevinDynamicsMove(n_steps=1)
-            sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=number_of_iterations, locality=1)
+            sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=number_of_iterations, locality=2)
             reporter = self.REPORTER(storage_path, checkpoint_interval=1)
             self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states, sampler_states,

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -737,13 +737,11 @@ class TestMultiStateSampler(object):
         n_samplers = len(sampler_states)
 
         with self.temporary_storage_path() as storage_path:
-            kwargs = dict()
-            kwargs['locality'] = 1
-            if hasattr(self.SAMPLER, 'replica_mixing_scheme'):
-                # TODO: Test both 'swap-all' with locality=None and 'swap-neighbors' with locality=1?
-                kwargs['replica_mixing_scheme'] = 'swap-neighbors' # required for non-global locality
             reporter = self.REPORTER(storage_path, checkpoint_interval=1)
-            sampler = self.SAMPLER(**kwargs)
+            sampler = self.SAMPLER()
+            if hasattr(sampler, 'replica_mixing_scheme'):
+                sampler.replica_mixing_scheme = 'swap-neighbors'
+            sampler.locality = 2
             self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states,
                                      sampler_states, unsampled_states)
@@ -854,12 +852,11 @@ class TestMultiStateSampler(object):
         with self.temporary_storage_path() as storage_path:
             number_of_iterations = 3
             move = mmtools.mcmc.LangevinDynamicsMove(n_steps=1)
-            kwargs = dict()
-            kwargs['locality'] = 2
-            if hasattr(self.SAMPLER, 'replica_mixing_scheme'):
-                # TODO: Test both 'swap-all' with locality=None and 'swap-neighbors' with locality=1?
-                kwargs['replica_mixing_scheme'] = 'swap-neighbors' # required for non-global locality
-            sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=number_of_iterations, **kwargs)
+            sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=number_of_iterations)
+            if hasattr(sampler, 'replica_mixing_scheme'):
+                # TODO: Test both 'swap-all' with locality=None and 'swap-neighbors' with locality=1
+                sampler.replica_mixing_scheme = 'swap-neighbors' # required for non-global locality
+            sampler.locality = 1
             reporter = self.REPORTER(storage_path, checkpoint_interval=1)
             self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states, sampler_states,

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -737,10 +737,13 @@ class TestMultiStateSampler(object):
         n_samplers = len(sampler_states)
 
         with self.temporary_storage_path() as storage_path:
+            kwargs = dict()
+            kwargs['locality'] = 1
+            if hasattr(self.SAMPLER, 'replica_mixing_scheme'):
+                # TODO: Test both 'swap-all' with locality=None and 'swap-neighbors' with locality=1?
+                kwargs['replica_mixing_scheme'] = 'swap-neighbors' # required for non-global locality
             reporter = self.REPORTER(storage_path, checkpoint_interval=1)
-            sampler = self.SAMPLER(locality=1)
-            if hasattr(sampler, 'replica_mixing_scheme'):
-                sampler.replica_mixing_scheme = 'swap-neighbors' # required for non-global locality
+            sampler = self.SAMPLER(**kwargs)
             self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states,
                                      sampler_states, unsampled_states)
@@ -851,7 +854,12 @@ class TestMultiStateSampler(object):
         with self.temporary_storage_path() as storage_path:
             number_of_iterations = 3
             move = mmtools.mcmc.LangevinDynamicsMove(n_steps=1)
-            sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=number_of_iterations, locality=2)
+            kwargs = dict()
+            kwargs['locality'] = 2
+            if hasattr(self.SAMPLER, 'replica_mixing_scheme'):
+                # TODO: Test both 'swap-all' with locality=None and 'swap-neighbors' with locality=1?
+                kwargs['replica_mixing_scheme'] = 'swap-neighbors' # required for non-global locality
+            sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=number_of_iterations, **kwargs)
             reporter = self.REPORTER(storage_path, checkpoint_interval=1)
             self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states, sampler_states,

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -576,7 +576,8 @@ class TestMultiStateSampler(object):
     def call_sampler_create(cls, sampler, reporter,
                             thermodynamic_states,
                             sampler_states,
-                            unsampled_states):
+                            unsampled_states,
+                            locality):
         """Helper function to call the create method for the sampler"""
         # Allows initial thermodynamic states to be handled by the built in methods
         sampler.create(thermodynamic_states, sampler_states, reporter, unsampled_thermodynamic_states=unsampled_states)


### PR DESCRIPTION
As discussed, I'm working on first adding support for restricted neighborhoods to the existing samplers before implementing SAMS.

Presuming we keep the current order of mix-propagate-energy, my first hurdle is to determine how to store the neighborhood that was used to compute the replica energies at a subset of thermodynamic states.

@andrrizzi @Lnaden : I'd appreciate your advice here! Should I:
1. Extend [`read_energies` and `write_energies`](https://github.com/choderalab/yank/blob/sams-neighborhood/Yank/multistate/multistatereporter.py#L690-L778) to also read and write an `[n_iterations, n_replicas, n_states]` integer array that is 1 if the energy was computed for that state and 0 if not?
2. Modify the current energy read/write code to use [masked arrays](http://unidata.github.io/netcdf4-python/#netCDF4.Variable.set_auto_mask) and simply mask the values of the existing [`energies`](https://github.com/choderalab/yank/blob/sams-neighborhood/Yank/multistate/multistatereporter.py#L742-L747) matrix that are not computed?

I'm thinking option (2) might be simpler, though I've never used masked arrays before. Has anyone had experience with these?

### Progress

- [x] Add `_neighborhood(state_index)` method to compute local neighborhood
- [x] Restrict energy computation to neighborhood
- [x] Store energies only within neighborhood, alongside neighborhood information
- [x] Add test to ensure that energy array is properly stored when locality is restricted
- [x] Test restricted neighborhood `MultiStateSampler`
- [x] Implement fast online analysis
- [x] Implement locality support in replica exchange and parallel tempering
- [ ] Implement locally weighted histogram analysis for offline analysis: [paper1](http://www.stat.rutgers.edu/home/ztan/Publication/SAMS_preprint.pdf),  [paper2](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4729400/pdf/JCPSA6-000144-034107_1.pdf) - bumping this to a subsequent PR
