### PR TITLE
Only support global-jump right now

### DIFF
--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -220,6 +220,7 @@ class SAMSSampler(MultiStateSampler):
         @staticmethod
         def _state_update_scheme_validator(instance, scheme):
             supported_schemes = ['global-jump', 'local-jump', 'restricted-range-jump']
+            supported_schemes = ['global-jump'] # TODO: Eliminate this after release
             if scheme not in supported_schemes:
                 raise ValueError("Unknown update scheme '{}'. Supported values "
                                  "are {}.".format(scheme, supported_schemes))


### PR DESCRIPTION
This PR disables all SAMS jump schemes except `global-jump` for the release.