### PR TITLE
Implement automatic determination of processes_per_experiments

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -969,8 +969,6 @@ class ExperimentBuilder(object):
             self._options.
         phase_options : dict
             The options to pass to the AlchemicalPhaseFactory constructor.
-        sampler_options : dict
-            The options to pass to the ReplicaExchange constructor.
         alchemical_region_options : dict
             The options to pass to AlchemicalRegion.
         alchemical_factory_options : dict

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2721,6 +2721,14 @@ class ExperimentBuilder(object):
         if n_mpi_processes <= n_experiments:
             return 1
 
+        # If we are using SAMS samplers, use 1 process only.
+        # TODO when n_replicas is a parameter of the constructor, remove this.
+        sampler_names = {self._create_experiment_sampler(exp[1], []).__class__.__name__ for exp in experiments}
+        if 'SAMSSampler' in sampler_names:
+            logger.warning('One MPI process will be assigned to each experiment but there are '
+                           'more MPI processes than experiments. Some process will be unused.')
+            return 1
+
         # Split the mpicomm among the experiments.
         group_size = min(1, int(n_mpi_processes / n_experiments))
 

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2372,7 +2372,7 @@ class ExperimentBuilder(object):
                 continue
 
             # Determine output directory and create it if it doesn't exist.
-            self._safe_makedirs(os.path.dirname(script_filepath))
+            os.makedirs(os.path.dirname(script_filepath), exist_ok=True)
 
             # Check if any of the phases needs to have its path generated.
             protocol = self._protocols[experiment['protocol']]
@@ -2625,20 +2625,6 @@ class ExperimentBuilder(object):
         analysis_script_path = os.path.join(results_dir, 'analysis.yaml')
         with open(analysis_script_path, 'w') as f:
             yaml.dump(analysis, f)
-
-    @mpi.on_single_node(rank=0, sync_nodes=True)
-    def _safe_makedirs(self, directory):
-        """Create directory and avoid race conditions.
-
-        This is executed only on node 0 to avoid race conditions. The
-        processes are synchronized at the end so that the non-0 nodes
-        won't raise an IO error when trying to write a file in a non-
-        existing directory.
-
-        """
-        # TODO when dropping Python 2, remove this and use os.makedirs(, exist_ok=True)
-        if not os.path.isdir(directory):
-            os.makedirs(directory)
 
     def _create_experiment_restraint(self, experiment_description):
         """Create a restraint object for the experiment."""

--- a/Yank/mpi.py
+++ b/Yank/mpi.py
@@ -57,7 +57,11 @@ logger = logging.getLogger(__name__)
 # GLOBAL VARIABLES
 # ==============================================================================
 
+# Force serial execution even in MPI environment.
 disable_mpi = False
+
+# A dummy MPI communicator used to simulate an MPI environment in tests.
+_simulated_mpicomm = None
 
 
 # ==============================================================================
@@ -83,6 +87,10 @@ def get_mpicomm():
     # If MPI execution is forcefully disabled, return None.
     if disable_mpi:
         return None
+
+    # If MPI is simulated, return the Dummy implementation.
+    if _simulated_mpicomm is not None:
+        return _simulated_mpicomm
 
     # If we have already initialized MPI, return the cached MPI communicator.
     if get_mpicomm._is_initialized:
@@ -422,8 +430,11 @@ def distribute(task, distributed_args, *other_args, send_results_to='all',
         If not None, the ``distributed_args`` are distributed among groups of
         nodes that are isolated from each other. This is particularly useful
         if ``task`` also calls :func:`distribute`, since normally that would result
-        in unexpected behavior. If an integer, the nodes are split into equal
-        groups of ``group_size`` nodes. If a list of integers, the nodes are
+        in unexpected behavior.
+
+        If an integer, the nodes are split into equal groups of ``group_size``
+        nodes. If ``n_nodes % group_size != 0``, the first jobs are allocated
+        more nodes than the latest. If a list of integers, the nodes are
         split in possibly unequal groups (see example below).
 
     Other Parameters
@@ -586,6 +597,35 @@ def delayed_termination(func):
         with delay_termination():
             return func(*args, **kwargs)
     return _delayed_termination
+
+
+# ==============================================================================
+# MPI TEST CLASSES
+# ==============================================================================
+
+class _DummyMPIComm():
+    """A Dummy MPI Communicator."""
+
+    def __init__(self, rank=0, size=4):
+        self.rank = rank
+        self.size = size
+
+
+@contextmanager
+def _simulated_mpi_environment(**kwargs):
+    """Context manager to temporarily set a simulated MPI environment.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        The parameters to pass to _DummyMPIComm constructor.
+
+    """
+    global _simulated_mpicomm
+    old_simulated_mpicomm = _simulated_mpicomm
+    _simulated_mpicomm = _DummyMPIComm(**kwargs)
+    yield
+    _simulated_mpicomm = old_simulated_mpicomm
 
 
 # ==============================================================================

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -2540,7 +2540,17 @@ def test_automatic_alchemical_path():
         yaml_script['experiments']['protocol'] = 'hydration-protocol'
 
         exp_builder = ExperimentBuilder(yaml_script)
-        exp_builder._check_resume()  # check_resume should not raise exceptions
+
+        # ExperimentBuilder._get_experiment_protocol handles dummy protocols.
+        experiment_path, experiment_description = next(exp_builder._expand_experiments())
+        with assert_raises(FileNotFoundError):
+            exp_builder._get_experiment_protocol(experiment_path, experiment_description)
+        dummy_protocol = exp_builder._get_experiment_protocol(experiment_path, experiment_description,
+                                                              use_dummy_protocol=True)
+        assert dummy_protocol['solvent2']['alchemical_path'] == {}  # This is the dummy protocol.
+
+        # check_resume should not raise exceptions at this point.
+        exp_builder._check_resume()
 
         # Building the experiment should generate the alchemical path.
         for experiment in exp_builder.build_experiments():

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -402,8 +402,8 @@ def test_paths_properties():
     assert exp_builder._db.setup_dir == os.path.join('output2', 'setup2')
 
 
-def test_auto_processes_per_experiment():
-    """Test the automatic determination of processes_per_experiment."""
+def test_processes_per_experiment():
+    """Test the determination of processes_per_experiment option."""
     # Create a script with 4 experiments.
     template_script = get_template_script()
     template_script['experiment1'] = copy.deepcopy(template_script['experiments'])
@@ -442,6 +442,17 @@ def test_auto_processes_per_experiment():
             err_msg = ('experiments: {}\nMPICOMM size: {}\nexpected result: {}'
                        '\nresult: {}').format(*test_cases[i], result)
             assert result == expected_result, err_msg
+
+    # Test manual setting of processes_per_experiments.
+    test_cases = [2, None]
+    for processes_per_experiment in test_cases:
+        exp_builder._options['processes_per_experiment'] = processes_per_experiment
+        # Serial execution is always None.
+        assert exp_builder._get_experiment_mpi_group_size(experiments) is None
+        with mpi._simulated_mpi_environment(size=5):
+            assert exp_builder._get_experiment_mpi_group_size(experiments[:-1]) == processes_per_experiment
+            # When there are SAMS sampler, it's always 1.
+            assert exp_builder._get_experiment_mpi_group_size(experiments) == 1
 
 
 def test_validation_wrong_options():

--- a/docs/examples/host-guest-implicit.rst
+++ b/docs/examples/host-guest-implicit.rst
@@ -27,7 +27,7 @@ Options Heading
    options:
      minimize: yes
      verbose: yes
-     number_of_iterations: 500
+     default_number_of_iterations: 500
      temperature: 300*kelvin
      pressure: null
      output_dir: hgoutput
@@ -38,7 +38,7 @@ to see what is happening.
 We will be running implicit, non-periodic NVT system. So we set the ``temperature``, then set the ``pressure`` to ``null``
 to ensure we are in NVT mode.
 
-Finally, we set a limited number of iterations with ``number_of_iterations`` (for this example) and choose a specific
+Finally, we set a limited number of iterations with ``default_number_of_iterations`` (for this example) and choose a specific
 output directory called ``hgoutput``. Note that this folder is relative to the ``yank.yaml`` file.
 
 

--- a/docs/examples/p-xylene-explicit.rst
+++ b/docs/examples/p-xylene-explicit.rst
@@ -313,7 +313,7 @@ the following options:
 .. code-block:: yaml
 
    options:
-     number_of_iterations: <Some Integer>
+     default_number_of_iterations: <Some Integer>
      resume_simulation: yes
 
 where you replace ``<Some Integer>`` with a number larger than the number of iterations you just ran.

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -265,12 +265,12 @@ Specifying Simulation Stop Conditions
 =====================================
 
 YANK simulations will run until one of two stop conditions are met, if specified: either the
-:ref:`maximum number of iterations <yaml_options_number_of_iterations>` is reached, or the
+:ref:`maximum number of iterations <yaml_options_default_number_of_iterations>` is reached, or the
 :ref:`error in free energy difference of the phase <yaml_options_online_analysis_parameters>` reaches a target value
 through online analysis.
 These options can be combined to change when YANK stops a simulation.
 
-Specifying a :ref:`maximum number of iterations <yaml_options_number_of_iterations>` will tell YANK to run each phase
+Specifying a :ref:`maximum number of iterations <yaml_options_default_number_of_iterations>` will tell YANK to run each phase
 up to the target number of iterations. This options accepts any positive integer, ``0`` (zero), or infinity
 (``.inf`` in the .yaml, ``float('inf')`` or ``numpy.inf`` in the API). Setting this option to ``0`` will tell YANK to only handle file
 initialization and input preparation, without running any production simulation. Setting this to ``.inf`` will

--- a/docs/site-resources/tutorial-files/implicit2_stock.yaml
+++ b/docs/site-resources/tutorial-files/implicit2_stock.yaml
@@ -2,7 +2,7 @@ options:
   minimize: yes
   verbose: yes
   output_dir: fxr-imp-34
-  number_of_iterations: 3000
+  default_number_of_iterations: 3000
   nsteps_per_iteration: 500
   temperature: 300*kelvin
   pressure: null

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,11 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+Development
+-----------
+- Renamed global option ``number_of_iterations`` to ``default_number_of_iterations``. `[docs] <http://getyank.org/latest/yamlpages/options.html#default_number_of_iterations>`_
+- Added support for automatic determination of ``processes_per_experiment`` (now the default). `[docs] <http://getyank.org/latest/yamlpages/options.html#processes_per_experiment>`_
+
 0.20.1 Alchemical factory options and fast computation of the energy matrix
 ---------------------------------------------------------------------------
 - Allow user to specify options for ``openmmtools.alchemy.AbsoluteAlchemicalFactory`` in the YAML file. In particular,

--- a/docs/yamlpages/cookbook.rst
+++ b/docs/yamlpages/cookbook.rst
@@ -50,7 +50,7 @@ In this example:
     experiments_dir: experiments
     randomize_ligand: yes
     minimize: yes
-    number_of_iterations: 2000
+    default_number_of_iterations: 2000
     temperature: 300*kelvin
     pressure: null
   
@@ -124,7 +124,7 @@ In this Example:
      minimize: yes
      verbose: yes
      output_dir: .
-     number_of_iterations: 2000
+     default_number_of_iterations: 2000
      temperature: 300*kelvin
      pressure: 1*atmosphere
 

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -64,7 +64,7 @@ Detailed Options List
     * :ref:`minimize_tolerance <yaml_options_minimize_tolerance>`
     * :ref:`number_of_equilibration_iterations <yaml_options_number_of_equilibration_iterations>`
     * :ref:`equilibration_timestep <yaml_options_equilibration_timestep>`
-    * :ref:`number_of_iterations <yaml_options_number_of_iterations>`
+    * :ref:`default_number_of_iterations <yaml_options_default_number_of_iterations>`
     * :ref:`nsteps_per_iteration <yaml_options_nsteps_per_iteration>`
     * :ref:`timestep <yaml_options_timestep>`
     * :ref:`checkpoint_interval <yaml_options_checkpoint_interval>`

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -220,13 +220,15 @@ Valid options (0): <Integer>
 .. code-block:: yaml
 
    options:
-     processes_per_experiment: null
+     processes_per_experiment: auto
 
 When running YANK on multiple processes with MPI, you can run several experiments in parallel by using this option to
-allocate a given number of processes to each experiment. If ``null``, the experiments are performed one after the
-other on all the available MPI processes.
+allocate a given number of processes to each experiment. This option is ignored if YANK is not run with MPI. If ``null``,
+the experiments are performed one after the other on all the available MPI processes. When ``auto`` is selected, YANK
+tries to run as many experiment as possible in parallel on independent MPI processes. Currently, only
+``processes_per_experiment = 1`` is supported for the SAMS sampler.
 
-Valid options (null): null / <Integer>
+Valid options (auto): auto / null / <Integer>
 
 
 
@@ -540,19 +542,20 @@ Valid Options (1.0 * femtosecond): <Quantity Time> [1]_
 
 
 
-.. _yaml_options_number_of_iterations:
+.. _yaml_options_default_number_of_iterations:
 
 .. rst-class:: html-toggle
 
-``number_of_iterations``
-------------------------
+``default_number_of_iterations``
+--------------------------------
 .. code-block:: yaml
 
    options:
-     number_of_iterations: 1
+     default_number_of_iterations: 1
 
-Number of iterations for production simulation. Note: If :ref:`resume_simulation <yaml_options_resume_simulation>` is
-set, this option can be used to extend previous simulations past their original number of iterations.
+Default number of iterations for the samplers that do not explicitly specify the option ``number_of_iterations``.
+Note: If :ref:`resume_simulation <yaml_options_resume_simulation>` is set, this option can be used to extend previous
+simulations past their original number of iterations.
 
 Specifying ``0`` will run through the setup, create all the simulation files, store all options, and minimize the
 initial configurations (if specified), but will not run any production simulations.

--- a/docs/yank-yaml-cookbook/all-options.yaml
+++ b/docs/yank-yaml-cookbook/all-options.yaml
@@ -50,7 +50,7 @@ options:
   minimize_tolerance: 1.0 * kilojoules_per_mole / nanometers    # Set minimization tolerance.
   number_of_equilibration_iterations: 1                         # Number of equilibration iterations.
   equilibration_timestep: 1.0 * femtosecond                     # Timestep for use in equilibration.
-  number_of_iterations: 1                                       # Number of replica-exchange iterations to simulate.
+  default_number_of_iterations: 1                               # The default number of iterations to simulate.
   nsteps_per_iteration: 500                                     # Number of timesteps per iteration.
   timestep: 2.0 * femtosecond                                   # Timestep for Langevin dyanmics.
   replica_mixing_scheme: swap-all                               # Specify how to mix replicas. Possible values are

--- a/docs/yank-yaml-cookbook/combinatorial-experiment.yaml
+++ b/docs/yank-yaml-cookbook/combinatorial-experiment.yaml
@@ -14,7 +14,7 @@ options:
   temperature: 310*kelvin
   pressure: 1*atmosphere
   constraints: HBonds
-  number_of_iterations: 200
+  default_number_of_iterations: 200
   minimize: yes
 
 


### PR DESCRIPTION
By default, `processes_per_experiment` was set to `None` (i.e. no MPI communicator splitting). This causes problems with SAMS simulations as we support only 1 replica through the YAML interface right now.

This adds the `processes_per_experiment: auto` (now the default) that tries to split the MPI communicator to run as many experiments in parallel as possible given the allocated resources.

I've also started to add in the `mpi` module code to simulate an MPI environment for tests.