### PR TITLE
Fix all doc warnings

### DIFF
--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -983,7 +983,7 @@ def get_keyword_args(function, try_mro_from_class=None):
         Try and trace the method resolution order (MRO) of the ``function_to_inspect`` by inferring a method stack from
         the supplied class.
         The signature of the function is checked in every MRO up the stack so long as there exists as
-        **kwargs in the method call. This is setting will yield expected results in every case, for instance, if
+        ``**kwargs`` in the method call. This is setting will yield expected results in every case, for instance, if
         the method does not call `super()`, or the Super class has a different function name.
         In the case of conflicting keywords, the lower MRO function is preferred.
 

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -499,7 +499,7 @@ This combines one or more replicas that sample from an expanded ensemble with an
    x_{k,n+1} \sim p(x | s_{k, n+1})
 
 SAMS state update schemes
-"""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Several state update schemes are available:
 
@@ -508,7 +508,7 @@ Several state update schemes are available:
 * ``local-jump``: Only proposals within the specified neighborhood are considered, but rejection rates may be high (EXPERIMENTAL; DISABLED)
 
 SAMS Locality
-"""""""""""""
+^^^^^^^^^^^^^
 
 The local neighborhood is specified by the ``locality`` parameter.
 If this is a positive integer, the neighborhood will be defined by state indices ``[k - locality, k + locality]``.
@@ -516,7 +516,7 @@ Reducing locality will restrict the range of states for which reduced potentials
 By default, the ``locality`` is global, such that energies at all thermodynamic states are computed; this allows the use of MBAR in data analysis.
 
 SAMS weight adaptation algorithm
-"""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 SAMS provides two ways of accumulating log weights each iteration:
 
@@ -524,7 +524,7 @@ SAMS provides two ways of accumulating log weights each iteration:
 * ``rao-blackwellized`` accumulates fractional weight in all states within the energy evaluation neighborhood
 
 SAMS initial weight adaptation stage
-""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Because the asymptotically-optimal weight adaptation scheme works best only when the log weights are close to optimal, a heuristic initial stage is used to more rapidly adapt the log weights before the asymptotically optimal scheme is used.
 The behavior of this first stage can be controlled by setting two parameters:
@@ -721,7 +721,7 @@ Automated convergence detection
 
 YANK has the ability to run a simulation until the free energy difference in a phase reaches a user-specified target
 uncertainty.
-If this option is set, either through the :ref:`yaml options <yaml_options_online_analysis_parameters>` or
+If this option is set, either through the :ref:`yaml options <yaml_samplers_online_analysis_parameters>` or
 :meth:`the Sampling API <yank.multistate.MultiStateSampler`, then each phase will be simulated until either the
 error free energy difference reaches the target, or the maximum number of iterations has been reached.
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,4 +1,4 @@
-@article{LeimkuhlerMatthews2016:g-BAOAB,
+@article{LeimkuhlerMatthews2016,
   title={Efficient molecular dynamics using geodesic integration and solvent--solute splitting},
   author={Leimkuhler, Benedict and Matthews, Charles},
   journal={Proc. R. Soc. A},
@@ -17,26 +17,6 @@
   pages={54--65},
   year={2017},
   publisher={Taylor \& Francis}
-}
-@article{Andersen1980,
-   author = {Andersen, Hans C.},
-   title = {Molecular dynamics simulations at constant pressure and/or temperature},
-   journal = {Journal of Chemical Physics},
-   volume = {72},
-   number = {4},
-   pages = {2384-2393},
-   year = {1980},
-   type = {Journal Article}
-}
-
-@article{Aqvist2004,
-   author = {Åqvist, Johan and Wennerström, Petra and Nervall, Martin and Bjelic, Sinisa and Brandsdal, Bjørn O.},
-   title = {Molecular dynamics simulations of water and biomolecules with a {Monte Carlo} constant pressure algorithm},
-   journal = {Chemical Physics Letters},
-   volume = {384},
-   pages = {288-294},
-   year = {2004},
-   type = {Journal Article}
 }
 
 @article{Berendsen1987,
@@ -59,46 +39,6 @@
    type = {Journal Article}
 }
 
-@article{Ceriotti2010,
-   author = {Ceriotti, M. and Parrinello, M. and Markland, Thomas E. and Manolopoulos, David E.},
-   title = {Efficient stochastic thermostatting of path integral molecular dynamics},
-   journal = {Journal of Chemical Physics},
-   volume = {133},
-   number = {12},
-   year = {2010},
-   type = {Journal Article}
-}
-
-@article{Chow1995,
-   author = {Chow, Kim-Hung and Ferguson, David M.},
-   title = {Isothermal-isobaric molecular dynamics simulations with {Monte Carlo} volume sampling},
-   journal = {Computer Physics Communications},
-   volume = {91},
-   pages = {283-289},
-   year = {1995},
-   type = {Journal Article}
-}
-
-@article{Craig2004,
-   author = {Craig, I. R. and Manolopoulos, David E.},
-   title = {Quantum statistics and classical mechanics: Real time correlation functions from ring polymer molecular dynamics},
-   journal = {Journal of Chemical Physics},
-   volume = {121},
-   pages = {3368-3373},
-   year = {2004},
-   type = {Journal Article}
-}
-
-@article{Duan2003,
-   author = {Duan, Y.; Wu, C. and Chowdhury, S. and Lee, M.C. and Xiong, G. and Zhang, W. and Yang, R. and Cieplak, P. and Luo, R. and Lee, T.},
-   title = {A point-charge force field for molecular mechanics simulations of proteins based on condensed-phase quantum mechanical calculations},
-   journal = {Journal of Computational Chemistry},
-   volume = {24},
-   pages = {1999-2012},
-   year = {2003},
-   type = {Journal Article}
-}
-
 @article{Essmann1995,
    author = {Essmann, Ulrich and Perera, Lalith and Berkowitz, Max L. and Darden, Tom and Lee, Hsing and Pedersen, Lee G.},
    title = {A smooth particle mesh {Ewald} method},
@@ -107,16 +47,6 @@
    number = {19},
    pages = {8577-8593},
    year = {1995},
-   type = {Journal Article}
-}
-
-@article{Hall1984,
-   author = {Hall, Randall W. and Berne, B. J.},
-   title = {Nonergodicity in path integral molecular dynamics},
-   journal = {Journal of Chemical Physics},
-   volume = {81},
-   number = {8},
-   year = {1984},
    type = {Journal Article}
 }
 
@@ -141,26 +71,6 @@
    type = {Journal Article}
 }
 
-@article{Hornak2006,
-   author = {Hornak, V. and Abel, R. and Okur, A. and Strockbine, B. and Roitberg, A. and Simmerling, C.},
-   title = {Comparison of multiple {Amber} force fields and development of improved protein backbone parameters},
-   journal = {Proteins},
-   volume = {65},
-   pages = {712-725},
-   year = {2006},
-   type = {Journal Article}
-}
-
-@article{Izaguirre2010,
-   author = {Izaguirre, Jesús A. and Sweet, Chris R. and Pande, Vijay S.},
-   title = {Multiscale dynamics of macromolecules using {Normal Mode Langevin}},
-   journal = {Pacific Symposium on Biocomputing},
-   volume = {15},
-   pages = {240-251},
-   year = {2010},
-   type = {Journal Article}
-}
-
 @article{Jorgensen1983,
    author = {Jorgensen, William L. and Chandrasekhar, Jayaraman and Madura, Jeffry D. and Impey, Roger W. and Klein, Michael L.},
    title = {Comparison of simple potential functions for simulating liquid water},
@@ -168,28 +78,6 @@
    volume = {79},
    pages = {926-935},
    year = {1983},
-   type = {Journal Article}
-}
-
-@inbook{Kollman1997,
-   author = {Kollman, P.A. and Dixon, R. and Cornell, W. and Fox, T. and Chipot, C. and Pohorille, A.},
-   title = {Computer Simulation of Biomolecular Systems},
-   editor = {Wilkinson, A. and Weiner, P. and van Gunsteren, Wilfred F.},
-   publisher = {Elsevier},
-   volume = {3},
-   pages = {83-96},
-   year = {1997},
-   type = {Book Section}
-}
-
-@article{Labute2008,
-   author = {Labute, Paul},
-   title = {The generalized {Born}/volume integral implicit solvent model: Estimation of the free energy of hydration using {London} dispersion instead of atomic surface area},
-   journal = {Journal of Computational Chemistry},
-   volume = {29},
-   number = {10},
-   pages = {1693-1698},
-   year = {2008},
    type = {Journal Article}
 }
 
@@ -204,58 +92,6 @@
    type = {Journal Article}
 }
 
-@article{Lamoureux2003,
-   author = {Lamoureux, Guillaume and Roux, Benoit},
-   title = {Modeling induced polarization with classical {Drude} oscillators: Theory and molecular dynamics simulation algorithm},
-   journal = {Journal of Chemical Physics},
-   volume = {119},
-   number = {6},
-   pages = {3025-3039},
-   year = {2003},
-   type = {Journal Article}
-}
-
-@article{Li2010,
-   author = {Li, D.W. and Br{\"u}schweiler, R.},
-   title = {{NMR}-based protein potentials},
-   journal = {Angewandte Chemie International Edition},
-   volume = {49},
-   pages = {6778-6780},
-   year = {2010},
-   type = {Journal Article}
-}
-
-@article{Lindorff-Larsen2010,
-   author = {Lindorff-Larsen, K. and Piana, S. and Palmo, K. and Maragakis, P. and Klepeis, J. and Dror, R.O. and Shaw, D.E.},
-   title = {Improved side-chain torsion potentials for the {Amber ff99SB} protein force field},
-   journal = {Proteins},
-   volume = {78},
-   pages = {1950-1958},
-   year = {2010},
-   type = {Journal Article}
-}
-
-@article{Liu1989,
-   author = {Liu, Dong C. and Nocedal, Jorge},
-   title = {On the Limited Memory {BFGS} Method For Large Scale Optimization},
-   journal = {Mathematical Programming},
-   volume = {45},
-   pages = {503-528},
-   year = {1989},
-   type = {Journal Article}
-}
-
-@article{Lopes2013,
-    author = {Lopes, Pedro E. M. and Huang, Jing and Shim, Jihyun and Luo, Yun and Li, Hui and Roux, Benoît and MacKerell, Alexander D.},
-    title = {Polarizable Force Field for Peptides and Proteins Based on the Classical {Drude} Oscillator},
-    journal = {Journal of Chemical Theory and Computation},
-    volume = {9},
-    number = {12},
-    pages = {5430-5449},
-    year = {2013},
-    type = {Journal Article}
-}
-
 @article{Mahoney2000,
    author = {Mahoney, Michael W. and Jorgensen, William L.},
    title = {A five-site model for liquid water and the reproduction of the density anomaly by rigid, nonpolarizable potential functions},
@@ -263,16 +99,6 @@
    volume = {112},
    pages = {8910-8922},
    year = {2000},
-   type = {Journal Article}
-}
-
-@article{Markland2008,
-   author = {Markland, Thomas E. and Manolopoulos, David E.},
-   title = {An efficient ring polymer contraction scheme for imaginary time path integral simulations},
-   journal = {Journal of Chemical Physics},
-   volume = {129},
-   number = {2},
-   year = {2008},
    type = {Journal Article}
 }
 
@@ -319,41 +145,10 @@
    type = {Journal Article}
 }
 
-@article{Parrinello1984,
-   author = {Parrinello, M. and Rahman, A.},
-   title = {Study of an {F} center in molten {KCl}},
-   journal = {Journal of Chemical Physics},
-   volume = {80},
-   number = {2},
-   pages = {860-867},
-   year = {1984},
-   type = {Journal Article}
-}
-
 @misc{Ponder,
    author = {Ponder, Jay W.},
    title = {Personal communication},
    type = {Personal Communication}
-}
-
-@article{Ren2002,
-   author = {Ren, P. and Ponder, Jay W.},
-   title = {A Consistent Treatment of Inter- and Intramolecular Polarization in Molecular Mechanics Calculations},
-   journal = {Journal of Computational Chemistry},
-   volume = {23},
-   pages = {1497-1506},
-   year = {2002},
-   type = {Journal Article}
-}
-
-@article{Ren2003,
-   author = {Ren, P. and Ponder, Jay W.},
-   title = {Polarizable Atomic Multipole Water Model for Molecular Mechanics Simulation},
-   journal = {Journal of Physical Chemistry B},
-   volume = {107},
-   pages = {5933-5947},
-   year = {2003},
-   type = {Journal Article}
 }
 
 @article{Schaefer1998,
@@ -367,16 +162,6 @@
    type = {Journal Article}
 }
 
-@article{Schnieders2007,
-   author = {Schnieders, Michael J. and Ponder, Jay W.},
-   title = {Polarizable Atomic Multipole Solutes in a Generalized {Kirkwood} Continuum},
-   journal = {Journal of Chemical Theory and Computation},
-   volume = {3},
-   pages = {2083-2097},
-   year = {2007},
-   type = {Journal Article}
-}
-
 @article{Shirts2008,
    author = {Shirts, Michael R. and Chodera, John D.},
    title = {Statistically optimal analysis of samples from multiple equilibrium states},
@@ -384,17 +169,6 @@
    volume = {129},
    pages = {124105},
    year = {2008},
-   type = {Journal Article}
-}
-
-@article{Shi2013,
-   author = {Shi, Yue and Xia, Zhen and Zhang, Jiajing and Best, Robert and Wu, Chuanjie and Ponder, Jay W. and Ren, Pengyu},
-   title = {Polarizable Atomic Multipole-Based {AMOEBA} Force Field for Proteins},
-   journal = {Journal of Chemical Theory and Computation},
-   volume = {9},
-   number = {9},
-   pages = {4046-4063},
-   year = {2013},
    type = {Journal Article}
 }
 
@@ -418,57 +192,6 @@
    type = {Journal Article}
 }
 
-@article{Shirts2005,
-   author = {Shirts, Michael R. and Pande, Vijay S.},
-   title = {Solvation free energies of amino acid side chain analogs for common molecular mechanics water models},
-   journal = {Journal of Chemical Physics},
-   volume = {132},
-   pages = {134508},
-   year = {2005},
-   type = {Journal Article}
-}
-
-@article{Sindhikara2009,
-  author =   {Sindhikara, Daniel J. and Kim, Seonah and Voter,
-                  Arthur F. and Roitberg, Adrian E.},
-  title =    {{Bad Seeds Sprout Perilous Dynamics: Stochastic
-                  Thermostat Induced Trajectory Synchronization in
-                  Biomolecules}},
-  journal =  {Journal of Chemical Theory and Computation},
-  year =     2009,
-  volume =   5,
-  number =   6,
-  pages =    {1624--1631},
-  month =    {April},
-}
-
-@article{Srinivasan1999,
-   author = {Srinivasan, J and Trevathan, M. W. and Beroza, P. and Case, D. A.},
-   title = {Application of a pairwise generalized {Born} model to proteins and nucleic acids: inclusion of salt effects},
-   journal = {Theor. Chem. Acc.},
-   volume = {101},
-   pages = {426-434},
-   year = {1999},
-   type = {Journal Article}
-}
-
-@article{Thole1981,
-   author = {Thole, B. T.},
-   title = {Molecular polarizabilities calculated with a modified dipole interaction},
-   journal = {Chemical Physics},
-   volume = {59},
-   number = {3},
-   pages = {341-350},
-   year = {1981},
-   type = {Journal Article}
-}
-
-@misc{Tinker,
-   author = {Ponder, Jay W.},
-   title = {{TINKER - Software Tools for Molecular Design, 4.2}},
-   year = {2004}
-}
-
 @article{Tironi1995,
    author = {Tironi, Ilario G. and Sperb, René and Smith, Paul E. and van Gunsteren, Wilfred F.},
    title = {A generalized reaction field method for molecular dynamics simulations},
@@ -487,30 +210,6 @@
    volume = {95},
    pages = {73-92},
    year = {1996},
-   type = {Journal Article}
-}
-
-@article{Uberuaga2004,
-  author =   {Blas P. Uberuaga and Marian Anghel and Arthur
-                  F. Voter},
-  title =    {{Synchronization of trajectories in canonical
-                  molecular-dynamics simulations: observation,
-                  explanation, and exploitation}},
-  journal =  {Journal of Chemical Physics},
-  year =     2004,
-  key =      {synchronization, parallelization},
-  volume =   120,
-  number =   14,
-  pages =    {6363--6374},
-}
-
-@article{Wang2000,
-   author = {Wang, J. and Cieplak, P. and Kollman, P.A.},
-   title = {How well does a restrained electrostatic potential ({RESP}) model perform in calculating conformational energies of organic and biological molecules?},
-   journal = {Journal of Computational Chemistry},
-   volume = {21},
-   pages = {1049-1074},
-   year = {2000},
    type = {Journal Article}
 }
 
@@ -560,3 +259,316 @@
    URL = {http://dx.doi.org/10.1021/acs.jctc.5b00784},
    eprint = {http://dx.doi.org/10.1021/acs.jctc.5b00784}
 }
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Below this line are commented out articles which are not directly cited.
+%%% If cited, simply uncomment and move above this block
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%@article{Andersen1980,
+   author = {Andersen, Hans C.},
+   title = {Molecular dynamics simulations at constant pressure and/or temperature},
+   journal = {Journal of Chemical Physics},
+   volume = {72},
+   number = {4},
+   pages = {2384-2393},
+   year = {1980},
+   type = {Journal Article}
+}
+
+%@article{Aqvist2004,
+   author = {Åqvist, Johan and Wennerström, Petra and Nervall, Martin and Bjelic, Sinisa and Brandsdal, Bjørn O.},
+   title = {Molecular dynamics simulations of water and biomolecules with a {Monte Carlo} constant pressure algorithm},
+   journal = {Chemical Physics Letters},
+   volume = {384},
+   pages = {288-294},
+   year = {2004},
+   type = {Journal Article}
+}
+
+%@article{Ceriotti2010,
+   author = {Ceriotti, M. and Parrinello, M. and Markland, Thomas E. and Manolopoulos, David E.},
+   title = {Efficient stochastic thermostatting of path integral molecular dynamics},
+   journal = {Journal of Chemical Physics},
+   volume = {133},
+   number = {12},
+   year = {2010},
+   type = {Journal Article}
+}
+
+%@article{Chow1995,
+   author = {Chow, Kim-Hung and Ferguson, David M.},
+   title = {Isothermal-isobaric molecular dynamics simulations with {Monte Carlo} volume sampling},
+   journal = {Computer Physics Communications},
+   volume = {91},
+   pages = {283-289},
+   year = {1995},
+   type = {Journal Article}
+}
+
+%@article{Craig2004,
+   author = {Craig, I. R. and Manolopoulos, David E.},
+   title = {Quantum statistics and classical mechanics: Real time correlation functions from ring polymer molecular dynamics},
+   journal = {Journal of Chemical Physics},
+   volume = {121},
+   pages = {3368-3373},
+   year = {2004},
+   type = {Journal Article}
+}
+
+%@article{Duan2003,
+   author = {Duan, Y.; Wu, C. and Chowdhury, S. and Lee, M.C. and Xiong, G. and Zhang, W. and Yang, R. and Cieplak, P. and Luo, R. and Lee, T.},
+   title = {A point-charge force field for molecular mechanics simulations of proteins based on condensed-phase quantum mechanical calculations},
+   journal = {Journal of Computational Chemistry},
+   volume = {24},
+   pages = {1999-2012},
+   year = {2003},
+   type = {Journal Article}
+}
+
+%@article{Hall1984,
+   author = {Hall, Randall W. and Berne, B. J.},
+   title = {Nonergodicity in path integral molecular dynamics},
+   journal = {Journal of Chemical Physics},
+   volume = {81},
+   number = {8},
+   year = {1984},
+   type = {Journal Article}
+}
+
+%@article{Hornak2006,
+   author = {Hornak, V. and Abel, R. and Okur, A. and Strockbine, B. and Roitberg, A. and Simmerling, C.},
+   title = {Comparison of multiple {Amber} force fields and development of improved protein backbone parameters},
+   journal = {Proteins},
+   volume = {65},
+   pages = {712-725},
+   year = {2006},
+   type = {Journal Article}
+}
+
+%@article{Izaguirre2010,
+   author = {Izaguirre, Jesús A. and Sweet, Chris R. and Pande, Vijay S.},
+   title = {Multiscale dynamics of macromolecules using {Normal Mode Langevin}},
+   journal = {Pacific Symposium on Biocomputing},
+   volume = {15},
+   pages = {240-251},
+   year = {2010},
+   type = {Journal Article}
+}
+
+%@inbook{Kollman1997,
+   author = {Kollman, P.A. and Dixon, R. and Cornell, W. and Fox, T. and Chipot, C. and Pohorille, A.},
+   title = {Computer Simulation of Biomolecular Systems},
+   editor = {Wilkinson, A. and Weiner, P. and van Gunsteren, Wilfred F.},
+   publisher = {Elsevier},
+   volume = {3},
+   pages = {83-96},
+   year = {1997},
+   type = {Book Section}
+}
+
+%@article{Labute2008,
+   author = {Labute, Paul},
+   title = {The generalized {Born}/volume integral implicit solvent model: Estimation of the free energy of hydration using {London} dispersion instead of atomic surface area},
+   journal = {Journal of Computational Chemistry},
+   volume = {29},
+   number = {10},
+   pages = {1693-1698},
+   year = {2008},
+   type = {Journal Article}
+}
+
+%@article{Lamoureux2003,
+   author = {Lamoureux, Guillaume and Roux, Benoit},
+   title = {Modeling induced polarization with classical {Drude} oscillators: Theory and molecular dynamics simulation algorithm},
+   journal = {Journal of Chemical Physics},
+   volume = {119},
+   number = {6},
+   pages = {3025-3039},
+   year = {2003},
+   type = {Journal Article}
+}
+
+%@article{Li2010,
+   author = {Li, D.W. and Br{\"u}schweiler, R.},
+   title = {{NMR}-based protein potentials},
+   journal = {Angewandte Chemie International Edition},
+   volume = {49},
+   pages = {6778-6780},
+   year = {2010},
+   type = {Journal Article}
+}
+
+%@article{Lindorff-Larsen2010,
+   author = {Lindorff-Larsen, K. and Piana, S. and Palmo, K. and Maragakis, P. and Klepeis, J. and Dror, R.O. and Shaw, D.E.},
+   title = {Improved side-chain torsion potentials for the {Amber ff99SB} protein force field},
+   journal = {Proteins},
+   volume = {78},
+   pages = {1950-1958},
+   year = {2010},
+   type = {Journal Article}
+}
+
+%@article{Liu1989,
+   author = {Liu, Dong C. and Nocedal, Jorge},
+   title = {On the Limited Memory {BFGS} Method For Large Scale Optimization},
+   journal = {Mathematical Programming},
+   volume = {45},
+   pages = {503-528},
+   year = {1989},
+   type = {Journal Article}
+}
+
+%@article{Lopes2013,
+    author = {Lopes, Pedro E. M. and Huang, Jing and Shim, Jihyun and Luo, Yun and Li, Hui and Roux, Benoît and MacKerell, Alexander D.},
+    title = {Polarizable Force Field for Peptides and Proteins Based on the Classical {Drude} Oscillator},
+    journal = {Journal of Chemical Theory and Computation},
+    volume = {9},
+    number = {12},
+    pages = {5430-5449},
+    year = {2013},
+    type = {Journal Article}
+}
+
+%@article{Markland2008,
+   author = {Markland, Thomas E. and Manolopoulos, David E.},
+   title = {An efficient ring polymer contraction scheme for imaginary time path integral simulations},
+   journal = {Journal of Chemical Physics},
+   volume = {129},
+   number = {2},
+   year = {2008},
+   type = {Journal Article}
+}
+
+%@article{Parrinello1984,
+   author = {Parrinello, M. and Rahman, A.},
+   title = {Study of an {F} center in molten {KCl}},
+   journal = {Journal of Chemical Physics},
+   volume = {80},
+   number = {2},
+   pages = {860-867},
+   year = {1984},
+   type = {Journal Article}
+}
+
+%@article{Ren2002,
+   author = {Ren, P. and Ponder, Jay W.},
+   title = {A Consistent Treatment of Inter- and Intramolecular Polarization in Molecular Mechanics Calculations},
+   journal = {Journal of Computational Chemistry},
+   volume = {23},
+   pages = {1497-1506},
+   year = {2002},
+   type = {Journal Article}
+}
+
+%@article{Ren2003,
+   author = {Ren, P. and Ponder, Jay W.},
+   title = {Polarizable Atomic Multipole Water Model for Molecular Mechanics Simulation},
+   journal = {Journal of Physical Chemistry B},
+   volume = {107},
+   pages = {5933-5947},
+   year = {2003},
+   type = {Journal Article}
+}
+
+%@article{Schnieders2007,
+   author = {Schnieders, Michael J. and Ponder, Jay W.},
+   title = {Polarizable Atomic Multipole Solutes in a Generalized {Kirkwood} Continuum},
+   journal = {Journal of Chemical Theory and Computation},
+   volume = {3},
+   pages = {2083-2097},
+   year = {2007},
+   type = {Journal Article}
+}
+
+
+%@article{Shi2013,
+   author = {Shi, Yue and Xia, Zhen and Zhang, Jiajing and Best, Robert and Wu, Chuanjie and Ponder, Jay W. and Ren, Pengyu},
+   title = {Polarizable Atomic Multipole-Based {AMOEBA} Force Field for Proteins},
+   journal = {Journal of Chemical Theory and Computation},
+   volume = {9},
+   number = {9},
+   pages = {4046-4063},
+   year = {2013},
+   type = {Journal Article}
+}
+
+%@article{Shirts2005,
+   author = {Shirts, Michael R. and Pande, Vijay S.},
+   title = {Solvation free energies of amino acid side chain analogs for common molecular mechanics water models},
+   journal = {Journal of Chemical Physics},
+   volume = {132},
+   pages = {134508},
+   year = {2005},
+   type = {Journal Article}
+}
+
+%@article{Sindhikara2009,
+  author =   {Sindhikara, Daniel J. and Kim, Seonah and Voter,
+                  Arthur F. and Roitberg, Adrian E.},
+  title =    {{Bad Seeds Sprout Perilous Dynamics: Stochastic
+                  Thermostat Induced Trajectory Synchronization in
+                  Biomolecules}},
+  journal =  {Journal of Chemical Theory and Computation},
+  year =     2009,
+  volume =   5,
+  number =   6,
+  pages =    {1624--1631},
+  month =    {April},
+}
+
+%@article{Srinivasan1999,
+   author = {Srinivasan, J and Trevathan, M. W. and Beroza, P. and Case, D. A.},
+   title = {Application of a pairwise generalized {Born} model to proteins and nucleic acids: inclusion of salt effects},
+   journal = {Theor. Chem. Acc.},
+   volume = {101},
+   pages = {426-434},
+   year = {1999},
+   type = {Journal Article}
+}
+
+%@article{Thole1981,
+   author = {Thole, B. T.},
+   title = {Molecular polarizabilities calculated with a modified dipole interaction},
+   journal = {Chemical Physics},
+   volume = {59},
+   number = {3},
+   pages = {341-350},
+   year = {1981},
+   type = {Journal Article}
+}
+
+%@misc{Tinker,
+   author = {Ponder, Jay W.},
+   title = {{TINKER - Software Tools for Molecular Design, 4.2}},
+   year = {2004}
+}
+
+%@article{Uberuaga2004,
+  author =   {Blas P. Uberuaga and Marian Anghel and Arthur
+                  F. Voter},
+  title =    {{Synchronization of trajectories in canonical
+                  molecular-dynamics simulations: observation,
+                  explanation, and exploitation}},
+  journal =  {Journal of Chemical Physics},
+  year =     2004,
+  key =      {synchronization, parallelization},
+  volume =   120,
+  number =   14,
+  pages =    {6363--6374},
+}
+
+%@article{Wang2000,
+   author = {Wang, J. and Cieplak, P. and Kollman, P.A.},
+   title = {How well does a restrained electrostatic potential ({RESP}) model perform in calculating conformational energies of organic and biological molecules?},
+   journal = {Journal of Computational Chemistry},
+   volume = {21},
+   pages = {1049-1074},
+   year = {2000},
+   type = {Journal Article}
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% End commented out article block
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -62,5 +62,11 @@ Long-range dispersion corrections for explicit solvent free energy calculations
 Bibliography
 ############
 
+.. The :all: directive searches subfolders for uses of :cite: for correct reference
+   However, this has the effect of dropping all citations in the .bib file in here and
+   the compiler complains about unused citations.
+   As such, unused articles in the .bib file are simply commented so as not to delete them if needed in the future.
+
 .. bibliography:: references.bib
    :style: unsrt
+   :all:

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -266,7 +266,7 @@ Specifying Simulation Stop Conditions
 
 YANK simulations will run until one of two stop conditions are met, if specified: either the
 :ref:`maximum number of iterations <yaml_options_default_number_of_iterations>` is reached, or the
-:ref:`error in free energy difference of the phase <yaml_options_online_analysis_parameters>` reaches a target value
+:ref:`error in free energy difference of the phase <yaml_samplers_online_analysis_parameters>` reaches a target value
 through online analysis.
 These options can be combined to change when YANK stops a simulation.
 
@@ -277,10 +277,10 @@ initialization and input preparation, without running any production simulation.
 run an unlimited number of simulations until another stop condition is met, or is stopped by the user. This option
 can be increased after a simulation has completed to extend the number of iterations run for each phase.
 
-Setting a target :ref:`free energy difference error <yaml_options_online_analysis_parameters>` tells
+Setting a target :ref:`free energy difference error <yaml_samplers_online_analysis_parameters>` tells
 YANK to run each phase until the error in the free energy difference is below some threshold. The free energy difference
 of the phase is estimated during the simulation through online analysis every
-:ref:`specified interval <yaml_options_online_analysis_interval>`.
+:ref:`specified interval <yaml_samplers_online_analysis_interval>`.
 This process will slow down the simulation, so it is recommended the interval be at least 100 iterations, if not more.
 
 It is recommended you also set a :ref:`switch phase interval <yaml_options_switch_phase_interval>` for a large number

--- a/docs/sphinxext/notebook_sphinxext.py
+++ b/docs/sphinxext/notebook_sphinxext.py
@@ -2,16 +2,15 @@ import os
 import shutil
 import glob
 
-from sphinx.util.compat import Directive
 from docutils import nodes
-from docutils.parsers.rst import directives
-from IPython.nbconvert import html, python
-
+from docutils.parsers.rst import directives, Directive
+from nbconvert.exporters import html, python
 from runipy.notebook_runner import NotebookRunner
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 IPYTHON_NOTEBOOK_DIR = "%s/../../examples" % HERE
+
 
 class NotebookDirective(Directive):
     """Insert an evaluated notebook into a document
@@ -100,15 +99,16 @@ class NotebookDirective(Directive):
         return [nb_node]
 
 
-
 class notebook_node(nodes.raw):
     pass
+
 
 def nb_to_python(nb_path):
     """convert notebook to python script"""
     exporter = python.PythonExporter()
     output, resources = exporter.from_filename(nb_path)
     return output
+
 
 def nb_to_html(nb_path):
     """convert notebook to html"""
@@ -142,11 +142,12 @@ def nb_to_html(nb_path):
     lines.append('</div>')
     return '\n'.join(lines)
 
+
 def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False):
     # Create evaluated version and save it to the dest path.
     # Always use --pylab so figures appear inline
     # perhaps this is questionable?
-    nb_runner = NotebookRunner(nb_in=nb_path, pylab=True)
+    nb_runner = NotebookRunner(nb_path, pylab=True)
     nb_runner.run_notebook(skip_exceptions=skip_exceptions)
     if dest_path is None:
         dest_path = 'temp_evaluated.ipynb'
@@ -156,14 +157,18 @@ def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False):
         os.remove(dest_path)
     return ret
 
+
 def formatted_link(path):
     return "`%s <%s>`__" % (os.path.basename(path), path)
+
 
 def visit_notebook_node(self, node):
     self.visit_raw(node)
 
+
 def depart_notebook_node(self, node):
     self.depart_raw(node)
+
 
 def setup(app):
     setup.app = app
@@ -174,4 +179,3 @@ def setup(app):
                  html=(visit_notebook_node, depart_notebook_node))
 
     app.add_directive('notebook', NotebookDirective)
-    

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -8,15 +8,15 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 
 Development
 -----------
-- Renamed global option ``number_of_iterations`` to ``default_number_of_iterations``. `[docs] <http://getyank.org/latest/yamlpages/options.html#default_number_of_iterations>`_
-- Added support for automatic determination of ``processes_per_experiment`` (now the default). `[docs] <http://getyank.org/latest/yamlpages/options.html#processes_per_experiment>`_
+- Renamed global option ``number_of_iterations`` to ``default_number_of_iterations``. `(docs) <http://getyank.org/latest/yamlpages/options.html#default_number_of_iterations>`__
+- Added support for automatic determination of ``processes_per_experiment`` (now the default). `(docs) <http://getyank.org/latest/yamlpages/options.html#processes_per_experiment>`__
 
 0.20.1 Alchemical factory options and fast computation of the energy matrix
 ---------------------------------------------------------------------------
 - Allow user to specify options for ``openmmtools.alchemy.AbsoluteAlchemicalFactory`` in the YAML file. In particular,
-  this introduces exact treatment of PME electrostatics for charged ligands. `[docs] <http://getyank.org/latest/yamlpages/options.html#alchemical_pme_treatment>`_
+  this introduces exact treatment of PME electrostatics for charged ligands. `(docs) <http://getyank.org/latest/yamlpages/options.html#alchemical_pme_treatment>`__
 - Major optimization of the computation of the energy matrix.
-- Added the option ``max_n_contexts``. `[docs] <http://getyank.org/latest/yamlpages/options.html#max_n_contexts>`_
+- Added the option ``max_n_contexts``. `(docs) <http://getyank.org/latest/yamlpages/options.html#max_n_contexts>`__
 - Bumped minimum required version of ``openmmtools`` to ``0.14.0``.
 
 0.20.0 Support for processing proteins through PDBFixer

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -165,7 +165,7 @@ Detailed Options List
 
 * :doc:`mcmc_moves <mcmc>`
 
-  * :ref:`MCMC Moves Syntax <_yaml_mcmc_example>`
+  * :ref:`MCMC Moves Syntax <yaml_mcmc_example>`
 
 * :doc:`samplers <samplers>`
 

--- a/docs/yamlpages/mcmc.rst
+++ b/docs/yamlpages/mcmc.rst
@@ -32,7 +32,7 @@ keyword is ``type``. YANK supports all the ``MCMCMove`` classes defined in the
 `openmmtools.mcmc <http://openmmtools.readthedocs.io/en/latest/mcmc.html#mcmc-move-types>`_ module, which currently are:
 
 * ``SequenceMove``: Container MCMC move describing a sequence of other moves.
-* ``LangevinSplittingDynamicsMove``: High-quality Langevin integrator family based on symmetric Strang splittings, using g-BAOAB :cite:`LeimkuhlerMatthews2016:g-BAOAB` as default
+* ``LangevinSplittingDynamicsMove``: High-quality Langevin integrator family based on symmetric Strang splittings, using g-BAOAB :cite:`LeimkuhlerMatthews2016` as default
 * ``LangevinDynamicsMove``: Leapfrog Langevin dynamics integrator from OpenMM (``simtk.openmm.LangevinIntegrator``); not recommended
 * ``GHMCMove``: Metropolized Langevin integrator, when exact sampling is required; not recommended for large systems
 * ``HMCMove``: Hybrid Monte Carlo integrator, when exact sampling is required; not recommended for large systems


### PR DESCRIPTION
Fix all the outstanding doc warnings, broken links, and DeprecationWarning, *all of them*

Fixed missing citation links
Docs now build on Sphinx 1.[567].X (more of a pain than I would like, cc @jchodera)

I don't think we actually use anything in the shipped `notebook_sphinxext`
file and is a leftover things from when we initially copied the docs
from MDTraj, so we might want to remove this in the future.

To fix the citations, I had to comment out many unused citations to get the warnings to stop, we can uncomment them if we actually cite them.