### PR TITLE
Implement SAMS sampler

### DIFF
--- a/Yank/multistate/__init__.py
+++ b/Yank/multistate/__init__.py
@@ -62,5 +62,6 @@ from .multistatesampler import MultiStateSampler
 from .multistatereporter import MultiStateReporter
 from .replicaexchange import ReplicaExchangeSampler, ReplicaExchangeAnalyzer
 from .paralleltempering import ParallelTemperingSampler, ParallelTemperingAnalyzer
+from .sams import SAMSSampler, SAMSAnalyzer
 from .multistateanalyzer import *
 from .utils import *

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -374,6 +374,9 @@ class PhaseAnalyzer(ABC):
         The reporter provides the hook into how to read the data, all other options control where differences are
         measured from and how each phase interfaces with other phases.
         """
+        if type(reporter) is str:
+            raise ValueError('reporter must be a MultiStateReporter instance')
+
         if not isinstance(registry, ObservablesRegistry):
             raise ValueError("Registry must be an instanced ObservablesRegistry")
         self.registry = registry

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -1275,7 +1275,7 @@ class MultiStateReporter(object):
             variable_parameters = self._determine_netcdf_variable_parameters(iteration, data, storage)
             storage.createVariable(variable, variable_parameters['dtype'],
                                    dimensions=variable_parameters['dims'],
-                                   cunksizes=variable_parameters['chunks'],
+                                   chunksizes=variable_parameters['chunks'],
                                    zlib=False)
         # Get the variable
         nc_var = storage[variable]

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -9,7 +9,7 @@ Multistatereporter
 ==================
 
 Master multi-thermodynamic state reporter module. Handles all Disk I/O
-reporting operations for any MultiStateSampeler derived classes.
+reporting operations for any MultiStateSampler derived classes.
 
 COPYRIGHT
 
@@ -35,6 +35,7 @@ import time
 import uuid
 import yaml
 import logging
+import warnings
 import collections
 
 import numpy as np
@@ -54,7 +55,9 @@ logger = logging.getLogger(__name__)
 # MULTISTATE SAMPLER REPORTER
 # ==============================================================================
 
-MISSING_VALUE = np.NaN # value for populating missing values
+# Value for populating missing values
+MISSING_VALUE = np.NaN
+
 
 class MultiStateReporter(object):
     """Handle storage write/read operations and different format conventions.
@@ -225,35 +228,6 @@ class MultiStateReporter(object):
             else:
                 open_check_list.append(storage.isopen())
         return np.all(open_check_list)
-
-    def _ensure_dimension_exists(self, dimname, dimsize):
-        """
-        Ensure a dimension exists and is of the appropriate size,
-        creating it if it does not already exist.
-
-        A ``ValueError`` is raised if ``dimsize`` does not match the existing dimension size.
-
-        Parameters
-        ----------
-        dimname : str
-            The dimension name
-        dimsize : int
-            The dimension size
-
-        """
-        if dimname not in self._storage_analysis.dimensions:
-            self._storage_analysis.createDimension(dimname, dimsize)
-        else:
-            # Check dimension matches expected size
-            dimension = self._storage_analysis.dimensions[dimname]
-            if dimsize == 0:
-                if not dimension.isunlimited():
-                    raise ValueError("NetCDF dimension {} already exists: was previously unlimited, but tried to "
-                                     "redeclare it with size {}".format(dimension.name, dimsize))
-            else:
-                if not int(dimension.size) == int(dimsize):
-                    raise ValueError("NetCDF dimension {} already exists: was previously size {}, but tried to "
-                                     "redeclare it with dimension {}".format(dimension.name, dimension.size, dimsize))
 
     def open(self, mode='r', convention='ReplicaExchange', netcdf_format='NETCDF4'):
         """
@@ -1076,11 +1050,14 @@ class MultiStateReporter(object):
         logZ : np.array with shape [n_states]
             Dimensionless logZ
         """
-        online_group = self._storage_analysis.groups['online_analysis']
-        logZ = online_group.variables['logZ'][iteration]
-        return logZ
+        # TODO: Remove commented block (or whole thing) when tests pass -LNN
+        data = self.read_online_analysis_data(None, "log_z")
+        return data['log_z']
+        # online_group = self._storage_analysis.groups['online_analysis']
+        # logZ = online_group.variables['logZ'][iteration]
+        # return logZ
 
-    def write_logZ(self, iteration: int, log_Z: np.ndarray):
+    def write_logZ(self, iteration: int, log_z: np.ndarray):
         """
         Write logZ
 
@@ -1089,20 +1066,23 @@ class MultiStateReporter(object):
         iteration : int,
             Iteration at which to save the free energy.
             Reads the current energy up to this value and stores it in the analysis reporter
-        logZ : np.array with shape [n_states]
-            Dimensionless logZ
+        log_z : np.array with shape [n_states]
+            Dimensionless log Z
         """
-        analysis_nc = self._storage_analysis
-        if 'logZ' not in analysis_nc.dimensions:
-            analysis_nc.createDimension('logZ_length', len(logZ))
-            if 'online_analysis' not in analysis_nc.groups:
-                online_group = analysis_nc.createGroup('online_analysis')
-                # larger chunks, faster operations, small matrix anyways
-                online_group.createVariable('logZ', float, dimensions=('iteration', 'logZ_length'),
-                                            zlib=True, chunksizes=(1, len(logZ)), fill_value=MISSING_VALUE)
-        online_group = analysis_nc.groups['online_analysis']
-        online_group.variables['logZ'][iteration] = logZ
+        self.write_online_data_dynamic_and_static(iteration, log_z=log_z)
+        # TODO: Remove commended block if tests work (Could also remove function entirely)-LNN
+        # analysis_nc = self._storage_analysis
+        # if 'logZ' not in analysis_nc.dimensions:
+        #     analysis_nc.createDimension('logZ_length', len(logZ))
+        #     if 'online_analysis' not in analysis_nc.groups:
+        #         online_group = analysis_nc.createGroup('online_analysis')
+        #         # larger chunks, faster operations, small matrix anyways
+        #         online_group.createVariable('logZ', float, dimensions=('iteration', 'logZ_length'),
+        #                                     zlib=True, chunksizes=(1, len(logZ)), fill_value=MISSING_VALUE)
+        # online_group = analysis_nc.groups['online_analysis']
+        # online_group.variables['logZ'][iteration] = logZ
 
+    # TODO: Remove function if tests pass -LNN
     def read_mbar_free_energies(self, iteration):
         """
         Read the MBAR dimensionless free energy at a given iteration from file.
@@ -1136,6 +1116,7 @@ class MultiStateReporter(object):
         free_energy = online_group.variables['free_energy'][iteration, :]
         return f_k, free_energy
 
+    # TODO: Remove function if tests pass -LNN
     def write_mbar_free_energies(self, iteration: int, f_k: np.ndarray, free_energy: tuple):
         """
         Write the mbar free energies at the current iteration. See :func:`read_mbar_free_energies` for more information
@@ -1173,9 +1154,218 @@ class MultiStateReporter(object):
         online_group.variables['f_k'][iteration] = f_k
         online_group.variables['free_energy'][iteration, :] = free_energy
 
+    def read_online_analysis_data(self, iteration, *keys: str):
+        """
+
+        Parameters
+        ----------
+        iteration : int or None
+            Iteration to fetch data at
+        keys : str
+            Variables to fetch data from
+
+        Returns
+        -------
+        online_analysis_data : dict
+            Data requested by *keys argument from online analysis, if they exist on disk
+
+        Warnings
+        --------
+        RuntimeWarning : If some keys were not found as requested
+
+        Raises
+        ------
+        ValueError : If no requested keys were found in the storage.
+        """
+        collected_variables = {}
+        collected_iteration_failure = []
+        collected_not_found = []
+        storage = self._storage_analysis.groups["online_analysis"]
+        for variable in keys:
+            try:
+                data = self._read_1d_online_data(iteration, variable, storage)
+                collected_variables[variable] = data
+            except IndexError:
+                if self._find_alternate_variable(iteration, variable, storage):
+                    collected_iteration_failure.append(variable)
+                else:
+                    collected_not_found.append(variable)
+        # Nothing found
+        if not collected_variables and not collected_iteration_failure:
+            raise ValueError("None of the requested keys could be found on disk!")
+        # Found some things possibly named wrong, still nothing to return
+        elif not collected_variables:
+            base_error = ("No variables found on disk with{} per-iteration data, but we did find the following " 
+                          "variables of the same name with{} per-iteration data. Possibly you meant those?"
+                          )
+            for failure in collected_iteration_failure:
+                base_error += "\n\t-{}".format(failure)
+            if iteration is None:
+                raise ValueError(base_error.format("out", ""))
+            else:
+                raise ValueError(base_error.format("", "out"))
+        elif collected_iteration_failure or collected_not_found:
+            base_warn = ("Some requested variables were found, others were missing or found on disk under {}per"
+                         "-iteration data:")
+            if iteration is None:
+                iteration_str = ""
+            else:
+                iteration_str = "non-"
+            base_warn = base_warn.format(iteration_str)
+            for failure in collected_iteration_failure:
+                base_warn += "\n\t{}per-iteration: {}".format(iteration_str, failure)
+            for missing in collected_not_found:
+                base_warn += "\n\tMissing: {}".format(missing)
+            warnings.warn(base_warn, RuntimeWarning)
+        return collected_variables
+
+    def write_online_analysis_data(self, iteration: Union[int, None], **kwargs):
+        """
+        Write semi-arbitrary 1-D numeric online analysis data to storage with optional per-iteration flag.
+        This function helps generalize what information is stored by any given reporter, while still
+        enforcing a regular input and output.
+
+        The logic of what to store and how is similar, but not exact to the :func:`write_dict`.
+
+        ``iteration`` accepts an integer as to indicate this this information should be written
+        on a per-iteration basis. The iteration the data are written to is the integer argument.
+        Pass ``None`` if this is *not* per-iteration data and stored independent of the iteration dimension
+
+        ``**kwargs`` are processed as the variable/value pairs to store and there must be *at least one*
+        This should be 1-D or scalar numerical value (e.g. numpy array, list, or tuple of numbers; NOT string, dict,
+        etc.). Type is inferred from the first value of data input.
+
+        Parameters
+        ----------
+        iteration : int or None
+            Optional iteration to write the data under, if ``None``, the variables will not be written on a
+            per-iteration basis
+        kwargs : pairs of name:value of numeric 1-D or scalar data
+            Name of variable and value to write to disk
+
+        Raises
+        ------
+        TypeError : If no values are given to ``**kwargs``
+        ValueError : If ``iteration`` is not an integer
+
+        """
+        self._resolve_iteration_args(iteration)
+        self._resolve_kwargs_exist(kwargs)
+        group = self._ensure_group_exists_and_get("online_analysis")
+        for name, value in kwargs.items():
+            self._write_1d_online_data(iteration, name, value, group)
+
+    def write_online_data_dynamic_and_static(self, iteration: int, **kwargs):
+        """
+        Helper function to do a :func:`write_online_analysis_data` call twice, both
+        with and without setting iteration.
+
+        See Also
+        --------
+        write_online_analysis_data
+        """
+        self.write_online_analysis_data(None, **kwargs)
+        self.write_online_analysis_data(iteration, **kwargs)
+
+    def _write_1d_online_data(self, iteration, variable, data, storage):
+        """Store data on disk given pre-calculated parameters"""
+        if iteration is not None:
+            variable = variable + "_iter"
+        if variable not in storage.variables:
+            variable_parameters = self._determine_netcdf_variable_parameters(iteration, data, storage)
+            storage.createVariable(variable, variable_parameters['dtype'],
+                                   dimensions=variable_parameters['dims'],
+                                   cunksizes=variable_parameters['chunks'],
+                                   zlib=False)
+        # Get the variable
+        nc_var = storage[variable]
+        # Only get the specific iteration if specified
+        if iteration is not None:
+            nc_var = nc_var[iteration]
+        # Write data
+        nc_var[:] = data
+
+    @staticmethod
+    def _find_alternate_variable(iteration, variable, storage):
+        """Helper function to figure out what went wrong when data not found"""
+        iter_var = variable + "_iter"
+        if iteration is None and iter_var in storage:
+            return True
+        elif iteration is not None and variable in storage:
+            return True
+        return False
+
+    @staticmethod
+    def _read_1d_online_data(iteration, variable, storage):
+        """Read data on disk given storage object
+
+        Returns
+        -------
+        data
+        """
+        if iteration is not None:
+            variable = variable + "_iter"
+        nc_var = storage[variable]
+        nc_data = nc_var
+        if iteration is not None:
+            nc_data = nc_data[iteration]
+        data = nc_data[:]
+        if nc_var.dimensions[-1] == "scalar":
+            return data[0]
+        else:
+            return data
+
+
+    def _determine_netcdf_variable_parameters(self, iteration, data, storage):
+        """
+        Pre-determine the variable information needed to create the variable on the storage layer
+        """
+
+        try:
+            # Check for known numpy types
+            dtype = data.dtype
+            size = len(data)
+            data_dim = "dim_size{}".format(size)
+        except AttributeError:
+            try:
+                dtype = type(data[0])
+                size = len(data)
+                data_dim = "dim_size{}".format(size)
+            except (IndexError, TypeError):
+                dtype = type(data)
+                size = 1
+                # Use existing scalar dimension
+                data_dim = "scalar"
+        self._ensure_dimension_exists(data_dim, size, storage=storage)
+        if iteration is not None:
+            dims = ("iteration", data_dim)
+            chunks = (1, size)
+        else:
+            dims = (data_dim,)
+            chunks = (size,)
+        return {'dtype': dtype, 'dims': dims, 'chunks': chunks}
+
     # -------------------------------------------------------------------------
     # Internal-usage.
     # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_iteration_args(iteration_arg):
+        """
+        Ensure iterations given as iterations are integer or None
+        """
+        err_message = "Only an int or None is allowed for iteration"
+        # Ensures int check if its a core int, np.int32, np.int64, or signed/unsigned variants
+        if iteration_arg is not None and not np.issubdtype(type(iteration_arg), np.integer):
+            raise ValueError(err_message)
+
+    @staticmethod
+    def _resolve_kwargs_exist(kwargs):
+        """
+        Ensure keyword args exist (at least 1)
+        """
+        if len(kwargs) == 0:
+            raise TypeError("There must be at least 1 keyword arg!")
 
     def _resolve_nc_path(self, path, storage):
         """Return the NC group or variable at the end of the path.
@@ -1269,6 +1459,59 @@ class MultiStateReporter(object):
             else:
                 raise ValueError("Iteration must be either an int or a slice!")
         return cast_iteration
+
+    def _ensure_dimension_exists(self, dim_name, dim_size, storage=None):
+        """
+        Ensure a dimension exists and is of the appropriate size,
+        creating it if it does not already exist.
+
+        A ``ValueError`` is raised if ``dim_size`` does not match the existing dimension size.
+
+        Parameters
+        ----------
+        dim_name : str
+            The dimension name
+        dim_size : int
+            The dimension size
+        storage : netCDF4.Dataset or netCDF4.Group, optional, default: None
+            Storage layer to check the dimension against. If none, the _storage_analysis is used
+
+        """
+        if storage is None:
+            storage = self._storage_analysis
+        if dim_name not in storage.dimensions:
+            storage.createDimension(dim_name, dim_size)
+        else:
+            # Check dimension matches expected size
+            dimension = storage.dimensions[dim_name]
+            if dim_size == 0:
+                if not dimension.isunlimited():
+                    raise ValueError("NetCDF dimension {} already exists: was previously unlimited, but tried to "
+                                     "redeclare it with size {}".format(dimension.name, dim_size))
+            else:
+                if not int(dimension.size) == int(dim_size):
+                    raise ValueError("NetCDF dimension {} already exists: was previously size {}, but tried to "
+                                     "redeclare it with dimension {}".format(dimension.name, dimension.size, dim_size))
+
+    def _ensure_group_exists_and_get(self, group_name, storage=None):
+        """
+        Ensure a group exists and fetch it if it does, creating first if it does not.
+
+        A ``ValueError`` is raised if ``dimsize`` does not match the existing dimension size.
+
+        Parameters
+        ----------
+        group_name : str
+            The group name
+        storage : known storage object or None, default None
+            Storage object to check against, if None, assumes the analysis storage
+
+        """
+        if storage is None:
+            storage = self._storage_analysis
+        if group_name not in storage.groups:
+            storage.createGroup(group_name)
+        return storage.groups[group_name]
 
     @staticmethod
     def _initialize_sampler_variables_on_file(dataset, n_atoms, n_replicas, is_periodic):

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -420,7 +420,8 @@ class MultiStateSampler(object):
                 new_value = self._validate_function(instance, new_value)
             setattr(instance, '_' + self._option_name, new_value)
             # Update storage if we ReplicaExchange is initialized.
-            if instance._thermodynamic_states is not None:
+            # TODO: JDC Please review this change!
+            if instance._thermodynamic_states is not None and instance._reporter is not None:
                 mpi.run_single_node(0, instance._store_options)
 
         # ----------------------------------
@@ -496,7 +497,7 @@ class MultiStateSampler(object):
     _TITLE_TEMPLATE = ('Multi-state sampler simulation created using MultiStateSampler class '
                        'of yank.multistate on {}')
 
-    def create(self, thermodynamic_states, sampler_states, storage,
+    def create(self, thermodynamic_states: list, sampler_states, storage,
                initial_thermodynamic_states=None, unsampled_thermodynamic_states=None,
                metadata=None):
         """Create new multistate sampler simulation.
@@ -541,6 +542,35 @@ class MultiStateSampler(object):
            Simulation metadata to be stored in the file.
         """
 
+        self._pre_write_create(thermodynamic_states, sampler_states, storage,
+                               initial_thermodynamic_states=initial_thermodynamic_states,
+                               unsampled_thermodynamic_states=unsampled_thermodynamic_states,
+                               metadata=metadata)
+
+        # Handle case in which storage is a string.
+        reporter = self._reporter_from_storage(storage, check_exist=False)
+
+        # Display papers to be cited.
+        self._display_citations()
+
+        # Close the reporter file so its ready for use
+        reporter.close()
+        self._reporter = reporter
+        self._initialize_reporter()
+
+    def _pre_write_create(self,
+                          thermodynamic_states,
+                          sampler_states,
+                          storage,
+                          initial_thermodynamic_states=None,
+                          unsampled_thermodynamic_states=None,
+                          metadata=None):
+        """
+        Internal function which allocates and sets up ALL variables prior to actually using them.
+        This is helpful to ensure subclasses have all variables created prior to writing them out with
+        :func:`_report_iteration`.
+        All calls to this function should be *identical* to :func:`create` itself
+        """
         # Make sure sampler_states is an iterable of SamplerStates for later.
         if isinstance(sampler_states, mmtools.states.SamplerState):
             sampler_states = [sampler_states]
@@ -640,14 +670,7 @@ class MultiStateSampler(object):
         self._energy_thermodynamic_states = np.zeros([self.n_replicas, self.n_states], np.float64)
         self._neighborhoods = np.zeros([self.n_replicas, self.n_states], 'i1')
         self._energy_unsampled_states = np.zeros([self.n_replicas, len(self._unsampled_states)], np.float64)
-
-        # Display papers to be cited.
-        self._display_citations()
-
-        # Close the reporter file so its ready for use
         reporter.close()
-        self._reporter = reporter
-        self._initialize_reporter()
 
     @mmtools.utils.with_timer('Minimizing all replicas')
     def minimize(self, tolerance=1.0 * unit.kilojoules_per_mole / unit.nanometers,
@@ -834,8 +857,7 @@ class MultiStateSampler(object):
 
     def __repr__(self):
         """Return a 'formal' representation that can be used to reconstruct the class, if possible."""
-        # TODO: Can we make this a more useful expression?
-        return "<instance of MultiStateSampler>"
+        return "<instance of {}>".format(self.__class__.__name__)
 
     def __del__(self):
         # The reporter could be None if MultiStateSampler was not created.
@@ -1173,7 +1195,7 @@ class MultiStateSampler(object):
         self._neighborhoods[:,:] = False
         for (replica_index, state_index) in enumerate(self._replica_thermodynamic_states):
             neighborhood = self._neighborhood(state_index)
-            self._neighborhoods[replica_index,neighborhood] = True
+            self._neighborhoods[replica_index, neighborhood] = True
 
         # Distribute energy computation across nodes. Only node 0 receives
         # all the energies since it needs to store them and mix states.
@@ -1183,7 +1205,8 @@ class MultiStateSampler(object):
         # Update energy matrices. Non-0 nodes update only the energies computed by this replica.
         for replica_id, energies in zip(replica_ids, new_energies):
             energy_thermodynamic_states, energy_unsampled_states = energies  # Unpack.
-            self._energy_thermodynamic_states[replica_id] = energy_thermodynamic_states
+            neighborhood = self._neighborhood(self._replica_thermodynamic_states[replica_id])
+            self._energy_thermodynamic_states[replica_id, neighborhood] = energy_thermodynamic_states
             self._energy_unsampled_states[replica_id] = energy_unsampled_states
 
     def _compute_replica_energies(self, replica_id):
@@ -1198,10 +1221,12 @@ class MultiStateSampler(object):
         # Determine neighborhood
         state_index = self._replica_thermodynamic_states[replica_id]
         neighborhood = self._neighborhood(state_index)
-        neighborhood_slice = slice(neighborhood[0], neighborhood[-1])
+        # Only compute energies over neighborhoods
+        energy_neighborhood_states = energy_thermodynamic_states[neighborhood]  # Array, can be indexed like this
+        neighborhood_thermodynamic_states = [self._thermodynamic_states[n] for n in neighborhood]  # List
 
         # Compute energy for all thermodynamic states.
-        for energies, states in [(energy_thermodynamic_states[neighborhood_slice], self._thermodynamic_states[neighborhood_slice]),
+        for energies, states in [(energy_neighborhood_states, neighborhood_thermodynamic_states),
                                  (energy_unsampled_states, self._unsampled_states)]:
             # Group thermodynamic states by compatibility.
             compatible_groups, original_indices = mmtools.states.group_by_compatibility(states)
@@ -1222,7 +1247,7 @@ class MultiStateSampler(object):
                     energies[state_idx] = compatible_energies[energy_idx]
 
         # Return the new energies.
-        return energy_thermodynamic_states, energy_unsampled_states
+        return energy_neighborhood_states, energy_unsampled_states
 
     # -------------------------------------------------------------------------
     # Internal-usage: Replicas mixing.

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1059,10 +1059,10 @@ class MultiStateSampler(object):
         """
         if self.locality == None:
             # Global neighborhood
-            return slice(0, self.n_states)
+            return list(range(0, self.n_states))
         else:
             # Local neighborhood specified by 'locality'
-            return slice(max(0, state_index - self.locality), min(self.n_states, state_index + self.locality + 1))
+            return list(range(max(0, state_index - self.locality), min(self.n_states, state_index + self.locality + 1)))
 
     # -------------------------------------------------------------------------
     # Internal-usage: Distributed tasks.
@@ -1198,9 +1198,10 @@ class MultiStateSampler(object):
         # Determine neighborhood
         state_index = self._replica_thermodynamic_states[replica_id]
         neighborhood = self._neighborhood(state_index)
+        neighborhood_slice = slice(neighborhood[0], neighborhood[-1])
 
         # Compute energy for all thermodynamic states.
-        for energies, states in [(energy_thermodynamic_states[neighborhood], self._thermodynamic_states[neighborhood]),
+        for energies, states in [(energy_thermodynamic_states[neighborhood_slice], self._thermodynamic_states[neighborhood_slice]),
                                  (energy_unsampled_states, self._unsampled_states)]:
             # Group thermodynamic states by compatibility.
             compatible_groups, original_indices = mmtools.states.group_by_compatibility(states)

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -1,0 +1,593 @@
+#!/usr/local/bin/env python
+
+# ==============================================================================
+# MODULE DOCSTRING
+# ==============================================================================
+
+"""
+SamsSampler
+===========
+
+Self-adjusted mixture sampling (SAMS), also known as optimally-adjusted mixture sampling.
+
+This implementation uses stochastic approximation to allow one or more replicas to sample the whole range of thermodynamic states
+for rapid online computation of free energies.
+
+COPYRIGHT
+
+Written by John D. Chodera <john.chodera@choderalab.org> while at Memorial Sloan Kettering Cancer Center.
+
+LICENSE
+
+This code is licensed under the latest available version of the MIT License.
+
+"""
+
+import copy
+import math
+import logging
+import numpy as np
+import openmmtools as mmtools
+from scipy.misc import logsumexp
+
+from .. import mpi
+from .multistatesampler import MultiStateSampler
+from .multistatereporter import MultiStateReporter
+from .multistateanalyzer import MultiStateSamplerAnalyzer
+
+logger = logging.getLogger(__name__)
+
+# ==============================================================================
+# PARALLEL TEMPERING
+# ==============================================================================
+
+class SAMSSampler(MultiStateSampler):
+    """Self-adjusted mixture sampling (SAMS), also known as optimally-adjusted mixture sampling.
+
+    This class provides a facility for self-adjusted mixture sampling simulations.
+    One or more replicas use the method of expanded ensembles [1] to sample multiple thermodynamic states within each replica,
+    with log weights for each thermodynamic state adapted on the fly [2] to achieve the desired target probabilities for each state.
+
+    Attributes
+    ----------
+    log_target_probabilities : array-like
+        log_target_probabilities[state_index] is the log target probability for state ``state_index``
+    state_update_scheme : str
+        Thermodynamic state sampling scheme. One of ['global-jump', 'local-jump', 'restricted-range']
+    locality : int
+        Number of neighboring states on either side to consider for local update schemes
+    update_stages : str
+        Number of stages to use for update. One of ['one-stage', 'two-stage']
+    weight_update_method : str
+        Method to use for updating log weights in SAMS. One of ['optimal', 'rao-blackwellized']
+    adapt_target_probabilities : bool
+        If True, target probabilities will be adapted to achieve minimal thermodynamic length between terminal thermodynamic states.
+    gamma0 : float, optional, default=0.0
+        Initial weight adaptation rate.
+    log_Z_guess : array-like of shape [n_states] of floats, optiona, default=None
+        Initial guess for logZ for all states, if available.
+
+    References
+    ----------
+    [1] Lyubartsev AP, Martsinovski AA, Shevkunov SV, and Vorontsov-Velyaminov PN. New approach to Monte Carlo calculation of the free energy: Method of expanded ensembles. JCP 96:1776, 1992
+    http://dx.doi.org/10.1063/1.462133
+
+    [2] Tan, Z. Optimally adjusted mixture sampling and locally weighted histogram analysis, Journal of Computational and Graphical Statistics 26:54, 2017.
+    http://dx.doi.org/10.1080/10618600.2015.1113975
+
+    Examples
+    --------
+    SAMS simulation of alanine dipeptide in implicit solvent at different temperatures.
+
+    Create the system:
+
+    >>> import math
+    >>> from simtk import unit
+    >>> from openmmtools import testsystems, states, mcmc
+    >>> testsystem = testsystems.AlanineDipeptideVacuum()
+
+    Create thermodynamic states for parallel tempering with exponentially-spaced schedule:
+
+    >>> n_replicas = 3  # Number of temperature replicas.
+    >>> T_min = 298.0 * unit.kelvin  # Minimum temperature.
+    >>> T_max = 600.0 * unit.kelvin  # Maximum temperature.
+    >>> temperatures = [T_min + (T_max - T_min) * (math.exp(float(i) / float(nreplicas-1)) - 1.0) / (math.e - 1.0)
+    ...                 for i in range(n_replicas)]
+    >>> thermodynamic_states = [states.ThermodynamicState(system=testsystem.system, temperature=T)
+    ...                         for T in temperatures]
+
+    Initialize simulation object with options. Run with a GHMC integrator:
+
+    >>> move = mcmc.GHMCMove(timestep=2.0*unit.femtoseconds, n_steps=50)
+    >>> simulation = SAMSSampler(mcmc_moves=move, number_of_iterations=2,
+    >>>                          state_update_scheme='restricted-range', locality=5,
+    >>>                          update_stages='two-stage', flatness_threshold=0.2,
+    >>>                          weight_update_method='rao-blackwellized',
+    >>>                          adapt_target_probabilities=False)
+
+
+    Create a single-replica SAMS simulation bound to a storage file and run:
+
+    >>> storage_path = tempfile.NamedTemporaryFile(delete=False).name + '.nc'
+    >>> reporter = MultiStateReporter(storage_path, checkpoint_interval=1)
+    >>> simulation.create(thermodynamic_states=thermodynamic_states,
+    >>>                   sampler_states=[states.SamplerState(testsystem.positions)],
+    >>>                   storage=reporter)
+    >>> simulation.run()  # This runs for a maximum of 2 iterations.
+    >>> simulation.iteration
+    2
+    >>> simulation.run(n_iterations=1)
+    >>> simulation.iteration
+    2
+
+    To resume a simulation from an existing storage file and extend it beyond
+    the original number of iterations.
+
+    >>> del simulation
+    >>> simulation = SAMSSampler.from_storage(reporter)
+    >>> simulation.extend(n_iterations=1)
+    >>> simulation.iteration
+    3
+
+    You can extract several information from the NetCDF file using the Reporter
+    class while the simulation is running. This reads the SamplerStates of every
+    run iteration.
+
+    >>> reporter = MultiStateReporter(storage=storage_path, open_mode='r', checkpoint_interval=1)
+    >>> sampler_states = reporter.read_sampler_states(iteration=range(1, 4))
+    >>> len(sampler_states)
+    3
+    >>> sampler_states[-1].positions.shape  # Alanine dipeptide has 22 atoms.
+    (22, 3)
+
+    Clean up.
+
+    >>> os.remove(storage_path)
+
+    See Also
+    --------
+    ReplicaExchangeSampler
+
+    """
+
+    _TITLE_TEMPLATE = ('Self-adjusted mixture sampling (SAMS) simultion using SAMSSampler '
+                       'class of yank.multistate on {}')
+
+    def __init__(self,
+                log_target_probabilities=None,
+                state_update_scheme='global-jump', locality=5,
+                update_stages='two-stage', flatness_threshold=0.2,
+                weight_update_method='rao-blackwellized',
+                adapt_target_probabilities=False,
+                gamma0=1.0,
+                log_Z_guess=None,
+                **kwargs):
+        """Initialize a SAMS sampler.
+
+        Parameters
+        ----------
+        log_target_probabilities : array-like or None
+            ``log_target_probabilities[state_index]`` is the log target probability for thermodynamic state ``state_index``
+            When converged, each state should be sampled with the specified log probability.
+            If None, uniform probabilities for all states will be assumed.
+        state_update_scheme : str, optional, default='global-jump'
+            Specifies the scheme used to sample new thermodynamic states given fixed sampler states.
+            One of ['global-jump', 'local-jump', 'restricted-range-jump']
+            ``global_jump`` will allow the sampler to access any thermodynamic state
+            ``local-jump`` will propose a move to one of the local neighborhood states, and accept or reject.
+            ``restricted-range`` will compute the probabilities for each of the states in the local neighborhood, increasing jump probability
+        locality : int, optional, default=1
+            Number of neighboring states on either side to consider for local update schemes.
+        update_stages : str, optional, default='two-stage'
+            One of ['one-stage', 'two-stage']
+            ``one-stage`` will use the asymptotically optimal scheme throughout the entire simulation (not recommended due to slow convergence)
+            ``two-stage`` will use a heuristic first stage to achieve flat histograms before switching to the asymptotically optimal scheme
+        flatness_threshold : float, optiona, default=0.2
+            Histogram relative flatness threshold to use for first stage of two-stage scheme.
+        weight_update_method : str, optional, default='rao-blackwellized'
+            Method to use for updating log weights in SAMS. One of ['optimal', 'rao-blackwellized']
+            ``rao-blackwellized`` will update log free energy estimate for all states for which energies were computed
+            ``optimal`` will use integral counts to update log free energy estimate of current state only
+        adapt_target_probabilities : bool, optional, default=False
+            If True, target probabilities will be adapted to achieve minimal thermodynamic length between terminal thermodynamic states.
+            (EXPERIMENTAL)
+        gamma0 : float, optional, default=0.0
+            Initial weight adaptation rate.
+        log_Z_guess : array-like of shape [n_states] of floats, optiona, default=None
+            Initial guess for logZ for all states, if available.
+        """
+        # Initialize multi-state sampler
+        super(SAMSSampler, self).__init__(**kwargs)
+        # Options
+        self.log_target_probabilities = log_target_probabilities
+        self.state_update_scheme = state_update_scheme
+        self.locality = locality
+        self.update_stages = update_stages
+        self.flatness_threshold = flatness_threshold
+        self.weight_update_method = weight_update_method
+        self.adapt_target_probabilities = adapt_target_probabilities
+        self.gamma0 = gamma0
+        self.log_Z_guess = log_Z_guess
+        # Private variables
+        self._replica_neighbors = None # self._replica_neighbors[replica_index] is a list of states that form the neighborhood of ``replica_index``
+
+    class _StoredProperty(MultiStateSampler._StoredProperty):
+
+        @staticmethod
+        def _state_update_scheme_validator(instance, scheme):
+            supported_schemes = ['global-jump', 'local-jump', 'restricted-range-jump']
+            if scheme not in supported_schemes:
+                raise ValueError("Unknown update scheme '{}'. Supported values "
+                                 "are {}.".format(scheme, supported_schemes))
+            return scheme
+
+        @staticmethod
+        def _update_stages_validator(instance, scheme):
+            supported_schemes = ['one-stage', 'two-stage']
+            if scheme not in supported_schemes:
+                raise ValueError("Unknown update scheme '{}'. Supported values "
+                                 "are {}.".format(scheme, supported_schemes))
+            return scheme
+
+        @staticmethod
+        def _weight_update_method_validator(instance, scheme):
+            supported_schemes = ['optimal', 'rao-blackwellized']
+            if scheme not in supported_schemes:
+                raise ValueError("Unknown update scheme '{}'. Supported values "
+                                 "are {}.".format(scheme, supported_schemes))
+            return scheme
+
+        @staticmethod
+        def _adapt_target_probabilities_validator(instance, scheme):
+            supported_schemes = [False]
+            if scheme not in supported_schemes:
+                raise ValueError("Unknown update scheme '{}'. Supported values "
+                                 "are {}.".format(scheme, supported_schemes))
+            return scheme
+
+    log_target_probabilities = _StoredProperty('log_target_probabilities', validate_function=None)
+    state_update_scheme = _StoredProperty('state_update_scheme', validate_function=_StoredProperty._state_update_scheme_validator)
+    locality = _StoredProperty('locality', validate_function=None)
+    update_stages = _StoredProperty('update_stages', validate_function=_StoredProperty._update_stages_validator)
+    flatness_threshold = _StoredProperty('flatness_threshold', validate_function=None)
+    weight_update_method = _StoredProperty('weight_update_method', validate_function=_StoredProperty._weight_update_method_validator)
+    adapt_target_probabilities = _StoredProperty('adapt_target_probabilities', validate_function=_StoredProperty._adapt_target_probabilities_validator)
+    gamma0 = _StoredProperty('gamma0', validate_function=None)
+    log_Z_guess = _StoredProperty('log_Z_guess', validate_function=None)
+
+    def create(self, thermodynamic_states: list, sampler_states:list, storage,
+               **kwargs):
+        """Initialize SAMS sampler.
+
+        Parameters
+        ----------
+        thermodynamic_states : list of openmmtools.states.ThermodynamicState
+            Thermodynamic states to simulate, where one replica is allocated per state.
+            Each state must have a system with the same number of atoms.
+        sampler_states : list of openmmtools.states.SamplerState
+            One or more sets of initial sampler states.
+            The number of replicas is determined by the number of sampler states provided,
+            and does not need to match the number of thermodynamic states.
+            Most commonly, a single sampler state is provided.
+        storage : str or Reporter
+            If str: path to the storage file, checkpoint options are default
+            If Reporter: Instanced :class:`Reporter` class, checkpoint information is read from
+            In the future this will be able to take a Storage class as well.
+        initial_thermodynamic_states : None or list or array-like of int of length len(sampler_states), optional,
+            default: None.
+            Initial thermodynamic_state index for each sampler_state.
+            If no initial distribution is chosen, ``sampler_states`` are distributed between the
+            ``thermodynamic_states`` following these rules:
+
+                * If ``len(thermodynamic_states) == len(sampler_states)``: 1-to-1 distribution
+
+                * If ``len(thermodynamic_states) > len(sampler_states)``: First and last state distributed first
+                  remaining ``sampler_states`` spaced evenly by index until ``sampler_states`` are depleted.
+                  If there is only one ``sampler_state``, then the only first ``thermodynamic_state`` will be chosen
+
+                * If ``len(thermodynamic_states) < len(sampler_states)``, each ``thermodynamic_state`` receives an
+                  equal number of ``sampler_states`` until there are insufficient number of ``sampler_states`` remaining
+                  to give each ``thermodynamic_state`` an equal number. Then the rules from the previous point are
+                  followed.
+        metadata : dict, optional
+           Simulation metadata to be stored in the file.
+        """
+        # Initialize replica-exchange simulation.
+        super(SAMSSampler, self).create(thermodynamic_states, sampler_states, storage=storage, **kwargs)
+
+        if (self.state_update_scheme == 'global-jump'):
+            self.locality = None # override locality to be global
+        if (self.locality is not None):
+            if (self.locality < 1):
+                raise Exception('locality must be >= 1')
+            elif (self.locality >= n_states):
+                self.locality = None
+
+        # Record current weight update stage
+        self._t0 = 0 # reference iteration to subtract
+        if self.update_stages == 'one-stage':
+            self._stage = 'asymptotically-optimal' # start with asymptotically-optimal stage
+        elif self.update_stages == 'two-stage':
+            self._stage = 'initial' # start with rapid heuristic adaptation initial stage
+
+        # Update log target probabilities
+        if self.log_target_probabilities is None:
+            self.log_target_probabilities = np.zeros([self.n_states], np.float64) - np.log(self.n_states) # log(1/n_states)
+
+        # Record initial logZ estimates
+        self._logZ = np.zeros([self.n_states], np.float64)
+        if self.log_Z_guess is not None:
+            if len(self.log_Z_guess) != self.n_states:
+                raise Exception('Initial log_Z_guess (dim {}) must have same number of states as n_states ({})'.format(len(log_Z_guess), self.n_states))
+            self._logZ = np.array(self.log_Z_guess, np.float64)
+
+        # Update log weights
+        self._update_log_weights()
+
+
+    # TODO: Get rid of from_storage() when we move read_logZ and write_logZ to multistatesampler.py
+    @classmethod
+    def from_storage(cls, storage):
+        """Constructor from an existing storage file.
+
+        Parameters
+        ----------
+        storage : str or Reporter
+            If str: The path to the storage file.
+            If :class:`Reporter`: uses the :class:`Reporter` options
+            In the future this will be able to take a Storage class as well.
+
+        Returns
+        -------
+        sampler : SAMSSampler
+            A new instance of MultiStateSampler (or subclass) in the same state of the
+            last stored iteration.
+
+        """
+        sampler = MultiStateSampler.from_storage(storage)
+
+        sampler._reporter.open(mode='a')
+        self._logZ = sampler._reporter.read_logZ()
+        sampler._reporter.close()
+
+        return sampler
+
+    def _report_iteration(self):
+        super(SAMSSampler, self)._report_iteration()
+        self._reporter.write_logZ(self._logZ)
+
+    @mpi.on_single_node(0, broadcast_result=True)
+    def _mix_replicas(self):
+        """Update thermodynamic states according to user-specified scheme."""
+        logger.debug("Updating thermodynamic states...")
+
+        # Reset storage to keep track of swap attempts this iteration.
+        self._n_accepted_matrix[:, :] = 0
+        self._n_proposed_matrix[:, :] = 0
+
+        # Perform swap attempts according to requested scheme.
+        # TODO: We may be able to refactor this to simply have different update schemes compute neighborhoods differently.
+        # TODO: Can we allow "plugin" addition of new update schemes that can be registered externally?
+        with mmtools.utils.time_it('Mixing of replicas'):
+            self._replica_log_P_k = np.zeros([self.n_replicas, self.n_states], np.float64)
+            if self.state_update_scheme == 'global-jump':
+                self._global_jump()
+            elif self.state_update_scheme == 'local-jump':
+                self._local_jump()
+            elif self.state_update_scheme == 'restricted-range-jump':
+                self._restricted_range_jump()
+            else:
+                raise Exception('Programming error: Unreachable code')
+
+        # Determine fraction of swaps accepted this iteration.
+        n_swaps_proposed = self._n_proposed_matrix.sum()
+        n_swaps_accepted = self._n_accepted_matrix.sum()
+        swap_fraction_accepted = 0.0
+        if n_swaps_proposed > 0:
+            # TODO drop casting to float when dropping Python 2 support.
+            swap_fraction_accepted = float(n_swaps_accepted) / n_swaps_proposed
+        logger.debug("Accepted {}/{} attempted swaps ({:.1f}%)".format(n_swaps_accepted, n_swaps_proposed,
+                                                                       swap_fraction_accepted * 100.0))
+
+        # Update logZ estimates
+        self._update_logZ_estimates()
+
+        # Update log weights based on target probabilities
+        self._update_log_weights()
+
+    def _local_jump(self):
+        n_replica, n_states, locality = self.n_replicas, self.n_states, self.locality
+        for (replica_index, current_state_index) in enumerate(self._replica_thermodynamic_states):
+            u_k = np.zeros([n_states], np.float64)
+            log_P_k = np.zeros([n_states], np.float64)
+            # Determine current neighborhood.
+            neighborhood = self._neighborhood()
+            neighborhood_size = len(neighborhood)
+            # Propose a move from the current neighborhood.
+            proposed_state_index = np.random.choice(neighborhood, p=np.ones([neighborhood_size], np.float64) / float(neighborhood_size))
+            # Determine neighborhood for proposed state.
+            proposed_neighborhood = self._neighborhood(proposed_state_index)
+            proposed_neighborhood_size = len(proposed_neighborhood)
+            # Compute state log weights.
+            log_Gamma_j_L = - float(proposed_neighborhood_size) # log probability of proposing return
+            log_Gamma_L_j = - float(neighborhood_size)          # log probability of proposing new state
+            L = current_state_index
+            # Compute potential for all states in neighborhood
+            for j in neighborhood:
+                u_k[j] = self._energy_thermodynamic_states[replica_index, j]
+            # Compute log of probability of selecting each state in neighborhood
+            for j in neighborhood:
+                if j != L:
+                    log_P_k[j] = log_Gamma_L_j + min(0.0, log_Gamma_j_L - log_Gamma_L_j + (self.log_weights[j] - u_k[j]) - (self.log_weights[L] - u_k[L]))
+            P_k = np.zeros([n_states], np.float64)
+            P_k[neighborhood] = np.exp(log_P_k[neighborhood])
+            # Compute probability to return to current state L
+            P_k[L] = 0.0
+            P_k[L] = 1.0 - P_k[neighborhood].sum()
+            log_P_k[L] = np.log(P_k[L])
+            # Update context.
+            thermodynamic_state_index = np.random.choice(neighborhood, p=P_k[neighborhood])
+            self._replica_thermodynamic_states[replica_index] = thermodynamic_state_index
+            # Accumulate statistics
+            self._replica_log_P_k[replica_index,:] = log_P_k[:]
+            self._n_proposed_matrix[current_state_index, neighborhood] += 1
+            self._n_accepted_matrix[current_state_index, thermodynamic_state_index] += 1
+
+    def _global_jump(self):
+        """
+        Global jump scheme.
+        This method is described after Eq. 3 in [2]
+        """
+        n_replica, n_states = self.n_replicas, self.n_states
+        for (replica_index, current_state_index) in enumerate(self._replica_thermodynamic_states):
+            u_k = np.zeros([n_states], np.float64)
+            log_P_k = np.zeros([n_states], np.float64)
+            # Compute unnormalized log probabilities for all thermodynamic states
+            neighborhood = self._neighborhood(current_state_index)
+            for state_index in neighborhood:
+                u_k[state_index] = self._energy_thermodynamic_states[replica_index, state_index]
+                log_P_k[state_index] = self.log_weights[state_index] - u_k[state_index]
+            log_P_k -= logsumexp(log_P_k)
+            # Update sampler Context to current thermodynamic state.
+            P_k = np.exp(log_P_k[neighborhood])
+            thermodynamic_state_index = np.random.choice(neighborhood, p=P_k)
+            self._replica_thermodynamic_states[replica_index] = thermodynamic_state_index
+            # Accumulate statistics
+            self._replica_log_P_k[replica_index,:] = log_P_k[:]
+            self._n_proposed_matrix[current_state_index, neighborhood] += 1
+            self._n_accepted_matrix[current_state_index, thermodynamic_state_index] += 1
+
+    def _restricted_range_jump(self):
+        n_replica, n_states, locality = self.n_replicas, self.n_states, self.locality
+        for (replica_index, current_state_index) in enumerate(self._replica_thermodynamic_states):
+            u_k = np.zeros([n_states], np.float64)
+            log_P_k = np.zeros([n_states], np.float64)
+            # Propose new state from current neighborhood.
+            neighborhood = self._neighborhood(current_state_index)
+            for j in neighborhood:
+                u_k[j] = self._energy_thermodynamic_states[replica_index, j]
+                log_P_k[j] = self.log_weights[j] - u_k[j]
+            log_P_k[neighborhood] -= logsumexp(log_P_k[neighborhood])
+            P_k = np.exp(log_P_k[neighborhood])
+            proposed_state_index = np.random.choice(neighborhood, p=P_k)
+            # Determine neighborhood of proposed state.
+            proposed_neighborhood = self._neighborhood(proposed_state_index)
+            for j in proposed_neighborhood:
+                if j not in neighborhood:
+                    u_k[j] = self._energy_thermodynamic_states[replica_index, j]
+            # Accept or reject.
+            log_P_accept = logsumexp(self.log_weights[neighborhood] - u_k[neighborhood]) - logsumexp(self.log_weights[proposed_neighborhood] - u_k[proposed_neighborhood])
+            if (log_P_accept >= 0.0) or (np.random.rand() < np.exp(log_P_accept)):
+                thermodynamic_state_index = proposed_state_index
+            self._replica_thermodynamic_states[replica_index] = thermodynamic_state_index
+            # Accumulate statistics
+            self._replica_log_P_k[replica_index,:] = log_P_k[:]
+            self._n_proposed_matrix[current_state_index, neighborhood] += 1
+            self._n_accepted_matrix[current_state_index, thermodynamic_state_index] += 1
+
+    def _state_histogram(self):
+        """
+        Compute the histogram for the number of times each state has been visited.
+
+        Returns
+        -------
+        N_k : array-like of shape [n_states] of int
+            N_k[state_index] is the number of times a replica has visited state ``state_index``
+        """
+        # TODO: Instead of summing each iteration, store `number_of_state_visits[:]` in storage?
+        replica_thermodynamic_states = self._reporter.read_replica_thermodynamic_states(iteration=slice(0,self._iteration))
+        N_k, _ = np.histogram(replica_thermodynamic_states, bins=np.arange(-0.5, self.n_states+0.5))
+        return N_k
+
+    def _update_stage(self):
+        """
+        Determine which adaptation stage we're in by checking histogram flatness.
+
+        """
+        if (self.update_stages == 'two-stage') and (self._stage == 'initial'):
+            # Check histogram flatness
+            N_k = self._state_histogram()
+            empirical_pi_k = N_k[:] / N_k.sum()
+            pi_k = np.exp(self.log_target_probabilities)
+            relative_error_k = np.abs(pi_k - empirical_pi_k) / pi_k
+            if np.all(relative_error_k < self.flatness_threshold):
+                # Histograms are sufficiently flat; switch to asymptotically optimal schem
+                self._stage = 'asymptotically-optimal'
+                self._t0 = self._iteration
+
+    def _update_logZ_estimates(self):
+        """
+        Update the logZ estimates according to selected SAMS update method
+
+        References
+        ----------
+        [1] http://www.stat.rutgers.edu/home/ztan/Publication/SAMS_redo4.pdf
+
+        """
+        # Retrieve target probabilities
+        log_pi_k = self.log_target_probabilities
+        pi_k = np.exp(self.log_target_probabilities)
+
+        # Update which stage we're in, checking histogram flatness
+        self._update_stage()
+
+        # Update logZ estimates from all replicas
+        for (replica_index, state_index) in enumerate(self._replica_thermodynamic_states):
+            # Compute attenuation factor gamma
+            if self._stage == 'initial':
+                beta_factor = 0.4
+                t = self._iteration + 1.0
+                gamma = min(pi_k[state_index], t**(-beta_factor)) # Eq. 15
+            elif self._stage == 'asymptotically-optimal':
+                gamma = 1.0 / float(self._iteration - self._t0 + 1./self.gamma0) # prefactor in Eq. 9 and 12 from [1]
+            else:
+                raise Exception('Programming error:unreachable code')
+
+            # TODO: Store gamma for each replica: self.ncfile.variables['gamma'][self.iteration] = gamma
+
+            # Update online logZ estimate
+            if self.weight_update_method == 'optimal':
+                # Based on Eq. 9 of Ref. [1]
+                self._logZ[state_index] += gamma * np.exp(-log_pi_k[state_index])
+            elif self.weight_update_method == 'rao-blackwellized':
+                # Based on Eq. 12 of Ref [1]
+                # TODO: This has to be the previous state index and log_P_k used before update; store neighborhood?
+                # TODO: Can we use masked arrays for this purpose?
+                neighborhood = self._neighborhoods[replica_index,:]
+                log_P_k = self._replica_log_P_k[replica_index,:]
+                self._logZ[neighborhood] += gamma * np.exp(log_P_k[neighborhood] - log_pi_k[neighborhood])
+            else:
+                raise Exception('Programming error: Unreachable code')
+
+        # Subtract off logZ[0] to prevent logZ from growing without bound
+        self._logZ[:] -= self._logZ[0]
+
+    def _update_log_weights(self):
+        """
+        Update the log weights based on current online logZ estimates
+
+        """
+        # TODO: Add option to adapt target probabilities as well
+        # TODO: If target probabilities are adapted, we need to store them as well
+
+        self.log_weights = self.log_target_probabilities[:] - self._logZ[:]
+
+class SAMSAnalyzer(MultiStateSamplerAnalyzer):
+    """
+    The SAMSAnalyzer is the analyzer for a simulation generated from a SAMSSampler simulation.
+
+    See Also
+    --------
+    ReplicaExchangeAnalyzer
+    PhaseAnalyzer
+
+    """
+    pass
+
+# ==============================================================================
+# MAIN AND TESTS
+# ==============================================================================
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -514,6 +514,9 @@ class SAMSSampler(MultiStateSampler):
         if (self.update_stages == 'two-stage') and (self._stage == 'initial'):
             # Check histogram flatness
             N_k = self._state_histogram()
+            if N_k.sum() == 0:
+                # No samples yet; don't do anything.
+                return
             empirical_pi_k = N_k[:] / N_k.sum()
             pi_k = np.exp(self.log_target_probabilities)
             relative_error_k = np.abs(pi_k - empirical_pi_k) / pi_k

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -911,9 +911,6 @@ class TestMultiStateSampler(object):
         """Test that citations are displayed and suppressed as needed."""
         thermodynamic_states, sampler_states, unsampled_states = copy.deepcopy(self.alanine_test)
 
-        # Remove one sampler state to verify distribution over states.
-        sampler_states = sampler_states[:-1]
-
         with self.temporary_storage_path() as storage_path:
             sampler = self.SAMPLER()
             reporter = self.REPORTER(storage_path, checkpoint_interval=1)
@@ -1050,10 +1047,6 @@ class TestMultiStateSampler(object):
                 original_dict.pop('_cached_transition_counts', None)
                 original_dict.pop('_cached_last_replica_thermodynamic_states', None)
 
-                # TODO: Remove these debug lines -LNN
-                # if self.SAMPLER == SAMSSampler:
-                #     import pdb
-                #     pdb.set_trace()
                 # Check all other arrays. Instantiate list so that we can pop from original_dict.
                 for attr, original_value in list(original_dict.items()):
                     if isinstance(original_value, np.ndarray):
@@ -1066,7 +1059,6 @@ class TestMultiStateSampler(object):
                 assert original_dict == restored_dict
 
                 # Run few iterations to see that we restore also after a while.
-
                 if iteration == 0:
                     sampler.run(number_of_iterations)
 
@@ -1319,6 +1311,7 @@ class TestMultiStateSampler(object):
                     mmtools.mcmc.MCRotationMove(),
                     mmtools.mcmc.GHMCMove(n_steps=1)
                 ])
+
                 sampler = self.SAMPLER(mcmc_moves=moves, number_of_iterations=2)
                 reporter = self.REPORTER(storage_path, checkpoint_interval=1)
                 self.call_sampler_create(sampler, reporter,
@@ -1337,7 +1330,7 @@ class TestMultiStateSampler(object):
 
                 # Extract the sampled thermodynamic states
                 # Only use propagated states since the last iteration is not subject to MCMC moves
-                sampled_states = list(reporter.read_replica_thermodynamic_states()[:-1].flat)
+                sampled_states = list(reporter.read_replica_thermodynamic_states()[1:].flat)
 
                 # All replicas must have moves with updated statistics.
                 for state_index, sequence_move in enumerate(sampler._mcmc_moves):
@@ -1574,6 +1567,7 @@ class TestReplicaExchange(TestMultiStateSampler):
         additional_values.update(self.property_creator('replica_mixing_scheme', 'replica_mixing_scheme', None, None))
         self.actual_stored_properties_check(additional_properties=additional_values)
 
+
 class TestSingleReplicaSAMS(TestMultiStateSampler):
     """Test suite for SAMSSampler class."""
 
@@ -1594,17 +1588,18 @@ class TestSingleReplicaSAMS(TestMultiStateSampler):
         """Test that storage is kept in sync with options. Unique to SAMSSampler"""
         additional_values = {}
         options = {
-            'state_update_scheme' : 'local-jump',
-            'locality' : 2,
-            'update_stages' : 'one-stage',
-            'weight_update_method' : 'optimal',
-            'adapt_target_probabilities' : False,
+            'state_update_scheme': 'local-jump',
+            'locality': 2,
+            'update_stages': 'one-stage',
+            'weight_update_method': 'optimal',
+            'adapt_target_probabilities': False,
             }
         for (name, value) in options.items():
             additional_values.update(self.property_creator(name, name, value, value))
         self.actual_stored_properties_check(additional_properties=additional_values)
 
     # TODO: Test all update methods
+
 
 class TestMultipleReplicaSAMS(TestMultiStateSampler):
     """Test suite for SAMSSampler class."""
@@ -1626,17 +1621,18 @@ class TestMultipleReplicaSAMS(TestMultiStateSampler):
         """Test that storage is kept in sync with options. Unique to SAMSSampler"""
         additional_values = {}
         options = {
-            'state_update_scheme' : 'restricted-range-jump',
-            'locality' : 3,
-            'update_stages' : 'two-stage',
+            'state_update_scheme': 'restricted-range-jump',
+            'locality': 3,
+            'update_stages': 'two-stage',
             'weight_update_method' : 'rao-blackwellized',
-            'adapt_target_probabilities' : False,
+            'adapt_target_probabilities': False,
             }
         for (name, value) in options.items():
             additional_values.update(self.property_creator(name, name, value, value))
         self.actual_stored_properties_check(additional_properties=additional_values)
 
     # TODO: Test all update methods
+
 
 class TestParallelTempering(TestMultiStateSampler):
 
@@ -1705,6 +1701,7 @@ class TestParallelTempering(TestMultiStateSampler):
                     energies[i][j] = state.reduced_potential(context)
         return energy_thermodynamic_states, energy_unsampled_states
 
+
 # ==============================================================================
 # MAIN AND TESTS
 # ==============================================================================
@@ -1715,4 +1712,4 @@ if __name__ == "__main__":
 
     # Test simple system of harmonic oscillators.
     # Disabled until we fix the test
-    test_replica_exchange()
+    # test_replica_exchange()

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -1046,6 +1046,10 @@ class TestMultiStateSampler(object):
                 original_dict.pop('_cached_transition_counts', None)
                 original_dict.pop('_cached_last_replica_thermodynamic_states', None)
 
+                # TODO: Remove these debug lines -LNN
+                # if self.SAMPLER == SAMSSampler:
+                #     import pdb
+                #     pdb.set_trace()
                 # Check all other arrays. Instantiate list so that we can pop from original_dict.
                 for attr, original_value in list(original_dict.items()):
                     if isinstance(original_value, np.ndarray):
@@ -1058,6 +1062,7 @@ class TestMultiStateSampler(object):
                 assert original_dict == restored_dict
 
                 # Run few iterations to see that we restore also after a while.
+
                 if iteration == 0:
                     sampler.run(number_of_iterations)
 


### PR DESCRIPTION
This supercedes #886.

@Lnaden : I need your help adding writing/reading logZ to the storage layer in an appropriately modular way. I'd like to store it without having to implement a ton of extra code to subclass things. We have a couple of options:

Option 1: Reuse `log_f_k`. It could make sense to co-opt the online analysis framework for SAMS, since it provides its own online analysis, but it would also require overriding or restructuring the way we do online analysis right now, which is very MBAR-centric. I'd like to overhaul that, but maybe later. Note that `logZ[k] = - log_f_k[k]` in my convention, so we can easily store one or the other---no real need to store both.

Option 2: Make it easier to extend what kinds of data are stored to / resumed from the storage. Is there some way we can make it really easy for subclasses to simply specify they want to store more data without having to subclass a ton of things? Right now, it seems like this would require
* Creating a new `SAMSReporter` that has its own copy of `__init__`
* Implementing `write_X` and `read_X` in `SAMSReporter`
* Implementing `from_storage` and `_report_iteration` to first call `MultiStateSampler` versions of these methods and then `read_X` or `write_X`

There may still be other bugs to squish, but resuming/storing `logZ` is the biggest challenge so far.

Once we get this implemented, we still need a way to test, since there is no way to select the sampler via the YAML file yet.
