### PR TITLE
Make the analysis storage chunk equal to checkpoint interval in SAMS

### DIFF
--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -619,7 +619,8 @@ class MultiStateReporter(object):
 
             # Create variables and attach units and description.
             ncvar_states = self._storage_analysis.createVariable('states', 'i4', ('iteration', 'replica'),
-                                                                 zlib=False, chunksizes=(1, n_replicas))
+                                                                 zlib=False,
+                                                                 chunksizes=(self._checkpoint_interval, n_replicas))
             setattr(ncvar_states, 'units', 'none')
             setattr(ncvar_states, "long_name", ("states[iteration][replica] is the thermodynamic state index "
                                                 "(0..n_states-1) of replica 'replica' of iteration 'iteration'."))
@@ -725,7 +726,9 @@ class MultiStateReporter(object):
                                                                    'f8',
                                                                    ('iteration', 'replica', 'state'),
                                                                    zlib=False,
-                                                                   chunksizes=(1, n_replicas, n_states))
+                                                                   chunksizes=(self._checkpoint_interval,
+                                                                               n_replicas,
+                                                                               n_states))
             ncvar_energies.units = 'kT'
             ncvar_energies.long_name = ("energies[iteration][replica][state] is the reduced (unitless) "
                                         "energy of replica 'replica' from iteration 'iteration' evaluated "
@@ -737,7 +740,9 @@ class MultiStateReporter(object):
                                                                    ('iteration', 'replica', 'state'),
                                                                    zlib=False,
                                                                    fill_value=1, # old-style files will be upgraded to have all states
-                                                                   chunksizes=(1, n_replicas, n_states))
+                                                                   chunksizes=(self._checkpoint_interval,
+                                                                               n_replicas,
+                                                                               n_states))
             ncvar_neighborhoods.long_name = ("neighborhoods[iteration][replica][state] is 1 if this energy was computed "
                                              "during this iteration.")
 
@@ -754,7 +759,7 @@ class MultiStateReporter(object):
                                                                             'f8',
                                                                             ('iteration', 'replica', 'unsampled'),
                                                                             zlib=False,
-                                                                            chunksizes=(1,
+                                                                            chunksizes=(self._checkpoint_interval,
                                                                                         n_replicas,
                                                                                         n_unsampled_states)
                                                                             )
@@ -823,13 +828,17 @@ class MultiStateReporter(object):
                                                                    'i4',
                                                                    ('iteration', 'state', 'state'),
                                                                    zlib=False,
-                                                                   chunksizes=(1, n_states, n_states)
+                                                                   chunksizes=(self._checkpoint_interval,
+                                                                               n_states,
+                                                                               n_states)
                                                                    )
             ncvar_proposed = self._storage_analysis.createVariable('proposed',
                                                                    'i4',
                                                                    ('iteration', 'state', 'state'),
                                                                    zlib=False,
-                                                                   chunksizes=(1, n_states, n_states)
+                                                                   chunksizes=(self._checkpoint_interval,
+                                                                               n_states,
+                                                                               n_states)
                                                                    )
             setattr(ncvar_accepted, 'units', 'none')
             setattr(ncvar_proposed, 'units', 'none')
@@ -873,9 +882,11 @@ class MultiStateReporter(object):
 
         """
         # Create variable if needed.
-        for storage in self._storage:
+        for storage_key, storage in self._storage_dict.items():
             if 'timestamp' not in storage.variables:
-                storage.createVariable('timestamp', str, ('iteration',), zlib=False, chunksizes=(1,))
+                storage.createVariable('timestamp', str, ('iteration',),
+                                       zlib=False,
+                                       chunksizes=(self._storage_chunks[storage_key],))
         timestamp = time.ctime()
         self._storage_analysis.variables['timestamp'][iteration] = timestamp
         checkpoint_iteration = self._calculate_checkpoint_iteration(iteration)
@@ -1126,9 +1137,9 @@ class MultiStateReporter(object):
             online_group = analysis_nc.createGroup('online_analysis')
             # larger chunks, faster operations, small matrix anyways
             online_group.createVariable('f_k', float, dimensions=('iteration', 'f_k_length'),
-                                        zlib=True, chunksizes=(1, len(f_k)))
+                                        zlib=True, chunksizes=(self._checkpoint_interval, len(f_k)))
             online_group.createVariable('free_energy', float, dimensions=('iteration', 'Df'),
-                                        zlib=True, chunksizes=(1, 2))
+                                        zlib=True, chunksizes=(self._checkpoint_interval, 2))
         online_group = analysis_nc.groups['online_analysis']
         online_group.variables['f_k'][iteration] = f_k
         online_group.variables['free_energy'][iteration, :] = free_energy
@@ -1322,7 +1333,7 @@ class MultiStateReporter(object):
 
         if iteration is not None:
             dims = ("iteration", data_dim)
-            chunks = (1, size)
+            chunks = (self._checkpoint_interval, size)
         else:
             dims = (data_dim,)
             chunks = (size,)
@@ -1497,7 +1508,7 @@ class MultiStateReporter(object):
         return storage.groups[group_name]
 
     @staticmethod
-    def _initialize_sampler_variables_on_file(dataset, n_atoms, n_replicas, is_periodic):
+    def _initialize_sampler_variables_on_file(dataset, n_atoms, n_replicas, is_periodic, iteration_chunk=1):
         """
         Initialize the NetCDF variables on the storage file needed to store sampler states.
         Does nothing if file already initialized
@@ -1512,6 +1523,8 @@ class MultiStateReporter(object):
             Number of Sampler states which will be written
         is_periodic : bool
             True if system is periodic; False otherwise.
+        iteration_chunk : int, Optional, Default: 1
+            What chunksize to use for the iteration dimension
         """
         if 'positions' not in dataset.variables:
 
@@ -1523,7 +1536,7 @@ class MultiStateReporter(object):
             # Define position variables
             ncvar_positions = dataset.createVariable('positions', 'f4',
                                                      ('iteration', 'replica', 'atom', 'spatial'),
-                                                     zlib=True, chunksizes=(1, n_replicas, n_atoms, 3))
+                                                     zlib=True, chunksizes=(iteration_chunk, n_replicas, n_atoms, 3))
             setattr(ncvar_positions, 'units', 'nm')
             setattr(ncvar_positions, "long_name", ("positions[iteration][replica][atom][spatial] is position of "
                                                    "coordinate 'spatial' of atom 'atom' from replica 'replica' for "
@@ -1533,9 +1546,9 @@ class MultiStateReporter(object):
             if is_periodic:
                 ncvar_box_vectors = dataset.createVariable('box_vectors', 'f4',
                                                            ('iteration', 'replica', 'spatial', 'spatial'),
-                                                           zlib=False, chunksizes=(1, n_replicas, 3, 3))
+                                                           zlib=False, chunksizes=(iteration_chunk, n_replicas, 3, 3))
                 ncvar_volumes = dataset.createVariable('volumes', 'f8', ('iteration', 'replica'),
-                                                       zlib=False, chunksizes=(1, n_replicas))
+                                                       zlib=False, chunksizes=(iteration_chunk, n_replicas))
 
                 setattr(ncvar_box_vectors, 'units', 'nm')
                 setattr(ncvar_volumes, 'units', 'nm**3')
@@ -1569,7 +1582,8 @@ class MultiStateReporter(object):
         # Check if the schema must be initialized, do this regardless of the checkpoint_interval for consistency
         is_periodic = True if (sampler_states[0].box_vectors is not None) else False
         self._initialize_sampler_variables_on_file(storage, sampler_states[0].n_particles,
-                                                   len(sampler_states), is_periodic)
+                                                   len(sampler_states), is_periodic,
+                                                   iteration_chunk=self._storage_chunks[storage_file])
         if obey_checkpoint_interval:
             write_iteration = self._calculate_checkpoint_iteration(iteration)
         else:
@@ -1718,6 +1732,11 @@ class MultiStateReporter(object):
             packed_data = np.empty(1, 'O')
             packed_data[0] = data_str
         nc_variable[:] = packed_data
+
+    @ property
+    def _storage_chunks(self):
+        """Known NetCDF storage chunk sizes"""
+        return {'checkpoint': 1, 'analysis': self._checkpoint_interval}
 
 
 # ==============================================================================

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -55,6 +55,7 @@ requirements:
     - matplotlib
     - jupyter
     - pdbfixer
+    - libnetcdf >=4.6.0
     #- libgcc
 
 test:


### PR DESCRIPTION
This is an optimization for read/write by using the `checkpoint_interval`
for the analysis file, and 1 for the checkpoint file.

Supersedes and closes #861 by merging into SAMS
Fixes #860