### PR TITLE
[WIP] Update to use latest miniconda in yank installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER John Chodera <john.chodera@choderalab.org>
 
 # Install miniconda
 RUN apt-get update && apt-get install -y wget
-RUN MINICONDA="Miniconda3-3.5.5-Linux-x86_64.sh" && \
+RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
     wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
     bash $MINICONDA -b -p /miniconda && \
     rm -f $MINICONDA


### PR DESCRIPTION
I tried building locally and saw the same failure as on Dockerhub. The failure occurs during `conda install --yes yank`, which for some reason gets killed. When I changed the miniconda download to use "latest," it succeeded locally. Marked WIP right now to see if this fixes the Dockerhub build, and to give a chance to test run the container.