### PR TITLE
Update automatic equilibration detection to handle SAMS

### DIFF
--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -1055,7 +1055,7 @@ class MultiStateReporter(object):
         logZ : np.array with shape [n_states]
             Dimensionless logZ
         """
-        data = self.read_online_analysis_data(None, "logZ")
+        data = self.read_online_analysis_data(iteration, "logZ")
         return data['logZ']
 
     def write_logZ(self, iteration: int, logZ: np.ndarray):

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -1165,12 +1165,15 @@ class MultiStateReporter(object):
 
         Raises
         ------
-        ValueError : If no requested keys were found in the storage.
+        ValueError : If no requested keys were found in the storage or if no online analysis data was written
         """
         collected_variables = {}
         collected_iteration_failure = []
         collected_not_found = []
-        storage = self._storage_analysis.groups["online_analysis"]
+        try:
+            storage = self._storage_analysis.groups["online_analysis"]
+        except KeyError:
+            raise ValueError("Online Analysis information was never written!")
         for variable in keys:
             try:
                 data = self._read_1d_online_data(iteration, variable, storage)

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -576,6 +576,9 @@ class SAMSSampler(MultiStateSampler):
         """
         logger.debug('Updating logZ estimates...')
 
+        # Store log weights used at the beginning of this iteration
+        self._reporter.write_online_analysis_data(self._iteration, log_weights=self.log_weights)
+
         # Retrieve target probabilities
         log_pi_k = self.log_target_probabilities
         pi_k = np.exp(self.log_target_probabilities)

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -54,13 +54,10 @@ class BlankPhase(analyze.YankPhaseAnalyzer):
     def get_states_energies(self):
         pass
 
-    def get_timeseries(self, passed_timeseries):
+    def get_effective_energy_timeseries(self):
         pass
 
     def _prepare_mbar_input_data(self):
-        pass
-
-    def get_timeseries_weights(self, *args):
         pass
 
 
@@ -244,7 +241,7 @@ class TestMultiPhaseAnalyzer(object):
         # Test energy output matches appropriate MBAR shapes
         assert u_sampled.shape == (self.n_replicas, self.n_states, self.n_steps)
         assert u_unsampled.shape == (self.n_replicas, 2, self.n_steps)
-        u_n = phase.get_timeseries(u_sampled, sampled_states)
+        u_n = phase.get_effective_energy_timeseries()
         assert u_n.shape == (self.n_steps,)
         # This may need to be adjusted from time to time as analyze changes
         discard = 1

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -51,9 +51,6 @@ class BlankPhase(analyze.YankPhaseAnalyzer):
     def _create_mbar_from_scratch(self):
         pass
 
-    def get_states_energies(self):
-        pass
-
     def get_effective_energy_timeseries(self):
         pass
 

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -354,9 +354,9 @@ class TestMultiPhaseAnalyzer(object):
         # Check compound multiphase stuff
         quad_free_energy, quad_dfree_energy = quad.get_free_energy()
         assert quad_free_energy == 0
-        assert quad_dfree_energy == np.sqrt(4*full_dfree_energy**2)
-        assert triple.get_standard_state_correction() == (2*full_phase.get_standard_state_correction() -
-                                                          full_phase.get_standard_state_correction())
+        assert np.allclose(quad_dfree_energy, np.sqrt(4*full_dfree_energy**2))
+        assert np.allclose(triple.get_standard_state_correction(),
+                           (2*full_phase.get_standard_state_correction() - full_phase.get_standard_state_correction()))
 
     def test_extract_trajectory(self):
         """extract_trajectory handles checkpointing and skip frame correctly."""

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -196,7 +196,7 @@ def test_replica_exchange_harmonic_oscillator(verbose=False, verbose_simulation=
         simulation.run()
 
         # Create Analyzer.
-        analyzer = ReplicaExchangeAnalyzer(storage)
+        analyzer = ReplicaExchangeAnalyzer(reporter)
 
         # TODO: Check if deviations exceed tolerance.
         Delta_f_ij, dDelta_f_ij = analyzer.get_free_energy()

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python
     - pandas
-    - numpy
+    - numpy >=1.11
     - scipy
     - cython
     - netcdf4


### PR DESCRIPTION
This PR makes changes to the multistate sampler analysis code to allow automatic equilibration detection to work with SAMS and other methods that adjust log weights dynamically.

@lnaden: I had to roll back a bit of the generalization of the `u_n` negative log deviance timeseries fed to automated equilibration detection because I couldn't find a good way to preserve this in generality. We can figure out a better way to generalize that component later. The rest of the infrastructure worked well, though!

I also had to implement a few hacks that access some online analysis data directly, since I couldn't figure out how to (1) check if the online analysis data existed, and (2) retrieve particular parts of it through the existing `Reporter` API. This could undoubtedly use refinement.

This hasn't been extensively tested beyond the unit tests. I'm brainstorming fast but useful tests, as well as testing on `lilac` right now.