### PR TITLE
Remove dependencies from setup.py - cut down meta.yaml build

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,22 +14,7 @@ requirements:
   build:
     - python
     - cython
-    - numpy
-    - scipy
     - setuptools
-    - netcdf4
-    - openmm >=7.1
-    - mdtraj >=1.7.2
-    - openmmtools >=0.14.0
-    - pymbar
-    - ambermini >=16.16.0
-    - docopt
-    - openmoltools
-    - sphinxcontrib-bibtex
-    - cerberus
-    - matplotlib
-    - jupyter
-    - pdbfixer
     #- gcc 4.8.2 # [linux]
     #- gcc 4.8.2 # [osx]
 

--- a/setup.py
+++ b/setup.py
@@ -141,20 +141,7 @@ setup(
                   },
     zip_safe=False,
     python_requires=">=3.5",
-    install_requires=[
-        'numpy',
-        'scipy',
-        'cython',
-        'openmm>=7.1',
-        'pymbar',
-        'openmmtools>=0.14.0',
-        'docopt>=0.6.1',
-        'netcdf4',
-        'cerberus',
-        'openmoltools>=0.7.5',
-        'mdtraj',
-        'pyyaml',
-        'pdbfixer'
-        ],
+    # This has been removed in favor of the conda meta.yaml file dependencies
+    # install_requires=[],
     ext_modules=cythonize(mixing_ext),
     entry_points={'console_scripts': ['yank = yank.cli:main']})


### PR DESCRIPTION
This speeds up conda build times by reducing the number of packages which have to be downloaded.

Fixes #876