### PR TITLE
FIRE minimizer and MPI support for Cray XK nodes

### DIFF
--- a/Yank/__init__.py
+++ b/Yank/__init__.py
@@ -14,6 +14,7 @@ from . import multistate
 from . import restraints
 from . import pipeline
 from . import experiment
+from . import fire
 from .yank import Topography, AlchemicalPhase
 
 __version__ = version.version

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -320,9 +320,10 @@ class AlchemicalPhaseFactory(object):
             tolerance = self.options['minimize_tolerance']
             max_iterations = self.options['minimize_max_iterations']
             scheme = self.options['minimize']
-            if scheme not in ['L-BFGS', 'FIRE']:
+            if scheme in ['yes', 'YES']:
                 scheme = 'FIRE'
-            alchemical_phase.minimize(tolerance=tolerance, max_iterations=max_iterations, scheme=scheme)
+            if scheme not in ['no', 'NO', False, None]:
+                alchemical_phase.minimize(tolerance=tolerance, max_iterations=max_iterations, scheme=scheme)
 
         # Randomize ligand if requested.
         if self.options['randomize_ligand']:

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -228,7 +228,7 @@ class AlchemicalPhaseFactory(object):
 
     DEFAULT_OPTIONS = {
         'anisotropic_dispersion_cutoff': 'auto',
-        'minimize': 'FIRE',
+        'minimize': True,
         'minimize_tolerance': 1.0 * unit.kilojoules_per_mole/unit.nanometers,
         'minimize_max_iterations': 1000,
         'randomize_ligand': False,
@@ -316,14 +316,10 @@ class AlchemicalPhaseFactory(object):
         alchemical_phase = self.create_alchemical_phase()
 
         # Minimize if requested.
-        if self.options['minimize']:                
+        if self.options['minimize']:
             tolerance = self.options['minimize_tolerance']
             max_iterations = self.options['minimize_max_iterations']
-            scheme = self.options['minimize']
-            if scheme in ['yes', 'YES']:
-                scheme = 'FIRE'
-            if scheme not in ['no', 'NO', False, None]:
-                alchemical_phase.minimize(tolerance=tolerance, max_iterations=max_iterations, scheme=scheme)
+            alchemical_phase.minimize(tolerance=tolerance, max_iterations=max_iterations)
 
         # Randomize ligand if requested.
         if self.options['randomize_ligand']:

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -228,9 +228,9 @@ class AlchemicalPhaseFactory(object):
 
     DEFAULT_OPTIONS = {
         'anisotropic_dispersion_cutoff': 'auto',
-        'minimize': True,
+        'minimize': 'FIRE',
         'minimize_tolerance': 1.0 * unit.kilojoules_per_mole/unit.nanometers,
-        'minimize_max_iterations': 0,
+        'minimize_max_iterations': 1000,
         'randomize_ligand': False,
         'randomize_ligand_sigma_multiplier': 2.0,
         'randomize_ligand_close_cutoff': 1.5 * unit.angstrom,
@@ -316,10 +316,13 @@ class AlchemicalPhaseFactory(object):
         alchemical_phase = self.create_alchemical_phase()
 
         # Minimize if requested.
-        if self.options['minimize']:
+        if self.options['minimize']:                
             tolerance = self.options['minimize_tolerance']
             max_iterations = self.options['minimize_max_iterations']
-            alchemical_phase.minimize(tolerance=tolerance, max_iterations=max_iterations)
+            scheme = self.options['minimize']
+            if scheme not in ['L-BFGS', 'FIRE']:
+                scheme = 'FIRE'
+            alchemical_phase.minimize(tolerance=tolerance, max_iterations=max_iterations, scheme=scheme)
 
         # Randomize ligand if requested.
         if self.options['randomize_ligand']:

--- a/Yank/fire.py
+++ b/Yank/fire.py
@@ -1,0 +1,194 @@
+from simtk import openmm, unit
+import numpy as np
+from openmmtools.constants import kB
+
+# ==============================================================================
+# FIRE minimizer
+#
+# TODO: Move this to openmmtools once it is sufficiently stable
+# ==============================================================================
+
+class FIREMinimizationIntegrator(openmm.CustomIntegrator):
+    """Fast Internal Relaxation Engine (FIRE) minimization.
+
+    Notes
+    -----
+    This integrator is taken verbatim from Peter Eastman's example appearing in the CustomIntegrator header file documentation.
+
+    References
+    ----------
+    Erik Bitzek, Pekka Koskinen, Franz Gaehler, Michael Moseler, and Peter Gumbsch.
+    Structural Relaxation Made Simple. PRL 97:170201, 2006.
+    http://dx.doi.org/10.1103/PhysRevLett.97.170201
+
+    Examples
+    --------
+
+    >>> from openmmtools import testsystems
+    >>> t = testsystems.AlanineDipeptideVacuum()
+    >>> system, positions = t.system, t.positions
+
+    Create a FIRE integrator with default parameters and minimize for 100 steps
+    
+    >>> integrator = FIREMinimizationIntegrator()
+    >>> context = openmm.Context(system, integrator)
+    >>> context.setPositions(positions)
+    >>> integrator.step(100)
+
+    """
+
+    def __init__(self, timestep=1.0 * unit.femtoseconds, tolerance=None, alpha=0.1, dt_max=10.0 * unit.femtoseconds, f_inc=1.1, f_dec=0.5, f_alpha=0.99, N_min=5):
+        """Construct a Fast Internal Relaxation Engine (FIRE) minimization integrator.
+        Parameters
+        ----------
+        timestep : unit.Quantity compatible with femtoseconds, optional, default = 1*femtoseconds
+            The integration timestep.
+        tolerance : unit.Quantity compatible with kilojoules_per_mole/nanometer, optional, default = None
+            Minimization will be terminated when RMS force reaches this tolerance.
+        alpha : float, optional default = 0.1
+            Velocity relaxation parameter, alpha \in (0,1).
+        dt_max : unit.Quantity compatible with femtoseconds, optional, default = 10*femtoseconds
+            Maximum allowed timestep.
+        f_inc : float, optional, default = 1.1
+            Timestep increment multiplicative factor.
+        f_dec : float, optional, default = 0.5
+            Timestep decrement multiplicative factor.
+        f_alpha : float, optional, default = 0.99
+            alpha multiplicative relaxation parameter
+        N_min : int, optional, default = 5
+            Limit on number of timesteps P is negative before decrementing timestep.
+        Notes
+        -----
+        Velocities should be set to zero before using this integrator.
+        """
+
+        # Check input ranges.
+        if not ((alpha > 0.0) and (alpha < 1.0)):
+            raise Exception("alpha must be in the interval (0,1); specified alpha = %f" % alpha)
+
+        if tolerance is None:
+            tolerance = 0 * unit.kilojoules_per_mole / unit.nanometers
+
+        super(FIREMinimizationIntegrator, self).__init__(timestep)
+
+        # Use high-precision constraints
+        self.setConstraintTolerance(1.0e-8)
+        
+        self.addGlobalVariable("alpha", alpha)  # alpha
+        self.addGlobalVariable("P", 0)  # P
+        self.addGlobalVariable("N_neg", 0.0)
+        self.addGlobalVariable("fmag", 0)  # |f|
+        self.addGlobalVariable("fmax", 0)  # max|f_i|
+        self.addGlobalVariable("ndof", 0)  # number of degrees of freedom
+        self.addGlobalVariable("ftol", tolerance.value_in_unit_system(unit.md_unit_system))  # convergence tolerance
+        self.addGlobalVariable("vmag", 0)  # |v|
+        self.addGlobalVariable("converged", 0) # 1 if convergence threshold reached, 0 otherwise
+        self.addPerDofVariable("x0", 0)
+        self.addPerDofVariable("v0", 0)
+        self.addPerDofVariable("x1", 0)
+        self.addGlobalVariable("E0", 0) # old energy associated with x0
+        self.addGlobalVariable("dE", 0)        
+        self.addGlobalVariable("restart", 0)        
+        self.addGlobalVariable("delta_t", timestep.value_in_unit_system(unit.md_unit_system))
+
+        # Compute ndof
+        #self.addComputeGlobal('ndof', '0')
+        self.addComputeSum('ndof', '1')
+
+        # Compute fmag = |f|
+        #self.addComputeGlobal('fmag', '0.0')
+        self.addComputeSum('fmag', 'f*f')
+        self.addComputeGlobal('fmag', 'sqrt(fmag)')
+
+        # Assess convergence
+        # TODO: Can we more closely match the OpenMM criterion here?
+        self.addComputeSum('converged', 'step(ftol - fmag/ndof)')
+
+        # Enclose everything in a block that checks if we have already converged.
+        self.beginIfBlock('converged < 1')
+
+        # Store old positions and energy
+        self.addComputePerDof('x0', 'x')
+        self.addComputePerDof('v0', 'v')
+        self.addComputeGlobal('E0', 'energy')
+
+        # MD: Take a velocity Verlet step.
+        self.addComputePerDof("v", "v+0.5*delta_t*f/m")
+        self.addComputePerDof("x", "x+delta_t*v")
+        self.addComputePerDof("x1", "x")
+        self.addConstrainPositions()
+        self.addComputePerDof("v", "v+0.5*delta_t*f/m+(x-x1)/delta_t")
+        self.addConstrainVelocities()    
+
+        self.addComputeGlobal('dE', 'energy - E0')
+
+        # Compute fmag = |f|
+        #self.addComputeGlobal('fmag', '0.0')
+        self.addComputeSum('fmag', 'f*f')
+        self.addComputeGlobal('fmag', 'sqrt(fmag)')
+        # Compute vmag = |v|
+        #self.addComputeGlobal('vmag', '0.0')
+        self.addComputeSum('vmag', 'v*v')
+        self.addComputeGlobal('vmag', 'sqrt(vmag)')
+
+        ## Check for NaN and try to recover.
+        #self.beginIfBlock('abs(step(energy)-step(1-energy)) = 0')
+        ## Reset positions and set velocities to zero.
+        #self.addComputePerDof('x', 'x0')
+        #self.addComputePerDof('v', '0.0')
+        ## Reset P counter.
+        #self.addComputeGlobal('N_neg', '0.0')
+        ## Scale down timestep.
+        #self.addComputeGlobal('dt', 'dt*%f' % f_dec)
+        #self.endBlock()
+
+        # F1: Compute P = F.v
+        self.addComputeSum('P', 'f*v')
+
+        # F2: set v = (1-alpha) v + alpha \hat{F}.|v|
+        # Update velocities.
+        # TODO: This must be corrected to be atomwise redirection of v magnitude along f
+        self.addComputePerDof('v', '(1-alpha)*v + alpha*(f/fmag)*vmag')
+
+        # Back up if the energy went up, protecing against NaNs
+        self.addComputeGlobal('restart', '1')
+        self.beginIfBlock('dE < 0')
+        self.addComputeGlobal('restart', '0')
+        self.endBlock()
+        self.beginIfBlock('restart > 0')
+        self.addComputePerDof('v', 'v0')        
+        self.addComputePerDof('x', 'x0')        
+        self.addComputeGlobal('P', '-1')
+        self.endBlock()
+
+        # Make sure dt doesn't go to zero
+        # TODO: This doesn't actually help much, and may not be necessary
+        dt_min = 1.0e-5 * timestep
+        self.beginIfBlock('delta_t <= %f' % dt_min.value_in_unit_system(unit.md_unit_system))
+        self.addComputeGlobal('delta_t', '%f' % timestep.value_in_unit_system(unit.md_unit_system))
+        self.endBlock()
+
+        # F3: If P > 0 and the number of steps since P was negative > N_min,
+        # Increase timestep dt = min(dt*f_inc, dt_max) and decrease alpha = alpha*f_alpha
+        self.beginIfBlock('P > 0')
+        # Update count of number of steps since P was negative.
+        self.addComputeGlobal('N_neg', 'N_neg + 1')
+        # If we have enough steps since P was negative, scale up timestep.
+        self.beginIfBlock('N_neg > %d' % N_min)
+        self.addComputeGlobal('delta_t', 'min(delta_t*%f, %f)' % (f_inc, dt_max.value_in_unit_system(unit.md_unit_system))) # TODO: Automatically convert dt_max to md units
+        self.addComputeGlobal('alpha', 'alpha * %f' % f_alpha)
+        self.endBlock()
+        self.endBlock()
+
+        # F4: If P < 0, decrease the timestep dt = dt*f_dec, freeze the system v=0,
+        # and set alpha = alpha_start
+        self.beginIfBlock('P < 0')
+        self.addComputeGlobal('N_neg', '0.0')
+        self.addComputeGlobal('delta_t', 'delta_t*%f' % f_dec)
+        self.addComputePerDof('v', '0.0')
+        self.addComputeGlobal('alpha', '%f' % alpha)
+        self.endBlock()
+
+        # Close block that checks for convergence.
+        self.endBlock()
+

--- a/Yank/mpi.py
+++ b/Yank/mpi.py
@@ -150,7 +150,7 @@ def get_mpicomm():
 
     # Cray machines are usually old and sick; prevent them from causing trouble with CUDA caches
     # by explicitly using different CUDA cache paths for each process
-     if 'ALPS_APP_PE' in variables:
+    if 'ALPS_APP_PE' in variables:
         cuda_cache_path = os.path.abspath(os.path.join('nvcc-cache', str(mpicomm.rank)))
         if not os.path.exists(cuda_cache_path):
             os.makedirs(cuda_cache_path)

--- a/Yank/mpi.py
+++ b/Yank/mpi.py
@@ -155,7 +155,7 @@ def get_mpicomm():
         if not os.path.exists(cuda_cache_path):
             os.makedirs(cuda_cache_path)
         os.environ['CUDA_CACHE_PATH'] = cuda_cache_path
-        print('Cray detected; node {}/{} using CUDA cache path {}'.format(mpicomm.rank+1, mpicomm.size, cuda_cache_path)
+        print('Cray detected; node {}/{} using CUDA cache path {}'.format(mpicomm.rank+1, mpicomm.size, cuda_cache_path))
 
     return mpicomm
 

--- a/Yank/mpi.py
+++ b/Yank/mpi.py
@@ -100,7 +100,10 @@ def get_mpicomm():
     # http://docs.roguewave.com/threadspotter/2012.1/linux/manual_html/apas03.html
     variables = ['PMI_RANK', 'OMPI_COMM_WORLD_RANK', 'OMPI_MCA_ns_nds_vpid',
                  'PMI_ID', 'SLURM_PROCID', 'LAMRANK', 'MPI_RANKID',
-                 'MP_CHILD', 'MP_RANK', 'MPIRUN_RANK']
+                 'MP_CHILD', 'MP_RANK', 'MPIRUN_RANK',
+                 'ALPS_APP_PE', # Cray aprun
+                ]
+
     use_mpi = False
     for var in variables:
         if var in os.environ:
@@ -144,6 +147,15 @@ def get_mpicomm():
 
     # Report initialization
     logger.debug("MPI initialized on node {}/{}".format(mpicomm.rank+1, mpicomm.size))
+
+    # Cray machines are usually old and sick; prevent them from causing trouble with CUDA caches
+    # by explicitly using different CUDA cache paths for each process
+     if 'ALPS_APP_PE' in variables:
+        cuda_cache_path = os.path.abspath(os.path.join('nvcc-cache', str(mpicomm.rank)))
+        if not os.path.exists(cuda_cache_path):
+            os.makedirs(cuda_cache_path)
+        os.environ['CUDA_CACHE_PATH'] = cuda_cache_path
+        print('Cray detected; node {}/{} using CUDA cache path {}'.format(mpicomm.rank+1, mpicomm.size, cuda_cache_path)
 
     return mpicomm
 

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1231,7 +1231,9 @@ class MultiStateSampler(object):
 
         # Use the FIRE minimizer
         integrator = FIREMinimizationIntegrator(tolerance=tolerance)
-        context, integrator = mmtools.cache.global_context_cache.get_context(thermodynamic_state, integrator=integrator)
+
+        # Create context
+        context = thermodynamic_state.create_context(integrator)
 
         # Set initial positions and box vectors.
         sampler_state.apply_to_context(context)
@@ -1260,11 +1262,14 @@ class MultiStateSampler(object):
 
         # Get the minimized positions.
         sampler_state.update_from_context(context)
-
+        
         # Compute the final energy of the system for logging.
         final_energy = thermodynamic_state.reduced_potential(sampler_state)
         logger.debug('Replica {}/{}: final energy {:8.3f}kT'.format(
             replica_id + 1, self.n_replicas, final_energy))
+
+        # Clean up the integrator
+        del context
 
         # Return minimized positions.
         return sampler_state.positions

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1251,7 +1251,8 @@ class MultiStateSampler(object):
             integrator.step(max_iterations)
         except Exception as e:
             if str(e) == 'Particle coordinate is nan':
-                logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS')
+                logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS after resetting positions')
+                sampler_state.apply_to_context(context)
                 openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
             else:
                 raise e

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -626,7 +626,7 @@ class MultiStateSampler(object):
 
     @mmtools.utils.with_timer('Minimizing all replicas')
     def minimize(self, tolerance=1.0 * unit.kilojoules_per_mole / unit.nanometers,
-                 max_iterations=0, scheme='FIRE'):
+                 max_iterations=0):
         """Minimize all replicas.
 
         Minimized positions are stored at the end.
@@ -639,9 +639,6 @@ class MultiStateSampler(object):
         max_iterations : int, optional
             Maximum number of iterations for minimization. If 0, minimization
             continues until converged.
-        scheme : str, optional, default='L-BFGS'
-            Minimization scheme to use
-            Implemented schemes: ['L-BFGS', 'FIRE']
 
         """
         # Check that simulation has been created.
@@ -654,7 +651,7 @@ class MultiStateSampler(object):
         # The other nodes, only need the positions that they use for propagation and
         # computation of the energy matrix entries.
         minimized_positions, sampler_state_ids = mpi.distribute(self._minimize_replica, range(self.n_replicas),
-                                                                tolerance, max_iterations, scheme,
+                                                                tolerance, max_iterations,
                                                                 send_results_to=0)
 
         # Update all sampler states. For non-0 nodes, this will update only the
@@ -1223,14 +1220,8 @@ class MultiStateSampler(object):
 
         return move_statistics
 
-    def _minimize_replica(self, replica_id, tolerance, max_iterations, scheme):
+    def _minimize_replica(self, replica_id, tolerance, max_iterations):
         """Minimize the specified replica.
-
-        Parameters
-        ----------
-        scheme : str
-            Minimization scheme to use
-            Implemented schemes: ['L-BFGS', 'FIRE']
         """
 
         # Retrieve thermodynamic and sampler states.
@@ -1238,16 +1229,9 @@ class MultiStateSampler(object):
         thermodynamic_state = self._thermodynamic_states[thermodynamic_state_id]
         sampler_state = self._sampler_states[replica_id]
 
-        # Retrieve a context. 
-        if scheme == 'L-BFGS':
-            # Any Integrator works for openmm.LocalEnergyMinimizer
-            context, integrator = mmtools.cache.global_context_cache.get_context(thermodynamic_state)
-        elif scheme == 'FIRE':
-            # Use the FIRE minimizer
-            integrator = FIREMinimizationIntegrator(tolerance=tolerance)
-            context, integrator = mmtools.cache.global_context_cache.get_context(thermodynamic_state, integrator=integrator)
-        else:
-            raise ValueError("Unknown minimization scheme '%s'" % scheme)        
+        # Use the FIRE minimizer
+        integrator = FIREMinimizationIntegrator(tolerance=tolerance)
+        context, integrator = mmtools.cache.global_context_cache.get_context(thermodynamic_state, integrator=integrator)
 
         # Set initial positions and box vectors.
         sampler_state.apply_to_context(context)
@@ -1257,24 +1241,25 @@ class MultiStateSampler(object):
         logger.debug('Replica {}/{}: initial energy {:8.3f}kT'.format(
             replica_id + 1, self.n_replicas, initial_energy))
 
-        if scheme == 'L-BFGS':
-            logger.debug('Using L-BFGS: tolerance {} max_iterations {}'.format(tolerance, max_iterations))
-            openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
-        elif scheme == 'FIRE':
-            if (max_iterations is None) or (max_iterations == 0):
-                max_iterations = 1000
-            logger.debug('Using FIRE: tolerance {} max_iterations {}'.format(tolerance, max_iterations))
-            try:
-                integrator.step(max_iterations)
-            except Exception as e:
-                if str(e) == 'Particle coordinate is nan':
-                    logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS')
-                    openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
-                else:
-                    raise e
+        # Minimize energy.
+        if (max_iterations is None) or (max_iterations == 0):
+            fire_iterations = 1000
+        else:
+            fire_iterations = max_iterations
+        logger.debug('Using FIRE: tolerance {} max_iterations {}'.format(tolerance, fire_iterations))
+        try:
+            integrator.step(max_iterations)
+        except Exception as e:
+            if str(e) == 'Particle coordinate is nan':
+                logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS')
+                openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
+            else:
+                raise e
 
         # Get the minimized positions.
         sampler_state.update_from_context(context)
+
+        # TODO: Do we have to destroy the FIRE integrator-associated context if we aren't going to use it again?
 
         # Compute the final energy of the system for logging.
         final_energy = thermodynamic_state.reduced_potential(sampler_state)

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1264,7 +1264,14 @@ class MultiStateSampler(object):
             if (max_iterations is None) or (max_iterations == 0):
                 max_iterations = 1000
             logger.debug('Using FIRE: tolerance {} max_iterations {}'.format(tolerance, max_iterations))
-            integrator.step(max_iterations)
+            try:
+                integrator.step(max_iterations)
+            except Exception as e:
+                if str(e) == 'Particle coordinate is nan':
+                    logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS')
+                    openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
+                else:
+                    raise e
 
         # Get the minimized positions.
         sampler_state.update_from_context(context)

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1674,10 +1674,6 @@ class Boresch(ReceptorLigandRestraint):
                 if self._is_analytical_correction_robust(thermodynamic_state.kT) is True:
                     break
 
-                # Unpick atoms for another attempt
-                self.restrained_receptor_atoms = None
-                self.restrained_ligand_atoms = None
-
         # Check if the analytical standard state correction is robust with these parameters.
         # This check is must be performed both in the case where the user has provided the
         # restrained atoms, and in the case where we exhausted the number of attempts.
@@ -1897,10 +1893,6 @@ class Boresch(ReceptorLigandRestraint):
         Future updates can further refine this algorithm.
 
         """
-        # No need to determine parameters if atoms have been given.
-        if self._are_restrained_atoms_defined:
-            return self.restrained_receptor_atoms + self.restrained_ligand_atoms
-
         # If receptor and ligand atoms are explicitly provided, use those.
         heavy_ligand_atoms = self.restrained_ligand_atoms
         heavy_receptor_atoms = self.restrained_receptor_atoms

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1674,6 +1674,10 @@ class Boresch(ReceptorLigandRestraint):
                 if self._is_analytical_correction_robust(thermodynamic_state.kT) is True:
                     break
 
+                # Unpick atoms for another attempt
+                self._are_restrained_atoms_defined = False
+
+
         # Check if the analytical standard state correction is robust with these parameters.
         # This check is must be performed both in the case where the user has provided the
         # restrained atoms, and in the case where we exhausted the number of attempts.

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1675,8 +1675,8 @@ class Boresch(ReceptorLigandRestraint):
                     break
 
                 # Unpick atoms for another attempt
-                self._are_restrained_atoms_defined = False
-
+                self.restrained_receptor_atoms = None
+                self.restrained_ligand_atoms = None
 
         # Check if the analytical standard state correction is robust with these parameters.
         # This check is must be performed both in the case where the user has provided the

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -530,7 +530,7 @@ class TestAlchemicalPhase(object):
             sampler_states = alchemical_phase._sampler.sampler_states
             new_diffs = [np.average(sampler_states[i].positions - sampler_states[i+1].positions)
                          for i in range(len(sampler_states) - 1)]
-            assert np.allclose(original_diffs, new_diffs)
+            assert np.allclose(original_diffs, new_diffs, rtol=0.1), "original_diffs {} are not close to new_diffs {}".format(original_diffs, new_diffs)
 
     def test_randomize_ligand(self):
         """Test method AlchemicalPhase.randomize_ligand."""

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -701,7 +701,7 @@ class IMultiStateSampler(mmtools.utils.SubhookedABCMeta):
         pass
 
     @abc.abstractmethod
-    def minimize(self, tolerance, max_iterations, scheme='FIRE'):
+    def minimize(self, tolerance, max_iterations):
         """Minimize all states.
 
         Parameters
@@ -712,9 +712,6 @@ class IMultiStateSampler(mmtools.utils.SubhookedABCMeta):
         max_iterations : int
             Maximum number of iterations for minimization. If 0, minimization
             continues until converged.
-        scheme : str, optional, default='FIRE'
-            Minimization scheme to use
-            Implemented schemes: ['L-BFGS', 'FIRE']
 
         """
         pass
@@ -1088,7 +1085,7 @@ class AlchemicalPhase(object):
                              storage=storage, unsampled_thermodynamic_states=expanded_cutoff_states, metadata=metadata)
 
     def minimize(self, tolerance=1.0*unit.kilojoules_per_mole/unit.nanometers,
-                 max_iterations=0, scheme='FIRE'):
+                 max_iterations=0):
         """Minimize all the states.
 
         The minimization is performed in two steps. In the first one, the
@@ -1104,9 +1101,6 @@ class AlchemicalPhase(object):
         max_iterations : int, optional
             Maximum number of iterations for minimization. If 0, minimization
             continues until converged.
-        scheme : str, optional, default='FIRE'
-            Minimization scheme to use
-            Implemented schemes: ['L-BFGS', 'FIRE']
 
         """
         metadata = self._sampler.metadata
@@ -1125,7 +1119,7 @@ class AlchemicalPhase(object):
         # Distribute minimization across nodes.
         minimized_sampler_states_ids = list(similar_sampler_states.keys())
         minimized_positions = mpi.distribute(self._minimize_sampler_state, minimized_sampler_states_ids,
-                                             sampler_states, reference_state, tolerance, max_iterations, scheme,
+                                             sampler_states, reference_state, tolerance, max_iterations,
                                              send_results_to='all')
 
         # Update all sampler states.
@@ -1136,7 +1130,7 @@ class AlchemicalPhase(object):
 
         # Update sampler and perform second minimization in alchemically modified states.
         self._sampler.sampler_states = sampler_states
-        self._sampler.minimize(tolerance=tolerance, max_iterations=max_iterations, scheme=scheme)
+        self._sampler.minimize(tolerance=tolerance, max_iterations=max_iterations)
 
     def randomize_ligand(self, sigma_multiplier=2.0, close_cutoff=1.5*unit.angstrom):
         """Randomize the ligand positions in every state.
@@ -1403,27 +1397,14 @@ class AlchemicalPhase(object):
 
     @staticmethod
     def _minimize_sampler_state(sampler_state_id, sampler_states, thermodynamic_state,
-                                tolerance, max_iterations, scheme):
+                                tolerance, max_iterations):
         """Minimize the specified sampler state at the given thermodynamic state.
-
-        Parameters
-        ----------
-        scheme : str
-            Minimization scheme to use
-            Implemented schemes: ['L-BFGS', 'FIRE']
         """
         sampler_state = sampler_states[sampler_state_id]
 
-        # Retrieve a context. 
-        if scheme == 'L-BFGS':
-            # Any Integrator works for openmm.LocalEnergyMinimizer
-            context, integrator = mmtools.cache.global_context_cache.get_context(thermodynamic_state)
-        elif scheme == 'FIRE':
-            # Use the FIRE minimizer
-            integrator = FIREMinimizationIntegrator(tolerance=tolerance)
-            context, integrator = mmtools.cache.global_context_cache.get_context(thermodynamic_state, integrator=integrator)
-        else:
-            raise ValueError("Unknown minimization scheme '%s'" % scheme)        
+        # Use the FIRE minimizer
+        integrator = FIREMinimizationIntegrator(tolerance=tolerance)
+        context, integrator = mmtools.cache.global_context_cache.get_context(thermodynamic_state, integrator=integrator)
 
         # Set initial positions and box vectors.
         sampler_state.apply_to_context(context)
@@ -1434,21 +1415,19 @@ class AlchemicalPhase(object):
             sampler_state_id + 1, len(sampler_states), initial_energy))
 
         # Minimize energy.
-        if scheme == 'L-BFGS':
-            logger.debug('Using L-BFGS: tolerance {} max_iterations {}'.format(tolerance, max_iterations))
-            openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
-        elif scheme == 'FIRE':
-            if (max_iterations is None) or (max_iterations == 0):
-                max_iterations = 1000
-            logger.debug('Using FIRE: tolerance {} max_iterations {}'.format(tolerance, max_iterations))
-            try:
-                integrator.step(max_iterations)
-            except Exception as e:
-                if str(e) == 'Particle coordinate is nan':
-                    logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS')
-                    openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
-                else:
-                    raise e
+        if (max_iterations is None) or (max_iterations == 0):
+            fire_iterations = 1000
+        else:
+            fire_iterations = max_iterations
+        logger.debug('Using FIRE: tolerance {} max_iterations {}'.format(tolerance, fire_iterations))
+        try:
+            integrator.step(max_iterations)
+        except Exception as e:
+            if str(e) == 'Particle coordinate is nan':
+                logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS')
+                openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
+            else:
+                raise e
 
         # Get the minimized positions.
         sampler_state.update_from_context(context)
@@ -1457,6 +1436,8 @@ class AlchemicalPhase(object):
         final_energy = thermodynamic_state.reduced_potential(sampler_state)
         logger.debug('Sampler state {}/{}: final energy {:8.3f}kT'.format(
             sampler_state_id + 1, len(sampler_states), final_energy))
+
+        # TODO: Do we have to destroy the FIRE integrator bound context if we aren't going to use it again?
 
         # Return minimized positions.
         return sampler_state.positions

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -1424,7 +1424,8 @@ class AlchemicalPhase(object):
             integrator.step(max_iterations)
         except Exception as e:
             if str(e) == 'Particle coordinate is nan':
-                logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS')
+                logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS after resetting positions')
+                sampler_state.apply_to_context(context)
                 openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
             else:
                 raise e

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -1441,7 +1441,14 @@ class AlchemicalPhase(object):
             if (max_iterations is None) or (max_iterations == 0):
                 max_iterations = 1000
             logger.debug('Using FIRE: tolerance {} max_iterations {}'.format(tolerance, max_iterations))
-            integrator.step(max_iterations)
+            try:
+                integrator.step(max_iterations)
+            except Exception as e:
+                if str(e) == 'Particle coordinate is nan':
+                    logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS')
+                    openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)
+                else:
+                    raise e
 
         # Get the minimized positions.
         sampler_state.update_from_context(context)

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -1404,7 +1404,9 @@ class AlchemicalPhase(object):
 
         # Use the FIRE minimizer
         integrator = FIREMinimizationIntegrator(tolerance=tolerance)
-        context, integrator = mmtools.cache.global_context_cache.get_context(thermodynamic_state, integrator=integrator)
+
+        # Create context
+        context = thermodynamic_state.create_context(integrator)
 
         # Set initial positions and box vectors.
         sampler_state.apply_to_context(context)
@@ -1435,9 +1437,12 @@ class AlchemicalPhase(object):
         sampler_state.update_from_context(context)
 
         # Compute the final energy of the system for logging.
-        final_energy = thermodynamic_state.reduced_potential(sampler_state)
+        final_energy = thermodynamic_state.reduced_potential(context)
         logger.debug('Sampler state {}/{}: final energy {:8.3f}kT'.format(
             sampler_state_id + 1, len(sampler_states), final_energy))
+
+        # Clean up the integrator
+        del context
 
         # Return minimized positions.
         return sampler_state.positions

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,3 +1,24 @@
+@article{LBFGS,
+  title={On the limited memory BFGS method for large scale optimization},
+  author={Liu, Dong C and Nocedal, Jorge},
+  journal={Mathematical programming},
+  volume={45},
+  number={1-3},
+  pages={503--528},
+  year={1989},
+  publisher={Springer}
+}
+
+@article{FIREMinimizer,
+  title={Structural relaxation made simple},
+  author={Bitzek, Erik and Koskinen, Pekka and G{\"a}hler, Franz and Moseler, Michael and Gumbsch, Peter},
+  journal={Physical review letters},
+  volume={97},
+  number={17},
+  pages={170201},
+  year={2006},
+  publisher={APS}
+}
 @article{LeimkuhlerMatthews2016,
   title={Efficient molecular dynamics using geodesic integration and solvent--solute splitting},
   author={Leimkuhler, Benedict and Matthews, Charles},

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -436,19 +436,14 @@ Valid options (0): <Integer>
 .. code-block:: yaml
 
    options:
-     minimize: FIRE
+     minimize: True
 
-Minimize the input configuration before starting simulation. 
+Minimize the input configuration before starting simulation.
 This is highly recommended if a pre-minimized structure is provided, or if explicit solvent generation is left to YANK.
+The FIRE minimizer :cite:`FIREMinimizer`, a fast minimizer that can run entirely on the GPU, is used first.
+If this fails, an L-BFGS minimizer :cite:`LBFGS` (as `implemented in OpenMM <http://docs.openmm.org/latest/userguide/application.html#energy-minimization>`_) is used.
 
-Options include:
-
-* ``FIRE``: The FIRE minimizer :cite:`FIREMinimizer`, a fast minimizer that may fail for very difficult systems
-* ``L-BFGS``: The L-BFGS minimizer :cite:`LBFGS` as `implemented in OpenMM <http://docs.openmm.org/latest/userguide/application.html#energy-minimization>`_
-* ``no``: No minimization
-
-
-Valid Options: [FIRE]/L-BFGS/no
+Valid Options: [yes]/no
 
 
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -436,12 +436,19 @@ Valid options (0): <Integer>
 .. code-block:: yaml
 
    options:
-     minimize: yes
+     minimize: FIRE
 
-Minimize the input configuration before starting simulation. Highly recommended if a pre-minimized structure is provided,
-or if explicit solvent generation is left to YANK.
+Minimize the input configuration before starting simulation. 
+This is highly recommended if a pre-minimized structure is provided, or if explicit solvent generation is left to YANK.
 
-Valid Options: [yes]/no
+Options include:
+
+* ``FIRE``: The FIRE minimizer :cite:`FIREMinimizer`, a fast minimizer that may fail for very difficult systems
+* ``L-BFGS``: The L-BFGS minimizer :cite:`LBFGS` as `implemented in OpenMM <http://docs.openmm.org/latest/userguide/application.html#energy-minimization>`_
+* ``no``: No minimization
+
+
+Valid Options: [FIRE]/L-BFGS/no
 
 
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -457,7 +457,7 @@ Valid Options: [yes]/no
 .. code-block:: yaml
 
    options:
-     minimize_max_iterations: 0
+     minimize_max_iterations: 1000
 
 Set the maximum number of iterations the
 :ref:`energy minimization process <yaml_options_minimize>` attempts to converge to :ref:`given tolerance energy <yaml_options_minimize_tolerance>`. 0 steps indicate unlimited.


### PR DESCRIPTION
On `lilac`, minimization of 50K atom systems (like c-Met) often took ~30 minutes/minimization, with several stages of minimization required (fully-interacting system, alchemically-modified system) to start a run. 

This PR implements support for a tuned version of the FIRE minimizer as a `CustomIntegrator`, now enabled by default:

Erik Bitzek, Pekka Koskinen, Franz Gaehler, Michael Moseler, and Peter Gumbsch.
Structural Relaxation Made Simple. PRL 97:170201, 2006. [DOI](http://dx.doi.org/10.1103/PhysRevLett.97.170201)

For c-Met, this brings minimization times down from 30 minutes to 30 seconds.