### PR TITLE
Augment --jobid to take the contents of an environment variable if desired

### DIFF
--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -105,11 +105,20 @@ def dispatch(args):
                 job_id = int(os.environ[job_id]) + 1
             else:
                 raise ValueError("--jobid '%s' unknown" % job_id)
-
     else:
         job_id = None
+
     if args['--njobs']:
-        n_jobs = int(args['--njobs'])
+        n_jobs = args['--njobs']
+        try:
+            # Try processing it as an integer
+            n_jobs = int(n_jobs)
+        except ValueError:
+            if n_jobs in os.environ:
+                # Take the value of the environment variable
+                n_jobs = int(os.environ[n_jobs])
+            else:
+                raise ValueError("--njobs '%s' unknown" % njobs)
     else:
         n_jobs = None
 

--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -41,6 +41,8 @@ Optional Arguments:
                                 Alternatively, a zero-indexed environment variable name can be specified, in which
                                 case the jobid will be taken from this variable (0 <= environment variable < n_jobs).
   --njobs=INTEGER               Specify the total number of parallel executions. jobid has to be specified too.
+                                Alternatively, an environment variable name can be specified, in which
+                                case the number of jobs jobid will be taken from this variable.
   -o, --override=OVERRIDE       Override a single option in the script file. May be specified multiple times.
                                 Specified as a nested dictionary of the form:
                                 top_option:sub_option:value

--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -38,6 +38,8 @@ Optional Arguments:
                                 1 <= job_id <= n_jobs. In this case, njobs must be specified as well and YANK will
                                 run only 1/n_jobs of the experiments. This can be used to run several separate YANK
                                 executions in parallel starting from the same script.
+                                Alternatively, a zero-indexed environment variable name can be specified, in which
+                                case the jobid will be taken from this variable (0 <= environment variable < n_jobs).
   --njobs=INTEGER               Specify the total number of parallel executions. jobid has to be specified too.
   -o, --override=OVERRIDE       Override a single option in the script file. May be specified multiple times.
                                 Specified as a nested dictionary of the form:
@@ -93,7 +95,17 @@ def dispatch(args):
         override = str(override_dict).replace("'", "").replace('"', '')
 
     if args['--jobid']:
-        job_id = int(args['--jobid'])
+        job_id = args['--jobid']
+        try:
+            # Try processing it as an integer
+            job_id = int(job_id)
+        except ValueError:
+            if job_id in os.environ:
+                # Take the value of the environment variable
+                job_id = int(os.environ[job_id]) + 1
+            else:
+                raise ValueError("--jobid '%s' unknown" % job_id)
+
     else:
         job_id = None
     if args['--njobs']:


### PR DESCRIPTION
This adds the ability to specify `--jobid=ENVNAME`, where `ENVNAME` is the name of a zero-indexed environment variable.

How do we test `--jobid` in the units tests? I was looking to add a unit test, but couldn't find where the `--jobid` tests were.

This feature is needed for ORNL TITAN.