### PR TITLE
Add samplers hooks to YAML scripts

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1229,7 +1229,7 @@ class ExperimentBuilder(object):
             if cutoff == 'auto':
                 return cutoff
             else:
-                return utils.process_unit_bearing_str(cutoff, unit.angstroms)
+                return utils.quantity_from_string(cutoff, unit.angstroms)
 
         special_conversions = {'constraints': to_openmm_app,
                                'number_of_iterations': integer_or_infinity,
@@ -1331,9 +1331,9 @@ class ExperimentBuilder(object):
             validator: int_or_all_string
         """
         # Build small molecule Epik by hand as dict since we are fetching from another source
-        epik_schema = utils.generate_signature_schema(moltools.schrodinger.run_epik,
-                                                      update_keys={'select': {'required': False, 'type': 'integer'}},
-                                                      exclude_keys=['extract_range'])
+        epik_schema = schema.generate_signature_schema(moltools.schrodinger.run_epik,
+                                                       update_keys={'select': {'required': False, 'type': 'integer'}},
+                                                       exclude_keys=['extract_range'])
         epik_schema = {'epik': {
             'required': False,
             'type': 'dict',
@@ -1500,7 +1500,7 @@ class ExperimentBuilder(object):
 
             See call to :func:`utils.to_unit_validator` for call
             """
-            unit_validator = utils.to_unit_validator(compatible_units)
+            unit_validator = schema.to_unit_validator(compatible_units)
 
             def _to_unit_unless_none(input_quantity):
                 if input_quantity is None:
@@ -1512,8 +1512,8 @@ class ExperimentBuilder(object):
         # Define solvents Schema
         # Create the basic solvent schema, ignoring things which have a dependency
         # Some keys we manually tweak
-        base_solvent_schema = utils.generate_signature_schema(AmberPrmtopFile.createSystem,
-                                                              exclude_keys=['nonbonded_method'])
+        base_solvent_schema = schema.generate_signature_schema(AmberPrmtopFile.createSystem,
+                                                               exclude_keys=['nonbonded_method'])
         implicit_solvent_default_schema = {'implicit_solvent': base_solvent_schema.pop('implicit_solvent')}
         rigid_water_default_schema = {'rigid_water': base_solvent_schema.pop('rigid_water')}
         nonbonded_cutoff_default_schema = {'nonbonded_cutoff': base_solvent_schema.pop('nonbonded_cutoff')}
@@ -1531,7 +1531,7 @@ class ExperimentBuilder(object):
         explicit_only_keys = {
             'clearance': {
                 'type': 'quantity',
-                'coerce': utils.to_unit_validator(unit.angstrom),
+                'coerce': schema.to_unit_validator(unit.angstrom),
             },
             'solvent_model': {
                 'type': 'string',

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2773,7 +2773,7 @@ class ExperimentBuilder(object):
             if solvent_id is None:
                 system_options = None
             else:
-                system_options = utils.merge_dict(self._db.solvents[solvent_id], exp_opts)
+                system_options = {**self._db.solvents[solvent_id], **exp_opts}
             logger.info("Reading phase {}".format(phase_name))
             system, topology, sampler_state = pipeline.read_system_files(
                 positions_file_path, parameters_file_path, system_options,

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -99,29 +99,6 @@ def to_openmm_app(input_string):
     return getattr(openmm.app, input_string)
 
 
-def convert_if_quantity(value):
-    """
-    Try to convert a passed value to quantity
-
-    Parameters
-    ----------
-    value : int, float, or simtk.unit.Quantity as string
-        This function tries to take a string which can be converted to a quantity with the
-        :func:`yank.utils.quantity_from_string`, or just a number
-
-    Returns
-    -------
-    output : value or simtk.unit.Quantity
-        Returns either the Quantity which was converted from string, or the original value.
-
-    """
-    try:
-        quantity = utils.quantity_from_string(value)
-    except:
-        return value
-    return quantity
-
-
 def _is_phase_completed(status, number_of_iterations):
     """Check if the stored simulation is completed.
 
@@ -211,7 +188,7 @@ class AlchemicalPhaseFactory(object):
 
     Parameters
     ----------
-    sampler : yank.multistate.ReplicaExchangeSampler
+    sampler : yank.multistate.MultiStateSampler
         Sampler which will carry out the simulation
     thermodynamic_state : openmmtools.states.ThermodynamicState
         Reference thermodynamic state without any alchemical modifications
@@ -557,7 +534,7 @@ class ExperimentBuilder(object):
     ...     yaml_content = '''
     ...     ---
     ...     options:
-    ...       number_of_iterations: 1
+    ...       default_number_of_iterations: 1
     ...       output_dir: {}
     ...     molecules:
     ...       T4lysozyme:
@@ -626,7 +603,8 @@ class ExperimentBuilder(object):
         'timestep': 2.0 * unit.femtosecond,
         'collision_rate': 1.0 / unit.picosecond,
         'mc_displacement_sigma': 10.0 * unit.angstroms,
-        'integrator_splitting': 'V R O R V'
+        'integrator_splitting': 'V R O R V',
+        'default_number_of_iterations': 5000
     }
 
     def __init__(self, script=None, job_id=None, n_jobs=None):
@@ -773,6 +751,7 @@ class ExperimentBuilder(object):
         self._db.systems = self._validate_systems(yaml_content.get('systems', {}))
 
         # Validate protocols
+        self._samplers = self._validate_samplers(yaml_content)
         self._protocols = self._validate_protocols(yaml_content.get('protocols', {}))
 
         # Validate experiments
@@ -891,8 +870,8 @@ class ExperimentBuilder(object):
 
         for experiment_idx, (exp_path, exp_description) in enumerate(self._expand_experiments()):
             # Determine the final number of iterations for this experiment.
-            _, _, sampler_options, _, _ = self._determine_experiment_options(exp_description)
-            number_of_iterations = sampler_options['number_of_iterations']
+            sampler = self._create_experiment_sampler(exp_description, mc_atoms=[])
+            number_of_iterations = sampler.number_of_iterations
 
             # Determine the phases status.
             phases = collections.OrderedDict()
@@ -1011,12 +990,11 @@ class ExperimentBuilder(object):
 
         experiment_options = _filter_options(self.EXPERIMENT_DEFAULT_OPTIONS)
         phase_options = _filter_options(AlchemicalPhaseFactory.DEFAULT_OPTIONS)
-        sampler_options = _filter_options(multistate.ReplicaExchangeSampler.default_options())
         alchemical_region_options = _filter_options(mmtools.alchemy._ALCHEMICAL_REGION_ARGS)
         alchemical_factory_options = _filter_options(utils.get_keyword_args(
             mmtools.alchemy.AbsoluteAlchemicalFactory.__init__))
 
-        return (experiment_options, phase_options, sampler_options,
+        return (experiment_options, phase_options,
                 alchemical_region_options, alchemical_factory_options)
 
     # --------------------------------------------------------------------------
@@ -1203,9 +1181,6 @@ class ExperimentBuilder(object):
         template_options = cls.EXPERIMENT_DEFAULT_OPTIONS.copy()
         template_options.update(AlchemicalPhaseFactory.DEFAULT_OPTIONS)
         template_options.update(mmtools.alchemy._ALCHEMICAL_REGION_ARGS)
-        sampler = multistate.ReplicaExchangeSampler
-        # Recursive search for calls to __init__ from the sampler structure
-        template_options.update(utils.get_keyword_args(sampler.__init__, try_mro_from_class=sampler))
         template_options.update(utils.get_keyword_args(
             mmtools.alchemy.AbsoluteAlchemicalFactory.__init__))
 
@@ -1219,12 +1194,6 @@ class ExperimentBuilder(object):
         template_options.pop('alchemical_torsions')
         template_options.pop('switch_width')  # AbsoluteAlchemicalFactory
 
-        # Some options need to be treated differently.
-        def integer_or_infinity(value):
-            if value != float('inf'):
-                value = int(value)
-            return value
-
         def check_anisotropic_cutoff(cutoff):
             if cutoff == 'auto':
                 return cutoff
@@ -1232,7 +1201,7 @@ class ExperimentBuilder(object):
                 return utils.quantity_from_string(cutoff, unit.angstroms)
 
         special_conversions = {'constraints': to_openmm_app,
-                               'number_of_iterations': integer_or_infinity,
+                               'default_number_of_iterations': schema.to_integer_or_infinity_coercer,
                                'anisotropic_dispersion_cutoff': check_anisotropic_cutoff}
 
         # Validate parameters.
@@ -1494,13 +1463,13 @@ class ExperimentBuilder(object):
             """
             return to_openmm_app(input_string) if input_string is not None else None
 
-        def to_unit_validator_unless_none(compatible_units):
+        def to_unit_unless_none_coercer(compatible_units):
             """
-            Extension to the :func:`utils.to_unit_validator` method which also allows a None object to be set
+            Extension to the :func:`utils.to_unit_coercer` method which also allows a None object to be set
 
-            See call to :func:`utils.to_unit_validator` for call
+            See call to :func:`utils.to_unit_coercer` for call
             """
-            unit_validator = schema.to_unit_validator(compatible_units)
+            unit_validator = schema.to_unit_coercer(compatible_units)
 
             def _to_unit_unless_none(input_quantity):
                 if input_quantity is None:
@@ -1531,7 +1500,7 @@ class ExperimentBuilder(object):
         explicit_only_keys = {
             'clearance': {
                 'type': 'quantity',
-                'coerce': schema.to_unit_validator(unit.angstrom),
+                'coerce': schema.to_unit_coercer(unit.angstrom),
             },
             'solvent_model': {
                 'type': 'string',
@@ -1547,7 +1516,7 @@ class ExperimentBuilder(object):
             },
             'ionic_strength': {
                 'type': 'quantity',
-                'coerce': to_unit_validator_unless_none(unit.molar),
+                'coerce': to_unit_unless_none_coercer(unit.molar),
                 'default_setter': ionic_strength_if_explicit_else_none,
                 'nullable': True
             },
@@ -1923,6 +1892,33 @@ class ExperimentBuilder(object):
                 raise YamlParseError(error.format(system_id, yaml.dump(system_validator.errors)))
         return validated_systems
 
+    @classmethod
+    def _validate_samplers(cls, yaml_content):
+        """Validate samplers section."""
+        sampler_descriptions = yaml_content.get('samplers', None)
+        if sampler_descriptions is None:
+            return {}
+
+        sampler_schema = """
+        samplers:
+            keyschema:
+                type: string
+            valueschema:
+                type: dict
+                validator: is_sampler_constructor
+                keyschema:
+                    type: string
+        """
+        sampler_schema = yaml.load(sampler_schema)
+
+        sampler_validator = schema.YANKCerberusValidator(sampler_schema)
+        if sampler_validator.validate({'samplers': sampler_descriptions}):
+            validated_samplers = sampler_validator.document
+        else:
+            error = "Samplers validation failed with:\n{}"
+            raise YamlParseError(error.format(yaml.dump(sampler_validator.errors)))
+        return validated_samplers['samplers']
+
     def _parse_experiments(self, yaml_content):
         """Validate experiments.
 
@@ -1990,6 +1986,10 @@ class ExperimentBuilder(object):
             required: yes
             type: string
             allowed: PROTOCOL_IDS_POPULATED_AT_RUNTIME
+        sampler:
+            required: no
+            type: string
+            allowed: SAMPLER_IDS_POPULATED_AT_RUNTIME
         options:
             required: no
             type: dict
@@ -2006,6 +2006,7 @@ class ExperimentBuilder(object):
         # Populate valid types
         experiment_schema['system']['allowed'] = [str(key) for key in self._db.systems.keys()]
         experiment_schema['protocol']['allowed'] = [str(key) for key in self._protocols.keys()]
+        experiment_schema['sampler']['allowed'] = [str(key) for key in self._samplers.keys()]
         # Options validator
         experiment_schema['options']['coerce'] = coerce_and_validate_options_here_against_existing
 
@@ -2644,13 +2645,73 @@ class ExperimentBuilder(object):
         # Determine restraint description (None if not specified).
         restraint_description = experiment_description.get('restraint', None)
         if restraint_description is not None:
-            restraint_parameters = copy.deepcopy(restraint_description)
-            restraint_type = restraint_parameters.pop('type')
-            # Convert quantity parameters.
-            restraint_parameters = {par: convert_if_quantity(value)
-                                    for par, value in restraint_parameters.items()}
-            return restraints.create_restraint(restraint_type, **restraint_parameters)
+            return schema.call_restraint_constructor(restraint_description)
         return None
+
+    def _create_experiment_mcmc_move(self, experiment_description, mc_atoms):
+        """Create the MCMCMove for the experiment sampler."""
+        # TODO this will take an mcmc_move_id instead of experiment_description
+        # TODO          once the mcmc_moves section will be added to the YAML script.
+        experiment_options = self._determine_experiment_options(experiment_description)[0]
+
+        # Apply MC rotation displacement to ligand.
+        if len(mc_atoms) > 0:
+            displacement_sigma = experiment_options['mc_displacement_sigma']
+            move_list = [
+                mmtools.mcmc.MCDisplacementMove(displacement_sigma=displacement_sigma,
+                                                atom_subset=mc_atoms),
+                mmtools.mcmc.MCRotationMove(atom_subset=mc_atoms)
+            ]
+        else:
+            move_list = []
+
+        # Creating Langevin integrator move.
+        integrator_splitting = experiment_options['integrator_splitting']
+        if integrator_splitting is not None:
+            logger.debug('Using Langevin integrator with splitting {}'.format(integrator_splitting))
+            move_list.append(mmtools.mcmc.LangevinSplittingDynamicsMove(
+                timestep=experiment_options['timestep'],
+                collision_rate=experiment_options['collision_rate'],
+                n_steps=experiment_options['nsteps_per_iteration'],
+                reassign_velocities=True,
+                n_restart_attempts=6,
+                splitting=integrator_splitting,
+                measure_shadow_work=False,
+                measure_heat=False)
+            )
+        else:
+            logger.debug('Using OpenMM Langevin integrator.')
+            move_list.append(mmtools.mcmc.LangevinDynamicsMove(
+                timestep=experiment_options['timestep'],
+                collision_rate=experiment_options['collision_rate'],
+                n_steps=experiment_options['nsteps_per_iteration'],
+                reassign_velocities=True,
+                n_restart_attempts=6)
+            )
+
+        return mmtools.mcmc.SequenceMove(move_list=move_list)
+
+    def _create_experiment_sampler(self, experiment_description, mc_atoms):
+        """Create the sampler object associated to the given experiment."""
+        # Check if we need to use the default sampler.
+        sampler_id = experiment_description.get('sampler', None)
+        if sampler_id is None:
+            constructor_description = {'type': 'ReplicaExchangeSampler'}
+        else:
+            constructor_description = copy.deepcopy(self._samplers[sampler_id])
+
+        # Overwrite default number of iterations if not specified.
+        if 'number_of_iterations' not in constructor_description:
+            experiment_options = self._determine_experiment_options(experiment_description)[0]
+            default_number_of_iterations = experiment_options['default_number_of_iterations']
+            constructor_description['number_of_iterations'] = default_number_of_iterations
+
+        # Create the MCMCMove for the sampler.
+        mcmc_move = self._create_experiment_mcmc_move(experiment_description, mc_atoms)
+        constructor_description['mcmc_moves'] = mcmc_move
+
+        # Create the sampler.
+        return schema.call_sampler_constructor(constructor_description)
 
     def _build_experiment(self, experiment_path, experiment):
         """Prepare a single experiment.
@@ -2673,8 +2734,7 @@ class ExperimentBuilder(object):
 
         # Get and validate experiment sub-options and divide them by class.
         exp_opts = self._determine_experiment_options(experiment)
-        (exp_opts, phase_opts, sampler_opts,
-         alchemical_region_opts, alchemical_factory_opts) = exp_opts
+        (exp_opts, phase_opts, alchemical_region_opts, alchemical_factory_opts) = exp_opts
 
         # Configure logger file for this experiment.
         experiment_log_file_path = self._get_experiment_log_path(experiment_path)
@@ -2826,35 +2886,10 @@ class ExperimentBuilder(object):
             # We don't try displacing and rotating the ligand with a Boresch restraint
             # since the attempts would likely always fail.
             if len(topography.ligand_atoms) > 0 and not isinstance(restraint, restraints.Boresch):
-                move_list = [
-                    mmtools.mcmc.MCDisplacementMove(displacement_sigma=exp_opts['mc_displacement_sigma'],
-                                                    atom_subset=topography.ligand_atoms),
-                    mmtools.mcmc.MCRotationMove(atom_subset=topography.ligand_atoms)
-                ]
+                mc_atoms = topography.ligand_atoms
             else:
-                move_list = []
-
-            # Creating Langevin integrator move.
-            integrator_splitting = exp_opts['integrator_splitting']
-            if exp_opts['integrator_splitting'] is not None:
-                logger.debug('Using Langevin integrator with splitting {}'.format(integrator_splitting))
-                move_list.append(mmtools.mcmc.LangevinSplittingDynamicsMove(timestep=exp_opts['timestep'],
-                                                                            collision_rate=exp_opts['collision_rate'],
-                                                                            n_steps=exp_opts['nsteps_per_iteration'],
-                                                                            reassign_velocities=True,
-                                                                            n_restart_attempts=6,
-                                                                            splitting=integrator_splitting,
-                                                                            measure_shadow_work=False,
-                                                                            measure_heat=False))
-            else:
-                logger.debug('Using OpenMM Langevin integrator.')
-                move_list.append(mmtools.mcmc.LangevinDynamicsMove(timestep=exp_opts['timestep'],
-                                                                   collision_rate=exp_opts['collision_rate'],
-                                                                   n_steps=exp_opts['nsteps_per_iteration'],
-                                                                   reassign_velocities=True,
-                                                                   n_restart_attempts=6))
-            mcmc_move = mmtools.mcmc.SequenceMove(move_list=move_list)
-            sampler = multistate.ReplicaExchangeSampler(mcmc_moves=mcmc_move, **sampler_opts)
+                mc_atoms = []
+            sampler = self._create_experiment_sampler(experiment, mc_atoms)
 
             # Create phases.
             phases[phase_idx] = AlchemicalPhaseFactory(sampler, thermodynamic_state, sampler_state,
@@ -2867,7 +2902,7 @@ class ExperimentBuilder(object):
         mpi.run_single_node(0, self._save_analysis_script, results_dir, phase_names)
 
         # Return new Experiment object.
-        return Experiment(phases, sampler_opts['number_of_iterations'],
+        return Experiment(phases, sampler.number_of_iterations,
                           exp_opts['switch_phase_interval'])
 
     # --------------------------------------------------------------------------

--- a/Yank/schema/__init__.py
+++ b/Yank/schema/__init__.py
@@ -3,5 +3,6 @@ A set of tools for validating Cerberus-based schemas
 """
 
 from .validator import YANKCerberusValidator
-from .validator import to_unit_validator
+from .validator import to_unit_coercer, to_integer_or_infinity_coercer
+from .validator import call_restraint_constructor, call_sampler_constructor
 from .validator import generate_unknown_type_validator, type_to_cerberus_map, generate_signature_schema

--- a/Yank/schema/__init__.py
+++ b/Yank/schema/__init__.py
@@ -3,5 +3,5 @@ A set of tools for validating Cerberus-based schemas
 """
 
 from .validator import YANKCerberusValidator
-from .validator import generate_unknown_type_validator
-from .validator import type_to_cerberus_map
+from .validator import to_unit_validator
+from .validator import generate_unknown_type_validator, type_to_cerberus_map, generate_signature_schema

--- a/Yank/tests/test_cli.py
+++ b/Yank/tests/test_cli.py
@@ -83,7 +83,7 @@ def test_script_yaml():
     yaml_content = """
         ---
         options:
-            number_of_iterations: 0
+            default_number_of_iterations: 0
             output_dir: '.'
             resume_setup: yes
             resume_simulation: no

--- a/Yank/tests/test_examples.py
+++ b/Yank/tests/test_examples.py
@@ -59,7 +59,7 @@ def run_example(path, example):
         # adjust yaml simulation parameters
         with open(yaml_path, 'r') as f:
             test_yaml_script = yaml.load(f)
-        test_yaml_script['options']['number_of_iterations'] = n_iterations
+        test_yaml_script['options']['default_number_of_iterations'] = n_iterations
         test_yaml_script['options']['output_dir'] = testoutput_dir
         with open(testyaml_path, 'w') as f:
             f.write(yaml.dump(test_yaml_script))

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -355,7 +355,6 @@ def test_yaml_parsing():
         minimize: False
         minimize_tolerance: 1.0 * kilojoules_per_mole / nanometers
         minimize_max_iterations: 0
-        replica_mixing_scheme: null
         annihilate_sterics: no
         annihilate_electrostatics: true
         alchemical_pme_treatment: direct-space
@@ -363,7 +362,7 @@ def test_yaml_parsing():
     """
 
     exp_builder = ExperimentBuilder(textwrap.dedent(yaml_content))
-    assert len(exp_builder._options) == 36
+    assert len(exp_builder._options) == 35
 
     # The global context cache has been set.
     assert mmtools.cache.global_context_cache.capacity == 9
@@ -372,7 +371,7 @@ def test_yaml_parsing():
     assert exp_builder._options['output_dir'] == '/path/to/output/'
     assert exp_builder._options['pressure'] is None
     assert exp_builder._options['constraints'] == openmm.app.AllBonds
-    assert exp_builder._options['replica_mixing_scheme'] is None
+    assert exp_builder._options['anisotropic_dispersion_cutoff'] is None
     assert exp_builder._options['timestep'] == 2.0 * unit.femtoseconds
     assert exp_builder._options['randomize_ligand_sigma_multiplier'] == 1.0e-2
     assert exp_builder._options['nsteps_per_iteration'] == 2500

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -101,7 +101,7 @@ def get_template_script(output_dir='.', keep_schrodinger=False, keep_openeye=Fal
     ---
     options:
         output_dir: {output_dir}
-        number_of_iterations: 0
+        default_number_of_iterations: 0
         temperature: 300*kelvin
         pressure: 1*atmosphere
         minimize: no
@@ -244,7 +244,7 @@ def get_functionality_script(output_directory=',', number_of_iter=0, experiment_
       minimize: no
       verbose: no
       output_dir: {output_directory}
-      number_of_iterations: {number_of_iter}
+      default_number_of_iterations: {number_of_iter}
       nsteps_per_iteration: 10
       temperature: 300*kelvin
       pressure: null
@@ -349,7 +349,7 @@ def test_yaml_parsing():
         collision_rate: 5.0 / picosecond
         timestep: 2.0 * femtosecond
         nsteps_per_iteration: 2500
-        number_of_iterations: .inf
+        default_number_of_iterations: .inf
         equilibration_timestep: 1.0 * femtosecond
         number_of_equilibration_iterations: 100
         minimize: False
@@ -377,7 +377,7 @@ def test_yaml_parsing():
     assert exp_builder._options['randomize_ligand_sigma_multiplier'] == 1.0e-2
     assert exp_builder._options['nsteps_per_iteration'] == 2500
     assert type(exp_builder._options['nsteps_per_iteration']) is int
-    assert exp_builder._options['number_of_iterations'] == float('inf')
+    assert exp_builder._options['default_number_of_iterations'] == float('inf')
     assert exp_builder._options['number_of_equilibration_iterations'] == 100
     assert type(exp_builder._options['number_of_equilibration_iterations']) is int
     assert exp_builder._options['minimize'] is False
@@ -672,6 +672,34 @@ def test_validation_wrong_systems():
         modified_script = basic_script.copy()
         modified_script['systems'] = {'sys': system}
         yield assert_raises_regexp, YamlParseError, regexp, exp_builder.parse, modified_script
+
+
+def test_validation_correct_samplers():
+    """Correct samplers YAML validation."""
+    samplers = [
+        {'type': 'MultiStateSampler', 'locality': 3},
+        {'type': 'ReplicaExchangeSampler'},
+        {'type': 'ReplicaExchangeSampler', 'number_of_iterations': 5, 'replica_mixing_scheme': 'swap-neighbors'},
+        {'type': 'ReplicaExchangeSampler', 'number_of_iterations': 5, 'replica_mixing_scheme': None}
+    ]
+    for sampler in samplers:
+        yield ExperimentBuilder._validate_samplers, {'samplers': {'sampler1': sampler}}
+
+
+def test_validation_wrong_samplers():
+    """YAML validation raises exception with wrong experiments specification."""
+    # Each test case is a pair (regexp_error, sampler_description).
+    samplers = [
+        ("locality must be an int",
+            {'type': 'MultiStateSampler', 'locality': 3.0}),
+        ("Could not found class NonExistentSampler",
+            {'type': 'NonExistentSampler'}),
+        ("found unknown parameter",
+            {'type': 'ReplicaExchangeSampler', 'unknown_kwarg': 5}),
+    ]
+    for regexp, sampler in samplers:
+        script = {'samplers': {'sampler1': sampler}}
+        yield assert_raises_regexp, YamlParseError, regexp, ExperimentBuilder._validate_samplers, script
 
 
 def test_order_phases():
@@ -1964,58 +1992,97 @@ def test_default_platform_precision():
 # Experiment building
 # ==============================================================================
 
-def test_alchemical_phase_factory_building():
-    """Test that options are passed to AlchemicalPhaseFactory correctly."""
-    with mmtools.utils.temporary_directory() as tmp_dir:
-        template_script = get_template_script(tmp_dir)
+class TestExperimentBuilding(object):
+    """Test that options are passed correctly from YAML to the built objects."""
+
+    @classmethod
+    def get_implicit_template_script(cls, output_dir):
+        """Return the template script with only an implicit system."""
+        template_script = get_template_script(output_dir)
 
         # Remove systems we don't need to setup.
         del template_script['systems']['explicit-system']
         del template_script['systems']['hydration-system']
         template_script['experiments']['system'] = 'implicit-system'
+        return template_script
 
-        # AbsoluteAlchemicalFactory options.
-        template_script['options']['alchemical_pme_treatment'] = 'exact'
+    def test_alchemical_phase_factory_building(self):
+        """Test that options are passed to AlchemicalPhaseFactory correctly."""
+        with mmtools.utils.temporary_directory() as tmp_dir:
+            template_script = self.get_implicit_template_script(tmp_dir)
 
-        # Test that options are passed to AlchemicalPhaseFactory correctly.
-        exp_builder = ExperimentBuilder(script=template_script)
-        for experiment in exp_builder.build_experiments():
-            for phase_factory in experiment.phases:
-                assert phase_factory.alchemical_factory.alchemical_pme_treatment == 'exact'
-                # Overwrite AbsoluteAlchemicalFactory default for disable_alchemical_dispersion_correction.
-                assert phase_factory.alchemical_factory.disable_alchemical_dispersion_correction == True
+            # AbsoluteAlchemicalFactory options.
+            template_script['options']['alchemical_pme_treatment'] = 'exact'
 
+            # Test that options are passed to AlchemicalPhaseFactory correctly.
+            exp_builder = ExperimentBuilder(script=template_script)
+            for experiment in exp_builder.build_experiments():
+                for phase_factory in experiment.phases:
+                    assert phase_factory.alchemical_factory.alchemical_pme_treatment == 'exact'
+                    # Overwrite AbsoluteAlchemicalFactory default for disable_alchemical_dispersion_correction.
+                    assert phase_factory.alchemical_factory.disable_alchemical_dispersion_correction == True
 
-def test_restraint_building():
-    """Test that experiment restraints are built correctly."""
-    with mmtools.utils.temporary_directory() as tmp_dir:
-        template_script = get_template_script(tmp_dir)
+    def test_restraint_building(self):
+        """Test that experiment restraints are built correctly."""
+        with mmtools.utils.temporary_directory() as tmp_dir:
+            template_script = self.get_implicit_template_script(tmp_dir)
 
-        # Remove systems we don't need to setup.
-        del template_script['systems']['explicit-system']
-        del template_script['systems']['hydration-system']
-        template_script['experiments']['system'] = 'implicit-system'
+            # Restraint options.
+            template_script['experiments']['restraint'] = {
+                'type': 'Harmonic',
+                'restrained_receptor_atoms': [10, 11, 12],
+                'restrained_ligand_atoms': 'resname MOL',
+                'spring_constant': '8*kilojoule_per_mole/nanometers**2'
+            }
 
-        # Restraint options.
-        template_script['experiments']['restraint'] = {
-            'type': 'Harmonic',
-            'restrained_receptor_atoms': [10, 11, 12],
-            'restrained_ligand_atoms': 'resname MOL',
-            'spring_constant': '8*kilojoule_per_mole/nanometers**2'
-        }
+            # Test that options are passed to the restraint correctly.
+            exp_builder = ExperimentBuilder(script=template_script)
+            for experiment in exp_builder.build_experiments():
+                restraint = experiment.phases[0].restraint
+                assert isinstance(restraint, restraints.Harmonic)
+                assert restraint.restrained_receptor_atoms == [10, 11, 12]
+                assert restraint.restrained_ligand_atoms == 'resname MOL'
+                print(restraint.spring_constant)
+                assert restraint.spring_constant.unit.is_compatible(
+                    unit.kilojoule_per_mole/unit.nanometers**2)
 
-        # Test that options are passed to AlchemicalPhaseFactory correctly.
-        exp_builder = ExperimentBuilder(script=template_script)
-        for experiment in exp_builder.build_experiments():
-            restraint = experiment.phases[0].restraint
-            assert isinstance(restraint, restraints.Harmonic)
-            assert restraint.restrained_receptor_atoms == [10, 11, 12]
-            assert restraint.restrained_ligand_atoms == 'resname MOL'
-            print(restraint.spring_constant)
-            assert restraint.spring_constant.unit.is_compatible(
-                unit.kilojoule_per_mole/unit.nanometers**2)
+                assert experiment.phases[1].restraint is None
 
-            assert experiment.phases[1].restraint is None
+    def test_sampler_building(self):
+        """Test that experiment sampler is correctly."""
+        with mmtools.utils.temporary_directory() as tmp_dir:
+            template_script = self.get_implicit_template_script(tmp_dir)
+            template_script['options']['resume_setup'] = True
+            default_number_of_iterations = template_script['options']['default_number_of_iterations']
+
+            # Add tested samplers.
+            template_script['samplers'] = {
+                'my-sampler1': {
+                    'type': 'ReplicaExchangeSampler',
+                    'number_of_iterations': 9,
+                    'replica_mixing_scheme': 'swap-neighbors',
+                },
+                'my-sampler2': {
+                    'type': 'MultiStateSampler',
+                    'locality': 5
+                }
+            }
+
+            # Test that options are passed to the sampler correctly.
+            for sampler_id, sampler_description in template_script['samplers'].items():
+                template_script['experiments']['sampler'] = sampler_id
+                exp_builder = ExperimentBuilder(script=template_script)
+                for experiment in exp_builder.build_experiments():
+                    for phase in experiment.phases:
+                        for k, v in sampler_description.items():
+                            if k == 'type':
+                                assert phase.sampler.__class__.__name__ == v
+                            else:
+                                assert getattr(phase.sampler, k) == v
+
+                        # If number_of_iterations is not specified, the default is used.
+                        if 'number_of_iterations' not in sampler_description:
+                            assert phase.sampler.number_of_iterations == default_number_of_iterations
 
 
 # ==============================================================================
@@ -2169,7 +2236,7 @@ def test_yaml_extension():
 
         yaml_extension = """
         options:
-            number_of_iterations: {}
+            default_number_of_iterations: {}
         solvents:
             GBSA-OBC2:
                 implicit_solvent: HCT
@@ -2184,7 +2251,7 @@ def test_yaml_extension():
         options:
             experiments_dir: .
             output_dir: .
-            number_of_iterations: {}
+            default_number_of_iterations: {}
         molecules:{}
             p-xylene:
                 filepath: {}
@@ -2314,7 +2381,7 @@ def test_run_experiment():
         options:
             resume_setup: no
             resume_simulation: no
-            number_of_iterations: 0
+            default_number_of_iterations: 0
             output_dir: {}
             setup_dir: ''
             experiments_dir: ''
@@ -2460,7 +2527,7 @@ def test_splitting():
     for replacement in [{'options': {'integrator_splitting': None}},
                         {'options': {'integrator_splitting': "O { V R V } O"}}]:
         with mmtools.utils.temporary_directory() as tmp_dir:
-            replacement['options']['number_of_iterations'] = 1
+            replacement['options']['default_number_of_iterations'] = 1
             solvation_stock(tmp_dir, overwrite_options=replacement)
 
 

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -92,7 +92,7 @@ options:
   minimize: no
   verbose: yes
   output_dir: %(output_directory)s
-  number_of_iterations: %(number_of_iter)s
+  default_number_of_iterations: %(number_of_iter)s
   nsteps_per_iteration: 100
   temperature: 300*kelvin
   pressure: null

--- a/Yank/tests/test_schema.py
+++ b/Yank/tests/test_schema.py
@@ -1,0 +1,46 @@
+#!/usr/local/bin/env python
+
+"""
+Test Cerberus schema validation.
+
+"""
+
+# =============================================================================================
+# GLOBAL IMPORTS
+# =============================================================================================
+
+from yank.schema.validator import *
+
+
+# ==============================================================================
+# UTILITY FUNCTIONS
+# ==============================================================================
+
+def test_generate_signature_schema():
+    """Test generate_signature_schema() function."""
+    def f(a, b, camelCase=True, none=None, quantity=3.0*unit.angstroms):
+        pass
+
+    f_schema = generate_signature_schema(f)
+    assert len(f_schema) == 3
+    for v in f_schema.values():
+        assert isinstance(v, dict)
+        assert v['required'] is False
+
+    # Remove Optional() marker for comparison
+    assert f_schema['camel_case']['type'] == 'boolean'
+    assert f_schema['none']['nullable'] is True
+    assert hasattr(f_schema['quantity']['coerce'], '__call__')  # Callable validator
+
+    # Check conversion
+    f_validator = YANKCerberusValidator(f_schema)
+    assert f_validator.validated({'quantity': '5*angstrom'}) == {'quantity': 5*unit.angstrom}
+
+    # Check update
+    optional_instance = {'camel_case': {'type': 'integer'}, 'none': {'type': 'float'}}
+    updated_schema = generate_signature_schema(f, update_keys=optional_instance,
+                                               exclude_keys={'quantity'})
+    assert len(updated_schema) == 2
+    assert updated_schema['none'].get('nullable') is None
+    assert updated_schema['none'].get('type') == 'float'
+    assert updated_schema['camel_case'].get('type') == 'integer'

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -9,6 +9,7 @@ Test various utility functions.
 # GLOBAL IMPORTS
 # =============================================================================================
 
+import abc
 import textwrap
 
 import openmoltools as omt
@@ -124,6 +125,35 @@ def test_expand_id_nodes():
                             'sys3': {'prmtopfile': 'mysystem.prmtop'}}
 
 
+def test_find_all_subclasses():
+    """Test find_all_subclasses() function."""
+    # Diamond inheritance.
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    class C(A, abc.ABC):
+        @abc.abstractmethod
+        def m(self):
+            pass
+
+    class D(B, C, abc.ABC):
+        @abc.abstractmethod
+        def m(self):
+            pass
+
+    class E(D):
+        def m(self):
+            pass
+
+    assert find_all_subclasses(B) == {D, E}
+    assert find_all_subclasses(B, discard_abstract=True) == {E}
+    assert find_all_subclasses(A) == {B, D, E, C}
+    assert find_all_subclasses(A, discard_abstract=True) == {B, E}
+
+
 def test_generate_signature_schema():
     """Test generate_signature_schema() function."""
     def f(a, b, camelCase=True, none=None, quantity=3.0*unit.angstroms):
@@ -180,7 +210,6 @@ def test_get_keyword_args():
     assert expected_true_cls == get_keyword_args(subdummy.__init__, try_mro_from_class=subdummy)
 
 
-
 def test_validate_parameters():
     """Test validate_parameters function."""
 
@@ -230,12 +259,14 @@ def test_validate_parameters():
                                        special_conversions=special_conv)
     assert convert_pars['length'] == '1.0*nanometers'
 
+
 @tools.raises(ValueError)
 def test_incompatible_parameters():
     """Check that validate_parameters raises exception with unknown parameter."""
     template_pars = {'int': 3}
     wrong_pars = {'int': 3.0}
     validate_parameters(wrong_pars, template_pars)
+
 
 @tools.raises(TypeError)
 def test_unknown_parameters():

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -152,10 +152,10 @@ def test_find_all_subclasses():
         def m(self):
             pass
 
-    assert find_all_subclasses(B) == {D, E}
-    assert find_all_subclasses(B, discard_abstract=True) == {E}
-    assert find_all_subclasses(A) == {B, D, E, C}
-    assert find_all_subclasses(A, discard_abstract=True) == {B, E}
+    assert find_all_subclasses(B) == {B, D, E}
+    assert find_all_subclasses(B, discard_abstract=True, include_parent=False) == {E}
+    assert find_all_subclasses(A) == {A, B, D, E, C}
+    assert find_all_subclasses(A, discard_abstract=True, include_parent=False) == {B, E}
 
 
 def test_get_keyword_args():

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -20,7 +20,7 @@ from yank.schema.validator import *
 
 
 # =============================================================================================
-# TESTING FUNCTIONS
+# COMBINATORIAL TREE
 # =============================================================================================
 
 def test_set_tree_path():
@@ -124,6 +124,10 @@ def test_expand_id_nodes():
                             'sys2': {'molecules': CombinatorialLeaf(['mol1_1', 'mol1_2', 'mol2_3', 'mol2_4'])},
                             'sys3': {'prmtopfile': 'mysystem.prmtop'}}
 
+
+# ==============================================================================
+# CONVERSION UTILITIES
+# ==============================================================================
 
 def test_find_all_subclasses():
     """Test find_all_subclasses() function."""
@@ -248,7 +252,7 @@ def test_validate_parameters():
     assert convert_pars['time'] == 1.0 * unit.femtoseconds
 
     # If check_unknown flag is not True it should not raise an error
-    validate_parameters({'unkown': 0}, template_pars)
+    validate_parameters({'unknown': 0}, template_pars)
 
     # Test special conversion
     def convert_length(length):
@@ -285,17 +289,30 @@ def test_underscore_to_camelcase():
 
 
 def test_quantity_from_string():
-    """Test the quantity from string function to ensure output is as expected"""
-    tests = [
+    """Test the quantity from string function to ensure output is as expected."""
+    test_cases = [
         # (string,                                 expected Unit)
-        ('3',                                      3.0), # Handle basic float
-        ('meter',                                  unit.meter), # Handle basic unit object
-        ('300 * kelvin',                           300*unit.kelvin), # Handle standard Quantity
-        ('" 0.3 * kilojoules_per_mole / watt**3"', 0.3*unit.kilojoules_per_mole/unit.watt**3), # Handle division, exponent, nested string
-        ('1*meter / (4*second)',                   0.25*unit.meter/unit.second), # Handle compound math and parenthesis
-        ('1 * watt**2 /((1* kelvin)**3 / gram)',   1*(unit.watt**2)*(unit.gram)/(unit.kelvin**3)) #Handle everything
-        ]
-    assert all(expected == quantity_from_string(passed_string) for passed_string, expected in tests)
+        ('3',                                      3.0),  # Handle basic float
+        ('meter',                                  unit.meter),  # Handle basic unit object
+        ('300 * kelvin',                           300*unit.kelvin),  # Handle standard Quantity
+        ('" 0.3 * kilojoules_per_mole / watt**3"', 0.3*unit.kilojoules_per_mole/unit.watt**3),  # Handle division, exponent, nested string
+        ('1*meter / (4*second)',                   0.25*unit.meter/unit.second),  # Handle compound math and parenthesis
+        ('1 * watt**2 /((1* kelvin)**3 / gram)',   1*(unit.watt**2)*(unit.gram)/(unit.kelvin**3))  #Handle everything
+    ]
+
+    for expression, expected in test_cases:
+        assert expected == quantity_from_string(expression)
+
+        # Test incompatible units.
+        with tools.assert_raises(TypeError):
+            quantity_from_string(expression, compatible_units=unit.second)
+
+        # Test compatibile units.
+        try:
+            expected_unit = expected.unit.in_unit_system(unit.md_unit_system)
+        except AttributeError:
+            continue
+        assert expected == quantity_from_string(expression, compatible_units=expected_unit)
 
 
 def test_TLeap_script():

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -158,36 +158,6 @@ def test_find_all_subclasses():
     assert find_all_subclasses(A, discard_abstract=True) == {B, E}
 
 
-def test_generate_signature_schema():
-    """Test generate_signature_schema() function."""
-    def f(a, b, camelCase=True, none=None, quantity=3.0*unit.angstroms):
-        pass
-
-    f_schema = generate_signature_schema(f)
-    assert len(f_schema) == 3
-    for v in f_schema.values():
-        assert isinstance(v, dict)
-        assert v['required'] is False
-
-    # Remove Optional() marker for comparison
-    assert f_schema['camel_case']['type'] == 'boolean'
-    assert f_schema['none']['nullable'] is True
-    assert hasattr(f_schema['quantity']['coerce'], '__call__')  # Callable validator
-
-    # Check conversion
-    f_validator = YANKCerberusValidator(f_schema)
-    assert f_validator.validated({'quantity': '5*angstrom'}) == {'quantity': 5*unit.angstrom}
-
-    # Check update
-    optional_instance = {'camel_case': {'type': 'integer'}, 'none': {'type': 'float'}}
-    updated_schema = generate_signature_schema(f, update_keys=optional_instance,
-                                               exclude_keys={'quantity'})
-    assert len(updated_schema) == 2
-    assert updated_schema['none'].get('nullable') is None
-    assert updated_schema['none'].get('type') == 'float'
-    assert updated_schema['camel_case'].get('type') == 'integer'
-
-
 def test_get_keyword_args():
     """Test get_keyword_args() function."""
     def f(a, b, c=True, d=3.0):

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -592,7 +592,7 @@ def notest_LennardJonesPair(**kwargs):
 #
 #     # Initialize YANK object.
 #     options = dict()
-#     options['number_of_iterations'] = 10
+#     options['default_number_of_iterations'] = 10
 #     options['platform'] = openmm.Platform.getPlatformByName("Reference") # use Reference platform for speed
 #     options['mc_rotation'] = False
 #     options['mc_displacement'] = True

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -776,29 +776,6 @@ def update_nested_dict(original, updated):
 # Conversion utilities
 # ==============================================================================
 
-def merge_dict(dict1, dict2):
-    """Return the union of two dictionaries in through Python version agnostic code.
-
-    In Python 3.5 there is a syntax to do this ``{**dict1, **dict2}`` but
-    in Python 2 you need to go through ``update()``.
-
-    TODO: Refactor to no longer need this now that Python 2 is dropped
-
-    Parameters
-    ----------
-    dict1 : dict
-    dict2 : dict
-
-    Returns
-    -------
-    merged_dict : dict
-        Union of dict1 and dict2
-    """
-    merged_dict = dict1.copy()
-    merged_dict.update(dict2)
-    return merged_dict
-
-
 def underscore_to_camelcase(underscore_str):
     """Convert the given string from ``underscore_case`` to ``camelCase``.
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -773,7 +773,7 @@ def update_nested_dict(original, updated):
 # Conversion utilities
 # ==============================================================================
 
-def find_all_subclasses(parent_cls, discard_abstract=False):
+def find_all_subclasses(parent_cls, discard_abstract=False, include_parent=True):
     """Return a set of all the classes inheriting from ``parent_cls``.
 
     The functions handle multiple inheritance and discard the same classes.
@@ -784,6 +784,9 @@ def find_all_subclasses(parent_cls, discard_abstract=False):
         The parent class.
     discard_abstract : bool, optional
         If True, abstract classes are not returned (default is False).
+    include_parent : bool, optional
+        If True, the parent class will be included, unless it is abstract
+        and ``discard_abstract`` is ``True``.
 
     Returns
     -------
@@ -796,6 +799,9 @@ def find_all_subclasses(parent_cls, discard_abstract=False):
         if not (discard_abstract and inspect.isabstract(subcls)):
             subclasses.add(subcls)
         subclasses.update(find_all_subclasses(subcls, discard_abstract))
+
+    if include_parent and not inspect.isabstract(parent_cls):
+        subclasses.add(parent_cls)
     return subclasses
 
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -776,6 +776,66 @@ def update_nested_dict(original, updated):
 # Conversion utilities
 # ==============================================================================
 
+def find_all_subclasses(parent_cls, discard_abstract=False):
+    """Return a set of all the classes inheriting from ``parent_cls``.
+
+    The functions handle multiple inheritance and discard the same classes.
+
+    Parameters
+    ----------
+    parent_cls : type
+        The parent class.
+    discard_abstract : bool, optional
+        If True, abstract classes are not returned (default is False).
+
+    Returns
+    -------
+    subclasses : set of type
+        The set of all the classes inheriting from ``parent_cls``.
+
+    """
+    subclasses = set()
+    for subcls in parent_cls.__subclasses__():
+        if not (discard_abstract and inspect.isabstract(subcls)):
+            subclasses.add(subcls)
+        subclasses.update(find_all_subclasses(subcls, discard_abstract))
+    return subclasses
+
+
+def find_subclass(parent_cls, subcls_name):
+    """Return the class called ``subcls_name`` inheriting from ``parent_cls``.
+
+    Parameters
+    ----------
+    parent_cls : type
+        The parent class.
+    subcls_name : str
+        The name of the class inheriting from ``parent_cls``.
+
+    Returns
+    -------
+    subcls : type
+        The class inheriting from ``parent_cls`` called ``subcls_name``.
+
+    Raises
+    ------
+    ValueError
+        If there is no class or there are multiple classes called ``subcls_name``
+        that inherit from ``parent_cls``.
+    """
+    subclasses = []
+    for subcls in find_all_subclasses(parent_cls):
+        if subcls.__name__ == subcls_name:
+            subclasses.append(subcls)
+    if len(subclasses) == 0:
+        raise ValueError('Could not found class {} inheriting from {}'
+                         ''.format(subcls_name, parent_cls))
+    if len(subclasses) > 1:
+        raise ValueError('Found multiple classes inheriting from {}: {}'
+                         ''.format(parent_cls, subclasses))
+    return subclasses[0]
+
+
 def underscore_to_camelcase(underscore_str):
     """Convert the given string from ``underscore_case`` to ``camelCase``.
 


### PR DESCRIPTION
This adds the sampler hooks into the YAML syntax as discussed in #898 . I've also added the `default_number_of_iterations` global option.

@Lnaden, I still have to update the `whatsnew` and the YAML docs, but I don't think I'll have time to do it before Tue (I need to do another couple of things before the end of the day) so feel free to merge/modify this if you need it before next week.