### PR TITLE
Improve SAMS State Histograms and Refactor from_storage

### DIFF
--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -1044,12 +1044,8 @@ class MultiStateReporter(object):
         logZ : np.array with shape [n_states]
             Dimensionless logZ
         """
-        # TODO: Remove commented block (or whole thing) when tests pass -LNN
         data = self.read_online_analysis_data(None, "logZ")
         return data['logZ']
-        # online_group = self._storage_analysis.groups['online_analysis']
-        # logZ = online_group.variables['logZ'][iteration]
-        # return logZ
 
     def write_logZ(self, iteration: int, logZ: np.ndarray):
         """
@@ -1064,17 +1060,6 @@ class MultiStateReporter(object):
             Dimensionless log Z
         """
         self.write_online_data_dynamic_and_static(iteration, logZ=logZ)
-        # TODO: Remove commended block if tests work (Could also remove function entirely)-LNN
-        # analysis_nc = self._storage_analysis
-        # if 'logZ' not in analysis_nc.dimensions:
-        #     analysis_nc.createDimension('logZ_length', len(logZ))
-        #     if 'online_analysis' not in analysis_nc.groups:
-        #         online_group = analysis_nc.createGroup('online_analysis')
-        #         # larger chunks, faster operations, small matrix anyways
-        #         online_group.createVariable('logZ', float, dimensions=('iteration', 'logZ_length'),
-        #                                     zlib=True, chunksizes=(1, len(logZ)), fill_value=MISSING_VALUE)
-        # online_group = analysis_nc.groups['online_analysis']
-        # online_group.variables['logZ'][iteration] = logZ
 
     # TODO: Remove function if tests pass -LNN
     def read_mbar_free_energies(self, iteration):
@@ -1285,9 +1270,9 @@ class MultiStateReporter(object):
     def _find_alternate_variable(iteration, variable, storage):
         """Helper function to figure out what went wrong when data not found"""
         iter_var = variable + "_history"
-        if iteration is None and iter_var in storage:
+        if iteration is None and iter_var in storage.variables:
             return True
-        elif iteration is not None and variable in storage:
+        elif iteration is not None and variable in storage.variables:
             return True
         return False
 
@@ -1311,7 +1296,6 @@ class MultiStateReporter(object):
         else:
             return data
 
-
     def _determine_netcdf_variable_parameters(self, iteration, data, storage):
         """
         Pre-determine the variable information needed to create the variable on the storage layer
@@ -1321,16 +1305,16 @@ class MultiStateReporter(object):
             # Scalar data
             size = 1
             try:
-                dtype = data.dtype # numpy
+                dtype = data.dtype  # numpy
             except AttributeError:
-                dtype = type(data) # python
+                dtype = type(data)  # python
         else:
             # Array data
             size = len(data)
             try:
-                dtype = data.dtype # numpy
+                dtype = data.dtype  # numpy
             except AttributeError:
-                dtype = type(data[0]) # python
+                dtype = type(data[0])  # python
 
         data_dim = "dim_size{}".format(size)
 

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -205,66 +205,72 @@ class MultiStateSampler(object):
             last stored iteration.
 
         """
-        # Handle case in which storage is a string.
-        reporter = cls._reporter_from_storage(storage, check_exist=True)
-
-        # Open a reporter to read the data.
-        reporter.open(mode='r')
-
-        # Retrieve options and create new simulation.
-        options = reporter.read_dict('options')
-        options['mcmc_moves'] = reporter.read_mcmc_moves()
-        sampler = cls(**options)
-
-        # Display papers to be cited.
-        sampler._display_citations()
-
-        # Read the last iteration reported to ensure we don't include junk
-        # data written just before a crash.
-        iteration = reporter.read_last_iteration()
-
-        # Retrieve other attributes.
-        logger.debug("Reading storage file {}...".format(reporter.filepath))
-        thermodynamic_states, unsampled_states = reporter.read_thermodynamic_states()
-        sampler_states = reporter.read_sampler_states(iteration=iteration)
-        state_indices = reporter.read_replica_thermodynamic_states(iteration=iteration)
-        energy_thermodynamic_states, neighborhoods, energy_unsampled_states = reporter.read_energies(iteration=iteration)
-        n_accepted_matrix, n_proposed_matrix = reporter.read_mixing_statistics(iteration=iteration)
-        metadata = reporter.read_dict('metadata')
-
-        # Search for last cached free energies only if online analysis is activated.
-        if sampler.online_analysis_interval is not None:
-            online_analysis_info = sampler._read_last_free_energy(reporter, iteration)
-            last_mbar_f_k, (_, last_err_free_energy) = online_analysis_info
-        else:
-            last_mbar_f_k, last_err_free_energy = None, None
-
-        # Close reading reporter.
-        reporter.close()
-
-        # Assign attributes.
-        sampler._iteration = iteration
-        sampler._thermodynamic_states = thermodynamic_states
-        sampler._unsampled_states = unsampled_states
-        sampler._sampler_states = sampler_states
-        sampler._replica_thermodynamic_states = state_indices
-        sampler._energy_thermodynamic_states = energy_thermodynamic_states
-        sampler._neighborhoods = neighborhoods
-        sampler._energy_unsampled_states = energy_unsampled_states
-        sampler._n_accepted_matrix = n_accepted_matrix
-        sampler._n_proposed_matrix = n_proposed_matrix
-        sampler._metadata = metadata
-
-        sampler._last_mbar_f_k = last_mbar_f_k
-        sampler._last_err_free_energy = last_err_free_energy
-
-        # We open the reporter only in node 0.
-        sampler._reporter = reporter
-        mpi.run_single_node(0, sampler._reporter.open, mode='a',
-                            broadcast_result=False, sync_nodes=False)
-
+        sampler, reporter = cls._instantiate_sampler_from_storage(storage)
+        sampler._restore_sampler_from_reporter(reporter)
         # Don't write the new last iteration, we have not technically written anything yet, so there is no "junk"
         return sampler
+
+
+        # # Handle case in which storage is a string.
+        # reporter = cls._reporter_from_storage(storage, check_exist=True)
+        #
+        # # Open a reporter to read the data.
+        # reporter.open(mode='r')
+        #
+        # # Retrieve options and create new simulation.
+        # options = reporter.read_dict('options')
+        # options['mcmc_moves'] = reporter.read_mcmc_moves()
+        # sampler = cls(**options)
+        #
+        # # Display papers to be cited.
+        # sampler._display_citations()
+        #
+        # # Read the last iteration reported to ensure we don't include junk
+        # # data written just before a crash.
+        # iteration = reporter.read_last_iteration()
+        #
+        # # Retrieve other attributes.
+        # logger.debug("Reading storage file {}...".format(reporter.filepath))
+        # thermodynamic_states, unsampled_states = reporter.read_thermodynamic_states()
+        # sampler_states = reporter.read_sampler_states(iteration=iteration)
+        # state_indices = reporter.read_replica_thermodynamic_states(iteration=iteration)
+        # energy_thermodynamic_states, neighborhoods, energy_unsampled_states = reporter.read_energies(iteration=iteration)
+        # n_accepted_matrix, n_proposed_matrix = reporter.read_mixing_statistics(iteration=iteration)
+        # metadata = reporter.read_dict('metadata')
+        #
+        # # Search for last cached free energies only if online analysis is activated.
+        # if sampler.online_analysis_interval is not None:
+        #     online_analysis_info = sampler._read_last_free_energy(reporter, iteration)
+        #     last_mbar_f_k, (_, last_err_free_energy) = online_analysis_info
+        # else:
+        #     last_mbar_f_k, last_err_free_energy = None, None
+        #
+        # # Close reading reporter.
+        # reporter.close()
+        #
+        # # Assign attributes.
+        # sampler._iteration = iteration
+        # sampler._thermodynamic_states = thermodynamic_states
+        # sampler._unsampled_states = unsampled_states
+        # sampler._sampler_states = sampler_states
+        # sampler._replica_thermodynamic_states = state_indices
+        # sampler._energy_thermodynamic_states = energy_thermodynamic_states
+        # sampler._neighborhoods = neighborhoods
+        # sampler._energy_unsampled_states = energy_unsampled_states
+        # sampler._n_accepted_matrix = n_accepted_matrix
+        # sampler._n_proposed_matrix = n_proposed_matrix
+        # sampler._metadata = metadata
+        #
+        # sampler._last_mbar_f_k = last_mbar_f_k
+        # sampler._last_err_free_energy = last_err_free_energy
+        #
+        # # We open the reporter only in node 0.
+        # sampler._reporter = reporter
+        # mpi.run_single_node(0, sampler._reporter.open, mode='a',
+        #                     broadcast_result=False, sync_nodes=False)
+        #
+        # # Don't write the new last iteration, we have not technically written anything yet, so there is no "junk"
+        # return sampler
 
     # TODO use Python 3.6 namedtuple syntax when we drop Python 3.5 support.
     Status = typing.NamedTuple('Status', [
@@ -868,6 +874,114 @@ class MultiStateSampler(object):
     # Internal-usage.
     # -------------------------------------------------------------------------
 
+    @classmethod
+    def _instantiate_sampler_from_storage(cls, storage):
+        """
+        Creates a new instance of the reporter on disk and sampler which can then be manipulated.
+        Does not set any variables, use :func:`_restore_sampler_from_reporter` after calling this to set them.
+        Helper function to break up the :func:`from_storage` method in a way that subclasses can specialize
+
+        Parameters
+        ----------
+        storage : str or Reporter
+            If str: The path to the storage file.
+            If :class:`Reporter`: uses the :class:`Reporter` options
+            In the future this will be able to take a Storage class as well.
+
+        Returns
+        -------
+        sampler :  MultiStateSampler
+            A new instance of MultiStateSampler (or subclass) with options restored from disk
+        reporter : MultiStateReporter
+            Loaded instance of the reporter from disk.
+            In case ``storage`` was a reporter  returns the input reporter.
+            Reporter will be closed when returned.
+        """
+
+        # Handle case in which storage is a string.
+        reporter = cls._reporter_from_storage(storage, check_exist=True)
+
+        # Open a reporter to read the data.
+        reporter.open(mode='r')
+
+        # Retrieve options and create new simulation.
+        options = reporter.read_dict('options')
+        options['mcmc_moves'] = reporter.read_mcmc_moves()
+        sampler = cls(**options)
+
+        # Display papers to be cited.
+        sampler._display_citations()
+        reporter.close()
+        return sampler, reporter
+
+    def _restore_sampler_from_reporter(self, reporter):
+        """
+        (Re-)initialize the instanced sampler from the reporter. Intended to be called as the second half of a
+        :func:`from_storage` method after the :class:`MultiStateSampler` has been instanced from disk.
+
+        The ``self.reporter`` instance of this sampler will be in an open state for append mode after this has been set,
+        and the ``reporter`` used as argument will be closed. In the event they are the same, reporter will be
+        returned as open in append mode.
+
+        Note: Needs an already initialized reporter to work correctly.
+        Warning: can overwrite the current state of this :class:`MultiStateSampler` instance.
+
+        Helper function to break up the from_storage method in a way that subclasses can specialize
+
+        Parameters
+        ----------
+        reporter : MultiStateReporter
+            Reporter instance to read options from
+
+        """
+        # Ensure reporter is closed for safe keeping first
+        reporter.close()
+        # Reopen in read mode
+        reporter.open(mode='r')
+        # Read the last iteration reported to ensure we don't include junk
+        # data written just before a crash.
+        iteration = reporter.read_last_iteration()
+
+        # Retrieve other attributes.
+        logger.debug("Reading storage file {}...".format(reporter.filepath))
+        thermodynamic_states, unsampled_states = reporter.read_thermodynamic_states()
+        sampler_states = reporter.read_sampler_states(iteration=iteration)
+        state_indices = reporter.read_replica_thermodynamic_states(iteration=iteration)
+        energy_thermodynamic_states, neighborhoods, energy_unsampled_states = reporter.read_energies(iteration=iteration)
+        n_accepted_matrix, n_proposed_matrix = reporter.read_mixing_statistics(iteration=iteration)
+        metadata = reporter.read_dict('metadata')
+
+        # Search for last cached free energies only if online analysis is activated.
+        if self.online_analysis_interval is not None:
+            online_analysis_info = self._read_last_free_energy(reporter, iteration)
+            last_mbar_f_k, (_, last_err_free_energy) = online_analysis_info
+        else:
+            last_mbar_f_k, last_err_free_energy = None, None
+
+        # Close reading reporter.
+        reporter.close()
+
+        # Assign attributes.
+        self._iteration = iteration
+        self._thermodynamic_states = thermodynamic_states
+        self._unsampled_states = unsampled_states
+        self._sampler_states = sampler_states
+        self._replica_thermodynamic_states = state_indices
+        self._energy_thermodynamic_states = energy_thermodynamic_states
+        self._neighborhoods = neighborhoods
+        self._energy_unsampled_states = energy_unsampled_states
+        self._n_accepted_matrix = n_accepted_matrix
+        self._n_proposed_matrix = n_proposed_matrix
+        self._metadata = metadata
+
+        self._last_mbar_f_k = last_mbar_f_k
+        self._last_err_free_energy = last_err_free_energy
+
+        # We open the reporter only in node 0.
+        self._reporter = reporter
+        mpi.run_single_node(0, self._reporter.open, mode='a',
+                            broadcast_result=False, sync_nodes=False)
+
     def _check_nan_energy(self):
         """Checks that energies are finite and abort otherwise.
 
@@ -1071,15 +1185,15 @@ class MultiStateSampler(object):
 
         Parameters
         ----------
-        current_state_index : int
-            The currrent state
+        state_index : int
+            The current state
 
         Returns
         -------
         neighborhood : list of int
             The states in the local neighborhood
         """
-        if self.locality == None:
+        if self.locality is None:
             # Global neighborhood
             return list(range(0, self.n_states))
         else:
@@ -1337,9 +1451,6 @@ class MultiStateSampler(object):
             return
 
         # Write out the numbers
-        #TODO: Remove call if tests pass -LNN
-        # self._reporter.write_mbar_free_energies(self._iteration, self._last_mbar_f_k,
-        #                                         (free_energy, self._last_err_free_energy))
         self._reporter.write_online_data_dynamic_and_static(self._iteration,
                                                             f_k=self._last_mbar_f_k,
                                                             free_energy=(free_energy, self._last_err_free_energy))
@@ -1386,9 +1497,6 @@ class MultiStateSampler(object):
         self._last_err_free_energy = np.Inf
 
         # Store free energy estimate
-        # TODO: Remove this call if tests pass -LNN
-        # self._reporter.write_mbar_free_energies(self._iteration, self._last_mbar_f_k,
-        #                                         (free_energy, self._last_err_free_energy))
         self._reporter.write_online_data_dynamic_and_static(self._iteration,
                                                             f_k=self._last_mbar_f_k,
                                                             free_energy=(free_energy, self._last_err_free_energy))

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -344,8 +344,8 @@ class SAMSSampler(MultiStateSampler):
 
     @mpi.on_single_node(rank=0, broadcast_result=False, sync_nodes=False)
     @mpi.delayed_termination
-    def _report_iteration(self):
-        super(SAMSSampler, self)._report_iteration()
+    def _report_iteration_items(self):
+        super(SAMSSampler, self)._report_iteration_items()
         self._reporter.write_logZ(self._iteration, self._logZ)
         try:
             # Might just try calling `self._state_histograms` instead (code duplication reduction)

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -1654,7 +1654,7 @@ class TestSingleReplicaSAMS(TestMultiStateSampler):
             reporter = self.REPORTER(storage_path, open_mode='a', checkpoint_interval=2)
             replica_thermodynamic_states = reporter.read_replica_thermodynamic_states()
             N_k, _ = np.histogram(replica_thermodynamic_states, bins=np.arange(-0.5, sampler.n_states + 0.5))
-            assert np.all(sampler._state_histogram() == N_k)
+            assert np.all(sampler._state_histogram == N_k)
 
     # TODO: Test all update methods
 

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -350,6 +350,7 @@ def test_sams_harmonic_oscillator(verbose=False, verbose_simulation=False):
     if verbose:
         print("PASSED.")
 
+
 # ==============================================================================
 # TEST REPORTER
 # ==============================================================================
@@ -463,7 +464,7 @@ class TestReporter(object):
             assert thermodynamic_state_2['_Reporter__compatible_state'] == 'thermodynamic_states/3'
 
     def test_write_sampler_states(self):
-        """Check correct storage of thermodynamic states."""
+        """Check correct storage of sampler states."""
         analysis_particles = (1, 2)
         with self.temporary_reporter(analysis_particle_indices=analysis_particles, checkpoint_interval=2) as reporter:
             # Create sampler states.
@@ -779,6 +780,14 @@ class TestMultiStateSampler(object):
         hostguest_unsampled_states = [copy.deepcopy(nonalchemical_state)]
 
         cls.hostguest_test = (hostguest_compound_states, hostguest_sampler_states, hostguest_unsampled_states)
+
+        # Debugging Messages to sent to Nose with --nocapture enabled
+        output_descr = "Testing Sampler: {}  -- States: {}  -- Samplers: {}".format(
+            cls.SAMPLER.__name__, cls.N_STATES, cls.N_SAMPLERS)
+        len_output = len(output_descr)
+        print("#" * len_output)
+        print(output_descr)
+        print("#" * len_output)
 
     @staticmethod
     @contextlib.contextmanager
@@ -1496,19 +1505,47 @@ class TestMultiStateSampler(object):
             # Run
             sampler.run()
 
-            # The stored values of online analysis should be up to date.
-            last_written_free_energy = self.SAMPLER._read_last_free_energy(sampler._reporter, sampler.iteration)
-            last_mbar_f_k, (last_free_energy, last_err_free_energy) = last_written_free_energy
+            def validate_this_test():
+                # The stored values of online analysis should be up to date.
+                last_written_free_energy = self.SAMPLER._read_last_free_energy(sampler._reporter, sampler.iteration)
+                last_mbar_f_k, (last_free_energy, last_err_free_energy) = last_written_free_energy
 
-            assert len(sampler._last_mbar_f_k) == len(thermodynamic_states)
-            assert not np.all(sampler._last_mbar_f_k == 0)
-            assert np.all(sampler._last_mbar_f_k == last_mbar_f_k)
+                assert len(sampler._last_mbar_f_k) == len(thermodynamic_states)
+                assert not np.all(sampler._last_mbar_f_k == 0)
+                assert np.all(sampler._last_mbar_f_k == last_mbar_f_k)
 
-            assert last_free_energy is not None
+                assert last_free_energy is not None
 
-            # Error should not be 0 yet
-            assert sampler._last_err_free_energy != 0
-            assert sampler._last_err_free_energy == last_err_free_energy, "SAMPLER %s : sampler._last_err_free_energy = %s, last_err_free_energy = %s" % (self.SAMPLER, sampler._last_err_free_energy, last_err_free_energy)
+                # Error should not be 0 yet
+                assert sampler._last_err_free_energy != 0
+
+                assert sampler._last_err_free_energy == last_err_free_energy, \
+                    ("SAMPLER %s : sampler._last_err_free_energy = %s, "
+                     "last_err_free_energy = %s" % (self.SAMPLER.__name__,
+                                                    sampler._last_err_free_energy,
+                                                    last_err_free_energy)
+                     )
+            try:
+                validate_this_test()
+            except AssertionError as e:
+                # Handle case where MBAR does not have a converged free energy yet by attempting to run longer
+                # Only run up until we have sampled every state, or we hit some cycle limit
+                cycle_limit = 20  # Put some upper limit of cycles
+                cycles = 0
+                while (not np.unique(sampler._reporter.read_replica_thermodynamic_states()).size == self.N_STATES
+                       or cycles == cycle_limit):
+                    sampler.extend(20)
+                    try:
+                        validate_this_test()
+                    except AssertionError:
+                        # If the max error count internally is reached, its a RuntimeError and won't be trapped
+                        # So it will be raised correctly
+                        pass
+                    else:
+                        # Test is good, let it pass by returning here
+                        return
+                # If we get here, we have not validated, raise original error
+                raise e
 
     def test_online_analysis_stops(self):
         """Test online analysis will stop the simulation"""
@@ -1598,10 +1635,31 @@ class TestSingleReplicaSAMS(TestMultiStateSampler):
             additional_values.update(self.property_creator(name, name, value, value))
         self.actual_stored_properties_check(additional_properties=additional_values)
 
+    def test_state_histogram(self):
+        """Ensure SAMS on-the-fly state histograms match actually visited states"""
+        thermodynamic_states, sampler_states, unsampled_states = copy.deepcopy(self.alanine_test)
+        with self.temporary_storage_path() as storage_path:
+            # For this test, we simply check that the checkpointing writes on the interval
+            # We don't care about the numbers, per se, but we do care about when things are written
+            n_iterations = 10
+            move = mmtools.mcmc.IntegratorMove(openmm.VerletIntegrator(1.0 * unit.femtosecond), n_steps=1)
+            sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=n_iterations)
+            reporter = self.REPORTER(storage_path, checkpoint_interval=2)
+            self.call_sampler_create(sampler, reporter,
+                                     thermodynamic_states, sampler_states,
+                                     unsampled_states)
+            # Propagate.
+            sampler.run()
+            reporter.close()
+            reporter = self.REPORTER(storage_path, open_mode='a', checkpoint_interval=2)
+            replica_thermodynamic_states = reporter.read_replica_thermodynamic_states()
+            N_k, _ = np.histogram(replica_thermodynamic_states, bins=np.arange(-0.5, sampler.n_states + 0.5))
+            assert np.all(sampler._state_histogram() == N_k)
+
     # TODO: Test all update methods
 
 
-class TestMultipleReplicaSAMS(TestMultiStateSampler):
+class TestMultipleReplicaSAMS(TestSingleReplicaSAMS):
     """Test suite for SAMSSampler class."""
 
     # ------------------------------------
@@ -1609,9 +1667,6 @@ class TestMultipleReplicaSAMS(TestMultiStateSampler):
     # ------------------------------------
 
     N_SAMPLERS = 2
-    N_STATES = 5
-    SAMPLER = SAMSSampler
-    REPORTER = MultiStateReporter
 
     # --------------------------------------
     # Tests overwritten from base test suite


### PR DESCRIPTION
Given the large number of changes, and some things which need reviewed, I made this
into a PR instead of quick fix.

This changes how SAMS gets it `state_histograms` by storing a shape `[n_states]`
vector each iteration to the same location instead of relying on the
`reporter.replica_thermodynmaic_states` variable of shape `[iteration, n_states]`
which gets slower to access as `iteration` increases due to NetCDF file chunking.
Implemented on request of @jchodera

I would also like some feedback regarding how I [changed the online-free-energy test](https://github.com/choderalab/yank/compare/sams...histograms_and_storage?expand=1#diff-dd3d51a3d6465f978ab53b80e79929c1R1508).
Since SAMS may not sample well enough in the short run for MBAR to converge, I added
a test extension which tries to run longer up to a hard limit to see if more samples
fix the undersampling problem. We'll eventually refine that test to better
handle SAMS in the future, but I think this should work for now.

The MultistateSampler `from_storage` function has been refactored and split into
3 functions:
* Public `from_storage` function with an unchanged signature, calls the other 2
* `_instantiate_sampler_from_storage` class method which simply calls the `__init__` of the sampler after reading options from storage object
* `_restore_sampler_from_reporter` instance method which restores the state of the sampler from a reporter object.

This break down allows subclasses to implement either of the hidden methods to help with
restoring the state in a more granular way instead of having to rely on making a
full `from_storage` sub-method which does everything for the parent, but then the child
would need to re-open the reporter, reapply the settings, and it annoyed the IDE's
since they thought the `super().from_storage` returned an instance of the parent, and
not the child, making it complain about any additional calls in the `from_storage`
sub method unique to the child
Could use review @andrrizzi if possible (code changes shorter than reasoning)

Also fixes a bug in the online-analysis storage subroutines of the `Reporter` where
searching for alternate variable names threw a TypeError due to a convenience thing netCDF4's tries to do with key processing not handling the `in` method the way I figured it would.

Finally, I made the sampler base test class in `test_sampling.py` print out something
more helpful when it starts in on a new sampler when `--nocapture` is set. Should
help us debug a bit faster in the future.