### PR TITLE
Unbias restraint analysis

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -89,10 +89,11 @@ class YankMultiStateSamplerAnalyzer(multistate.MultiStateSamplerAnalyzer, YankPh
 
         if compute_ssc:
             thermodynamic_state = self._get_end_thermodynamic_states()[0]
+            restraint_energy_cutoff, restraint_distance_cutoff = self._get_restraint_cutoffs()
             # TODO: Compute average box volume here to feed to max_volume?
             ssc = restraint_force.compute_standard_state_correction(
-                thermodynamic_state, square_well=True, radius_cutoff=self.restraint_distance_cutoff,
-                energy_cutoff=self.restraint_energy_cutoff, max_volume='system')
+                thermodynamic_state, square_well=True, radius_cutoff=restraint_distance_cutoff,
+                energy_cutoff=restraint_energy_cutoff, max_volume='system')
 
             # Update observable.
             self._computed_observables['standard_state_correction'] = ssc

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -131,7 +131,7 @@ class YankParallelTemperingAnalyzer(multistate.ParallelTemperingAnalyzer, YankMu
 # MODULE FUNCTIONS
 # =============================================================================================
 
-def get_analyzer(file_base_path):
+def get_analyzer(file_base_path, **analyzer_kwargs):
     """
     Utility function to convert storage file to a Reporter and Analyzer by reading the data on file
 
@@ -142,6 +142,8 @@ def get_analyzer(file_base_path):
     ----------
     file_base_path : string
         Complete path to the storage file with filename and extension.
+    **analyzer_kwargs
+        Keyword arguments to pass to the analyzer.
 
     Returns
     -------
@@ -161,13 +163,13 @@ def get_analyzer(file_base_path):
     """
     # Eventually change this to auto-detect simulation from reporter:
     if True:
-        analyzer = YankReplicaExchangeAnalyzer(reporter)
+        analyzer = YankReplicaExchangeAnalyzer(reporter, **analyzer_kwargs)
     else:
         raise RuntimeError("Cannot automatically determine analyzer for Reporter: {}".format(reporter))
     return analyzer
 
 
-def analyze_directory(source_directory):
+def analyze_directory(source_directory, **analyzer_kwargs):
     """
     Analyze contents of store files to compute free energy differences.
 
@@ -177,7 +179,9 @@ def analyze_directory(source_directory):
     Parameters
     ----------
     source_directory : string
-       The location of the simulation storage files.
+        The location of the simulation storage files.
+    **analyzer_kwargs
+        Keyword arguments to pass to the analyzer.
 
     """
     analysis_script_path = os.path.join(source_directory, 'analysis.yaml')
@@ -191,7 +195,7 @@ def analyze_directory(source_directory):
     data = dict()
     for phase_name, sign in analysis:
         phase_path = os.path.join(source_directory, phase_name + '.nc')
-        phase = get_analyzer(phase_path)
+        phase = get_analyzer(phase_path, **analyzer_kwargs)
         data[phase_name] = phase.analyze_phase()
         kT = phase.kT
 

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -83,7 +83,7 @@ class YankMultiStateSamplerAnalyzer(multistate.MultiStateSamplerAnalyzer, YankPh
         # Determine if we need to recompute the standard state correction.
         compute_ssc = True
         try:
-            restraint_force, _, _ = self._get_restraint_data()
+            restraint_force, _, _ = self._get_radially_symmetric_restraint_data()
         except (mmtools.forces.NoForceFoundError, TypeError):
             compute_ssc = False
 

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -81,7 +81,7 @@ class YankMultiStateSamplerAnalyzer(multistate.MultiStateSamplerAnalyzer, YankPh
             return self._computed_observables['standard_state_correction']
 
         # Determine if we need to recompute the standard state correction.
-        compute_ssc = True
+        compute_ssc = self.unbias_restraint
         try:
             restraint_force, _, _ = self._get_radially_symmetric_restraint_data()
         except (mmtools.forces.NoForceFoundError, TypeError):

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -97,15 +97,15 @@ def dispatch(args):
 def extract_analyzer_kwargs(args, quantities_as_strings=False):
     """Return a dictionary with the keyword arguments to pass to the analyzer."""
     analyzer_kwargs = {}
-    if args['skipunbiasing']:
+    if args['--skipunbiasing']:
         analyzer_kwargs['unbias_restraint'] = False
-    if args['energycutoff']:
-        analyzer_kwargs['restraint_energy_cutoff'] = float(args['energycutoff'])
-    if args['distcutoff']:
+    if args['--energycutoff']:
+        analyzer_kwargs['restraint_energy_cutoff'] = float(args['--energycutoff'])
+    if args['--distcutoff']:
         if quantities_as_strings:
-            distcutoff = args['distcutoff'] + '*angstroms'
+            distcutoff = args['--distcutoff'] + '*angstroms'
         else:
-            distcutoff = float(args['distcutoff']) * unit.angstroms
+            distcutoff = float(args['--distcutoff']) * unit.angstroms
         analyzer_kwargs['restraint_distance_cutoff'] = distcutoff
     return analyzer_kwargs
 

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -43,9 +43,18 @@ Free Energy Required Arguments:
 
 Free Energy Optional Arguments:
   --skipunbiasing               Skip the radially-symmetric restraint unbiasing. This can be an expensive step.
+                                If this flag is not specified, and no cutoff is given, a distance cutoff is
+                                automatically determined as the 99.9-percentile of the restraint distance distribution
+                                in the bound state.
   --distcutoff=DISTANCE         The restraint distance cutoff (in angstroms) to be used to unbias the restraint.
+                                When the restraint is unbiased, the analyzer discards all the samples for which the
+                                distance between the restrained atoms is above this cutoff. Effectively, this is
+                                equivalent to placing a hard wall potential at a restraint distance "distcutoff".
   --energycutoff=ENERGY         The restraint unitless potential energy cutoff (i.e. in kT) to be used to unbias the
-                                restraint.
+                                restraint. When the restraint is unbiased, the analyzer discards all the samples for
+                                which the restrain potential energy (in kT) is above this cutoff. Effectively, this is
+                                equivalent to placing a hard wall potential at a restraint distance such that the
+                                restraint potential energy is equal to "energycutoff".
 
 YANK Health Report Arguments:
   -o=REPORT, --output=REPORT    Name of the health report Jupyter notebook or static file, can use a path + name as well

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -179,10 +179,12 @@ def dispatch_report(args):
     # PDF requires xelatex binary in the OS (provided by LaTeX such as TeXLive and MiKTeX)
     requires_prerendering = file_extension.lower() in {'.pdf', '.html'}
     try:
+        import seaborn
         import matplotlib
         import jupyter
     except ImportError:
         error_msg = ("Rendering this notebook requires the following packages:\n"
+                     " - seaborn\n"
                      " - matplotlib\n"
                      " - jupyter\n"
                      "These are not required to generate the notebook however")
@@ -221,6 +223,8 @@ def dispatch_report(args):
         loaded_notebook = nbformat.read(io.StringIO(notebook_text), as_version=4)
         # Process the notebook.
         ep = ExecutePreprocessor(timeout=None)
+        # Sometimes the default startup timeout exceed the default of 60 seconds.
+        ep.startup_timeout = 180
         # Set the title name, does not appear in all exporters
         resource_data = {'metadata': {'name': 'YANK Simulation Report: {}'.format(file_base_name)}}
         print("Processing notebook now, this may take a while...")

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1427,9 +1427,8 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         apply_distance_cutoff = restraint_distance_cutoff is not None
 
         # We need to take into account the initial unsampled states to index correctly N_l.
-        state_idx_shift = 0
-        while N_l[state_idx_shift] == 0:
-            state_idx_shift +=1
+        n_unsampled_states = len(u_ln) - self.n_states
+        first_sampled_state_idx = int(n_unsampled_states / 2)
 
         # Determine which samples are outside the cutoffs or have to be truncated.
         columns_to_keep = []
@@ -1437,7 +1436,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
             if ((apply_energy_cutoff and energies_ln[iteration_ln_idx] > restraint_energy_cutoff) or
                     (apply_distance_cutoff and distances_ln[iteration_ln_idx] > restraint_distance_cutoff)):
                 # Update the number of samples generated from its state.
-                N_l[state_idx + state_idx_shift] -= 1
+                N_l[state_idx + first_sampled_state_idx] -= 1
             else:
                 columns_to_keep.append(iteration_ln_idx)
 

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1472,7 +1472,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         # iterations_groups = itertools.groupby(enumerate(decorrelated_iterations), key=lambda x: int(x[1] / chunk_size))
 
         # Pre-computing energies/distances.
-        logger.debug('Computing restraint energies...')
+        logger.debug('Computing restraint energies/distances...')
         replica_state_indices = self._reporter.read_replica_thermodynamic_states()
         for iteration_idx, iteration in enumerate(decorrelated_iterations):
             # Check if we have already computed this energy/distance.

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1817,9 +1817,9 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
         Returns
         -------
-        n_equilibration_iteration : int
+        n_equilibration_iterations : int
         statistical_inefficiency : float
-        n_effective_iterations : int
+        n_uncorrelated_iterations : int
         """
         u_n = self.get_effective_energy_timeseries(energies, replica_state_indices)
         # Discard equilibration samples.

--- a/Yank/reports/YANK_Health_Report_Template.ipynb
+++ b/Yank/reports/YANK_Health_Report_Template.ipynb
@@ -29,13 +29,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Mandatory Settings\n",
     "store_directory = 'STOREDIRBLANK'\n",
+    "analyzer_kwargs = ANALYZERKWARGSBLANK\n",
     "\n",
     "# Optional Settings\n",
     "decorrelation_threshold = 0.1\n",
@@ -62,7 +61,7 @@
     "from matplotlib import pyplot as plt\n",
     "from yank.reports import notebook\n",
     "%matplotlib inline\n",
-    "report = notebook.HealthReportData(store_directory)\n",
+    "report = notebook.HealthReportData(store_directory, **analyzer_kwargs)\n",
     "report.report_version()"
    ]
   },
@@ -212,9 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mixing_figure = report.generate_mixing_plot(mixing_cutoff=mixing_cutoff, \n",
@@ -224,9 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "Replica Pseudorandom Walk Examination\n",
     "====================\n",
@@ -252,9 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "replica_mixing_figure = report.generate_replica_mixing_plot(phase_stacked_replica_plots=phase_stacked_replica_plots)"
@@ -427,7 +420,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/Yank/reports/YANK_Health_Report_Template.ipynb
+++ b/Yank/reports/YANK_Health_Report_Template.ipynb
@@ -302,9 +302,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Restraint energies and distances distribution\n",
+    "# Radially-symmetric restraint energy and distance distributions\n",
     "\n",
-    "When unbiasing the restraint, it is important"
+    "This plot is generated only if the simulation employs a radially-symmetric restraint (e.g. harmonic, flat-bottom), and the unbias_restraint option of the analyzer was set.\n",
+    "\n",
+    "## What do I want to see here?\n",
+    "When unbiasing the restraint, it is important to verify that the cutoffs do not remove too many configurations sampled from the bound state. Almost all the density of the bound state should be on the left of an eventual cutoff (red line).\n",
+    "\n",
+    "In general, we expect the distribution in the bound state to be narrower than in the non-interacting state. If this is not the case, then either the binder is weak and it has left the binding site during the simulation, or the restraint might be too tight and limiting the conformational space explored by the ligand."
    ]
   },
   {
@@ -313,7 +318,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    ""
+    "restraint_distribution_figure = report.restraint_distributions_plot()"
    ]
   },
   {

--- a/Yank/reports/YANK_Health_Report_Template.ipynb
+++ b/Yank/reports/YANK_Health_Report_Template.ipynb
@@ -276,7 +276,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Free Energy Trace for Equalibrium Stability\n",
+    "# Free Energy Trace for Equilibrium Stability\n",
     "\n",
     "The free energy difference alone, even with all the additional information previously, may still be an underestimate of the true free energy. One way to check this is to drop samples from the start and end of the simulation, and re-run the free energy estimate. Ideally, you would want to see the forward and reverse analysis be roughly converged for when more than 80% of the samples are kept, divergence when only 10-30% of the samples are kept is expected behavior. \n",
     "\n",
@@ -302,7 +302,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Execute this block to write out serialzied data\n",
+    "# Restraint energies and distances distribution\n",
+    "\n",
+    "When unbiasing the restraint, it is important"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Execute this block to write out serialized data\n",
     "\n",
     "This is left commented out in the template to prevent it from auto-running with everything else\n"
    ]

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -680,7 +680,8 @@ class HealthReportData(object):
                 s_reverse = states[:, -1:-kept_iterations - 1:-1]
                 for energy_sub, state_sub, storage in [
                         (u_forward, s_forward, free_energy_trace_f), (u_reverse, s_reverse, free_energy_trace_r)]:
-                    u_n = analyzer.get_effective_energy_timeseries(energies=energy_sub, states=state_sub)
+                    u_n = analyzer.get_effective_energy_timeseries(energies=energy_sub,
+                                                                   replica_state_indices=state_sub)
                     number_equilibrated, g_t, neff_max = analyze.multistate.utils.get_equilibration_data(u_n)
                     energy_sub = analyze.multistate.utils.remove_unequilibrated_data(energy_sub,
                                                                                      number_equilibrated,
@@ -735,7 +736,7 @@ class HealthReportData(object):
                 break
         # Check if we have a restraint at all.
         if len(lambda1_data[ENERGIES_IDX]) == 0:
-            print('The restraint unbiasing was not performed for this calculation.')
+            print('The restraint unbiasing step was not performed for this calculation.')
             return
 
         # The restraint distances are not computed if there's no distance cutoff.
@@ -750,7 +751,7 @@ class HealthReportData(object):
                 data[DISTANCES_IDX] /= units.angstroms
 
         # Plot the lambda=1 and lambda=0 restraints data.
-        figure, axes = plt.subplots(ncols=len(lambda1_data))
+        figure, axes = plt.subplots(ncols=len(lambda1_data), figsize=(20, 10))
         if len(lambda1_data) == 1:
             axes = [axes]
         for ax, lambda1, lambda0 in zip(axes, lambda1_data, lambda0_data):
@@ -763,7 +764,7 @@ class HealthReportData(object):
             ax.plot([cutoff for _ in range(100)], np.linspace(limits[0], limits[1]/2, num=100))
 
         # Labels and legend.
-        for i, (ax, xlabel) in zip(axes, xlabels):
+        for i, (ax, xlabel) in enumerate(zip(axes, xlabels)):
             ax.set_xlabel(xlabel)
             if i == 0:
                 ax.set_ylabel('Number of samples')

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -11,11 +11,11 @@ import yaml
 import numpy as np
 from scipy import interpolate
 from matplotlib import pyplot as plt
-from matplotlib.colors import LinearSegmentedColormap, NoNorm
+from matplotlib.colors import LinearSegmentedColormap
 from matplotlib import gridspec
 from simtk import unit as units
 from .. import version
-from .. import analyze
+from .. import analyze, utils
 
 kB = units.BOLTZMANN_CONSTANT_kB * units.AVOGADRO_CONSTANT_NA
 
@@ -24,7 +24,7 @@ class HealthReportData(object):
     """
     Class which houses the data used for the notebook and the generation of all plots including formatting
     """
-    def __init__(self, store_directory):
+    def __init__(self, store_directory, **analyzer_kwargs):
         """
         Initial data read in and object assignment
 
@@ -32,7 +32,19 @@ class HealthReportData(object):
         ----------
         store_directory : string
             Location where the analysis.yaml file is and where the NetCDF files are
+        **analyzer_kwargs
+            Keyword arguments to pass to the analyzer class. Quantities can be
+            passed as strings.
         """
+        # Convert analyzer string quantities into variables.
+        for key, value in analyzer_kwargs.items():
+            try:
+                quantity = utils.quantity_from_string(value)
+            except:
+                pass
+            else:
+                analyzer_kwargs[key] = quantity
+
         # Read in data
         analysis_script_path = os.path.join(store_directory, 'analysis.yaml')
         if not os.path.isfile(analysis_script_path):

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -560,13 +560,13 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
     -----
     To create a subclass, follow these steps:
 
-        1. Implement the property :func:`_energy_function` with the energy function of choice.
+        1. Implement the :func:`_create_restraint_force` returning the
+        force object modeling the restraint.
 
-        2. Implement the property :func:`_bond_parameters` to return the :func:`_energy_function`
-        parameters as a dict ``{parameter_name: parameter_value}``.
+        2. Implement the property :func:`_are_restraint_parameters_defined`.
 
-        3. Optionally, you can overwrite the :func:`_determine_bond_parameters` member
-        function to automatically determine these parameters from the atoms positions.
+        3. Optionally, you can overwrite the :func:`_determine_restraint_parameters`
+        method to automatically determine these parameters from the atoms positions.
 
     """
     def __init__(self, restrained_receptor_atoms=None, restrained_ligand_atoms=None):
@@ -634,8 +634,8 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
                                           'atoms.'.format(self.__class__.__name__))
 
         # Create restraint force.
-        restraint_force = self._create_restraint_force(self.restrained_receptor_atoms,
-                                                       self.restrained_ligand_atoms)
+        restraint_force = self._get_restraint_force(self.restrained_receptor_atoms,
+                                                    self.restrained_ligand_atoms)
 
         # Set periodic conditions on the force if necessary.
         restraint_force.setUsesPeriodicBoundaryConditions(thermodynamic_state.is_periodic)
@@ -664,78 +664,8 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         timer = mmtools.utils.Timer()
         timer.start(benchmark_id)
 
-        r_min = 0 * unit.nanometers
-        r_max = 100 * unit.nanometers  # TODO: Use maximum distance between atoms?
-
-        # Create a System object containing two particles connected by the reference force
-        system = openmm.System()
-        system.addParticle(1.0 * unit.amu)
-        system.addParticle(1.0 * unit.amu)
-        force = self._create_restraint_force([0], [1])
-        # Disable the PBC if on for this approximation of the analytical solution
-        force.setUsesPeriodicBoundaryConditions(False)
-        system.addForce(force)
-
-        # Create a Reference context to evaluate energies on the CPU.
-        integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)
-        platform = openmm.Platform.getPlatformByName('Reference')
-        context = openmm.Context(system, integrator, platform)
-
-        # Set default positions.
-        positions = unit.Quantity(np.zeros([2,3]), unit.nanometers)
-        context.setPositions(positions)
-
-        # Create a function to compute integrand as a function of interparticle separation.
-        beta = thermodynamic_state.beta
-
-        def integrand(r):
-            """
-            Parameters
-            ----------
-            r : float
-                Inter-particle separation in nanometers
-
-            Returns
-            -------
-            dI : float
-               Contribution to integrand (in nm^2).
-
-            """
-            positions[1, 0] = r * unit.nanometers
-            context.setPositions(positions)
-            state = context.getState(getEnergy=True)
-            potential = state.getPotentialEnergy()
-            dI = 4.0 * math.pi * r**2 * math.exp(-beta * potential)
-            return dI
-
-        # Integrate shell volume.
-        shell_volume, shell_volume_error = scipy.integrate.quad(lambda r: integrand(r), r_min / unit.nanometers,
-                                                                r_max / unit.nanometers) * unit.nanometers**3
-        logger.debug("shell_volume = %f nm^3" % (shell_volume / unit.nanometers**3))
-
-        # The restraint shell volume must be smaller than the
-        # system box volume or the restraint doesn't make sense.
-        if thermodynamic_state.is_periodic:
-            # Compute system volume in NVT/NPT ensemble.
-            system_box_volume = thermodynamic_state.volume
-            if system_box_volume is None:  # NPT ensemble
-                box_vectors = thermodynamic_state.system.getDefaultPeriodicBoxVectors()
-                system_box_volume = mmtools.states._box_vectors_volume(box_vectors)
-            logger.debug("System volume = {} nm^3".format(system_box_volume / unit.nanometers**3))
-
-            # Raise error if shell volume is too big.
-            if shell_volume > system_box_volume:
-                raise RuntimeError('The restraint does not limit the configurational '
-                                   'space within the solvation box.')
-
-        # Compute standard-state volume for a single molecule in a box of
-        # size (1 L) / (avogadros number). Should also generate constant V0.
-        liter = 1000.0 * unit.centimeters**3  # one liter
-        standard_state_volume = liter / (unit.AVOGADRO_CONSTANT_NA*unit.mole)  # standard state volume
-        logger.debug("Standard state volume = {} nm^3".format(standard_state_volume / unit.nanometers**3))
-
-        # Compute standard state correction for releasing shell restraints into standard-state box (in units of kT).
-        DeltaG = - math.log(standard_state_volume / shell_volume)
+        restraint_force = self._get_restraint_force([0], [1])
+        DeltaG = restraint_force.compute_standard_state_correction(thermodynamic_state, max_volume='system')
         logger.debug('Standard state correction: {:.3f} kT'.format(DeltaG))
 
         # Report elapsed time.
@@ -767,41 +697,47 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         self._determine_restrained_atoms(sampler_state, topography)
 
         # Determine missing parameters. This is implemented in the subclass.
-        self._determine_bond_parameters(thermodynamic_state, sampler_state, topography)
+        self._determine_restraint_parameters(thermodynamic_state, sampler_state, topography)
 
     # -------------------------------------------------------------------------
     # Internal-usage: properties and methods for subclasses.
     # -------------------------------------------------------------------------
 
     @abc.abstractproperty
-    def _energy_function(self):
-        """str: energy expression of the restraint force.
+    def _are_restraint_parameters_defined(self):
+        """bool: True if the restraint parameters are defined."""
+        pass
 
-        This must be implemented by the inheriting class.
+    @abc.abstractmethod
+    def _create_restraint_force(self, particles1, particles2):
+        """Create a new restraint force between specified atoms.
+
+        The property _are_restraint_parameters_defined is guaranteed to
+        be True when this is called.
+
+        Parameters
+        ----------
+        particles1 : list of int
+            Indices of first group of atoms to restraint.
+        particles2 : list of int
+            Indices of second group of atoms to restraint.
+
+        Returns
+        -------
+        force : simtk.openmm.Force
+           The created restraint force.
 
         """
         pass
 
-    @abc.abstractproperty
-    def _bond_parameters(self):
-        """dict: the bond parameters of the restraint force.
-
-        This is a dictionary parameter_name: parameter_value that
-        will be used to configure the `CustomBondForce` added to
-        the `System`.
-
-        If there are parameters undefined, this must be None.
-
-        """
-        pass
-
-    def _determine_bond_parameters(self, thermodynamic_state, sampler_state, topography):
+    def _determine_restraint_parameters(self, thermodynamic_state, sampler_state, topography):
         """Determine the missing bond parameters.
 
         Optionally, a subclass can implement this method to automatically
         define the bond parameters of the restraints from the information
         in the given states and topography. The default implementation just
-        raises a NotImplemented error if `_bond_parameters` are undefined.
+        raises a NotImplemented error if `_are_restraint_parameters_defined`
+        is False.
 
         Parameters
         ----------
@@ -814,7 +750,7 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
 
         """
         # Raise exception only if the subclass doesn't already defines parameters.
-        if self._bond_parameters is None:
+        if not self._are_restraint_parameters_defined:
             raise NotImplementedError('Restraint {} cannot automatically determine '
                                       'bond parameters.'.format(self.__class__.__name__))
 
@@ -830,6 +766,16 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
             if atoms is None or not (isinstance(atoms, list) and len(atoms) > 0):
                 return False
         return True
+
+    def _get_restraint_force(self, particles1, particles2):
+        """Check that the parameters are defined before calling the force constructor."""
+        # Check if restraint parameters have been defined.
+        if self._are_restraint_parameters_defined is None:
+            err_msg = 'Restraint {}: Undefined bond parameters.'.format(self.__class__.__name__)
+            raise RestraintParameterError(err_msg)
+
+        # Create restraint force.
+        return self._create_restraint_force(particles1, particles2)
 
     def _determine_restrained_atoms(self, sampler_state, topography):
         """Determine the atoms to restrain.
@@ -901,51 +847,6 @@ class RadiallySymmetricRestraint(ReceptorLigandRestraint):
         self.restrained_receptor_atoms = compute_atom_set(restrained_receptor_atoms,
                                                           'receptor_atoms',
                                                           self._closest_atom_to_centroid)
-
-    def _create_restraint_force(self, particles1, particles2):
-        """Create a new restraint force between specified atoms.
-
-        Parameters
-        ----------
-        particles1 : list of int
-            Indices of first group of atoms to restraint.
-        particles2 : list of int
-            Indices of second group of atoms to restraint.
-
-        Returns
-        -------
-        force : simtk.openmm.CustomBondForce
-           The created restraint force.
-
-        """
-        # Check if parameters have been defined.
-        if self._bond_parameters is None:
-            err_msg = 'Restraint {}: Undefined bond parameters.'.format(self.__class__.__name__)
-            raise RestraintParameterError(err_msg)
-
-        # Unzip bond parameters names and values from dict.
-        parameter_names, parameter_values = zip(*self._bond_parameters.items())
-
-        # Create bond force and lambda_restraints parameter to control it.
-        if len(particles1) == 1 and len(particles2) == 1:
-            # CustomCentroidBondForce works only on 64bit platforms. When the
-            # restrained groups only have 1 particle, we can use the standard
-            # CustomBondForce so that we can support 32bit platforms too.
-            energy_function = self._energy_function.replace('distance(g1,g2)', 'r')
-            force = openmm.CustomBondForce('lambda_restraints * ' + energy_function)
-            force.addBond(particles1[0], particles2[0], parameter_values)
-        else:
-            force = openmm.CustomCentroidBondForce(2, 'lambda_restraints * ' + self._energy_function)
-            force.addGroup(particles1)
-            force.addGroup(particles2)
-            force.addBond([0, 1], parameter_values)
-
-        # Add all parameters.
-        force.addGlobalParameter('lambda_restraints', 1.0)
-        for parameter in parameter_names:
-            force.addPerBondParameter(parameter)
-
-        return force
 
     @staticmethod
     def _closest_atom_to_centroid(positions, indices=None, masses=None):
@@ -1102,22 +1003,39 @@ class Harmonic(RadiallySymmetricRestraint):
         self.spring_constant = spring_constant
 
     @property
-    def _energy_function(self):
-        """str: energy expression of the restraint force."""
-        return '(K/2)*distance(g1,g2)^2'
+    def _are_restraint_parameters_defined(self):
+        """bool: True if the restraint parameters are defined."""
+        return self.spring_constant is not None
 
-    @property
-    def _bond_parameters(self):
-        """dict: the bond parameters of the restraint force.
+    def _create_restraint_force(self, particles1, particles2):
+        """Create a new restraint force between specified atoms.
 
-        If there are parameters undefined, this is None.
+        Parameters
+        ----------
+        particles1 : list of int
+            Indices of first group of atoms to restraint.
+        particles2 : list of int
+            Indices of second group of atoms to restraint.
+
+        Returns
+        -------
+        force : simtk.openmm.Force
+           The created restraint force.
 
         """
-        if self.spring_constant is None:
-            return None
-        return {'K': self.spring_constant}
+        # Create bond force and lambda_restraints parameter to control it.
+        if len(particles1) == 1 and len(particles2) == 1:
+            # CustomCentroidBondForce works only on 64bit platforms. When the
+            # restrained groups only have 1 particle, we can use the standard
+            # CustomBondForce so that we can support 32bit platforms too.
+            return mmtools.forces.HarmonicRestraintBondForce(spring_constant=self.spring_constant,
+                                                             restrained_atom_index1=particles1[0],
+                                                             restrained_atom_index2=particles2[0])
+        return mmtools.forces.HarmonicRestraintForce(spring_constant=self.spring_constant,
+                                                     restrained_atom_indices1=particles1,
+                                                     restrained_atom_indices2=particles2)
 
-    def _determine_bond_parameters(self, thermodynamic_state, sampler_state, topography):
+    def _determine_restraint_parameters(self, thermodynamic_state, sampler_state, topography):
         """Automatically choose a spring constant for the restraint force.
 
         The spring constant is selected to give 1 kT at one standard deviation
@@ -1264,17 +1182,41 @@ class FlatBottom(RadiallySymmetricRestraint):
         return 'step(distance(g1,g2)-r0) * (K/2)*(distance(g1,g2)-r0)^2'
 
     @property
-    def _bond_parameters(self):
-        """dict: the bond parameters of the restraint force.
+    def _are_restraint_parameters_defined(self):
+        """bool: True if the restraint parameters are defined."""
+        return self.spring_constant is not None and self.well_radius is not None
 
-        If there are parameters undefined, this is None.
+    def _create_restraint_force(self, particles1, particles2):
+        """Create a new restraint force between specified atoms.
+
+        Parameters
+        ----------
+        particles1 : list of int
+            Indices of first group of atoms to restraint.
+        particles2 : list of int
+            Indices of second group of atoms to restraint.
+
+        Returns
+        -------
+        force : simtk.openmm.Force
+           The created restraint force.
 
         """
-        if self.spring_constant is None or self.well_radius is None:
-            return None
-        return {'K': self.spring_constant, 'r0': self.well_radius}
+        # Create bond force and lambda_restraints parameter to control it.
+        if len(particles1) == 1 and len(particles2) == 1:
+            # CustomCentroidBondForce works only on 64bit platforms. When the
+            # restrained groups only have 1 particle, we can use the standard
+            # CustomBondForce so that we can support 32bit platforms too.
+            return mmtools.forces.FlatBottomRestraintBondForce(spring_constant=self.spring_constant,
+                                                               well_radius=self.well_radius,
+                                                               restrained_atom_index1=particles1[0],
+                                                               restrained_atom_index2=particles2[0])
+        return mmtools.forces.FlatBottomRestraintForce(spring_constant=self.spring_constant,
+                                                       well_radius=self.well_radius,
+                                                       restrained_atom_indices1=particles1,
+                                                       restrained_atom_indices2=particles2)
 
-    def _determine_bond_parameters(self, thermodynamic_state, sampler_state, topography):
+    def _determine_restraint_parameters(self, thermodynamic_state, sampler_state, topography):
         """Automatically choose a spring constant and well radius.
 
         The spring constant, is set to 5.92 kcal/mol/A**2, the well

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -467,7 +467,8 @@ class ReceptorLigandRestraint(ABC):
 
         # If the System is full, just separate the force from nonbonded interactions.
         if len(available_force_groups) == 0:
-            nonbonded_force = mmtools.forces.find_nonbonded_force(system)
+            _, nonbonded_force = mmtools.forces.find_forces(system, openmm.NonbondedForce,
+                                                            only_one=True)
             available_force_groups = set(range(32))
             available_force_groups.discard(nonbonded_force.getForceGroup())
 

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -323,7 +323,7 @@ class TestMultiPhaseAnalyzer(object):
     def test_multi_phase(self):
         """Test MultiPhaseAnalysis"""
         # Create the phases
-        full_phase = self.ANALYZER(self.reporter, name=self.repex_name)
+        full_phase = self.ANALYZER(self.reporter, name=self.repex_name, unbias_restraint=False)
         blank_phase = BlankPhase(self.reporter, name="blank")
         fe_phase = FreeEnergyPhase(self.reporter, name="fe")
         fes_phase = FEStandardStatePhase(self.reporter, name="fes")
@@ -392,7 +392,7 @@ class TestMultiPhaseAnalyzer(object):
 
     def test_cached_properties_dependencies(self):
         """Test that cached properties are invalidated when their dependencies change."""
-        analyzer = self.ANALYZER(self.reporter, name=self.repex_name)
+        analyzer = self.ANALYZER(self.reporter, name=self.repex_name, unbias_restraint=False)
 
         def check_cached_properties(is_in):
             for cached_property in cached_properties:
@@ -455,6 +455,7 @@ class TestMultiPhaseAnalyzer(object):
         # Switch unbias_restraint to True. The old cached value is invalidated and
         # now u_ln and N_l have two extra states.
         analyzer.unbias_restraint = True
+        analyzer.restraint_energy_cutoff = 18.2
         assert analyzer._unbiased_decorrelated_u_ln.shape[0] == analyzer._decorrelated_u_ln.shape[0] + 2
         assert analyzer._unbiased_decorrelated_N_l.shape[0] == analyzer._decorrelated_N_l.shape[0] + 2
         # The automatic cutoff (default value) should remove some of the iterations.

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -465,7 +465,7 @@ class TestMultiPhaseAnalyzer(object):
         assert analyzer._unbiased_decorrelated_N_l[0] == 0
         assert analyzer._unbiased_decorrelated_N_l[-1] == 0
 
-        # With a ver big energy cutoff, all the energies besides the extra two states should be identical.
+        # With a very big energy cutoff, all the energies besides the extra two states should be identical.
         analyzer.restraint_energy_cutoff = 100.0  # kT
         assert np.array_equal(analyzer._unbiased_decorrelated_u_ln[1:-1], analyzer._decorrelated_u_ln)
         assert np.array_equal(analyzer._unbiased_decorrelated_N_l[1:-1], analyzer._decorrelated_N_l)

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -390,25 +390,23 @@ class TestPhaseAnalyzer(object):
         assert np.array_equal(analyzer._unbiased_decorrelated_u_kn, analyzer._decorrelated_u_kn)
         assert np.array_equal(analyzer._unbiased_decorrelated_N_k, analyzer._decorrelated_N_k)
 
-        # Switch unbias_restraint to True. The old cached value is
-        # invalidated and now u_kn and N_k have two extra states.
+        # Switch unbias_restraint to True. The old cached value is invalidated and
+        # now u_kn and N_k have two extra states.
         analyzer.unbias_restraint = True
         assert analyzer._unbiased_decorrelated_u_kn.shape[0] == analyzer._decorrelated_u_kn.shape[0] + 2
         assert analyzer._unbiased_decorrelated_N_k.shape[0] == analyzer._decorrelated_N_k.shape[0] + 2
-        # Since there's no cutoff, all the energies besides the
-        # extra two states should be identical
-        assert np.array_equal(analyzer._unbiased_decorrelated_u_kn[1:-1], analyzer._decorrelated_u_kn)
-        assert np.array_equal(analyzer._unbiased_decorrelated_N_k[1:-1], analyzer._decorrelated_N_k)
+        # The automatic cutoff (default value) should remove some of the iterations.
+        assert analyzer._unbiased_decorrelated_u_kn.shape[1] < analyzer._decorrelated_u_kn.shape[1]
         # The energy without the restraint should always be smaller.
         assert np.all(analyzer._unbiased_decorrelated_u_kn[0] < analyzer._unbiased_decorrelated_u_kn[1])
         assert np.all(analyzer._unbiased_decorrelated_u_kn[-1] < analyzer._unbiased_decorrelated_u_kn[-2])
         assert analyzer._unbiased_decorrelated_N_k[0] == 0
         assert analyzer._unbiased_decorrelated_N_k[-1] == 0
 
-        # With an energy cutoff, some columns are discarded.
-        analyzer.restraint_energy_cutoff = 18.22
-        analyzer.restraint_distance_cutoff = 123*unit.angstroms
-        assert analyzer._unbiased_decorrelated_u_kn.shape[1] < analyzer._decorrelated_u_kn.shape[1]
+        # With a ver big energy cutoff, all the energies besides the extra two states should be identical.
+        analyzer.restraint_energy_cutoff = 100.0  # kT
+        assert np.array_equal(analyzer._unbiased_decorrelated_u_kn[1:-1], analyzer._decorrelated_u_kn)
+        assert np.array_equal(analyzer._unbiased_decorrelated_N_k[1:-1], analyzer._decorrelated_N_k)
 
 
     def test_extract_trajectory(self):

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -384,13 +384,15 @@ def test_restraint_force_group():
         system = thermo_state.system
         for force_idx, force in enumerate(system.getForces()):
             try:
-                parameter_name = force.getGlobalParameterName(0)
+                num_parameters = force.getNumGlobalParameters()
             except AttributeError:
                 continue
-            if parameter_name == 'lambda_restraints':
-                restraint_force_idx = force_idx
-                restraint_force_group = force.getForceGroup()
-                break
+            for parameter_idx in range(num_parameters):
+                parameter_name = force.getGlobalParameterName(parameter_idx)
+                if parameter_name == 'lambda_restraints':
+                    restraint_force_idx = force_idx
+                    restraint_force_group = force.getForceGroup()
+                    break
 
         # No other force should have the same force group.
         for force_idx, force in enumerate(system.getForces()):

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -930,10 +930,11 @@ class AlchemicalPhase(object):
         is_complex = len(topography.receptor_atoms) > 0
 
         # We currently don't support reaction field.
-        # DEBUG: Commented out by JDC for testing
-        #nonbonded_method = mmtools.forces.find_nonbonded_force(reference_system).getNonbondedMethod()
-        #if nonbonded_method == openmm.NonbondedForce.CutoffPeriodic:
-        #    raise RuntimeError('CutoffPeriodic is not supported yet. Use PME for explicit solvent.')
+        _, nonbonded_force = mmtools.forces.find_forces(reference_system, openmm.NonbondedForce,
+                                                        only_one=True)
+        nonbonded_method = nonbonded_force.getNonbondedMethod()
+        if nonbonded_method == openmm.NonbondedForce.CutoffPeriodic:
+            raise RuntimeError('CutoffPeriodic is not supported yet. Use PME for explicit solvent.')
 
         # Make sure sampler_states is a list of SamplerStates.
         if isinstance(sampler_states, mmtools.states.SamplerState):

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - netcdf4
     - openmm >=7.1
     - mdtraj >=1.7.2
-    - openmmtools >=0.14.0
+    - openmmtools >=0.15.0
     - pymbar
     - ambermini >=16.16.0
     - docopt


### PR DESCRIPTION
Fix #882.

Not ready yet. I still have to add a bunch of tests (and fix the bugs), modify the CLI arguments, and do some cleanup, but this is a first draft of the implementation for the unbiasing of Harmonic/Flatbottom restraints. It also adds a system to invalidate automatically cached values once the attributes they depend on are changed. This allows, for example, to quickly compute free energy profile as a function of the restraint cutoff or the number of iterations, which could be performed only very very slowly before these changes.

Tests won't pass until choderalab/openmmtools#336 is merged, and a new openmmtools release is cut.