### PR TITLE
Fix bug in automated Boresch atom picking 

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1674,10 +1674,6 @@ class Boresch(ReceptorLigandRestraint):
                 if self._is_analytical_correction_robust(thermodynamic_state.kT) is True:
                     break
 
-                # Unpick atoms for another attempt
-                self.restrained_receptor_atoms = None
-                self.restrained_ligand_atoms = None
-
         # Check if the analytical standard state correction is robust with these parameters.
         # This check is must be performed both in the case where the user has provided the
         # restrained atoms, and in the case where we exhausted the number of attempts.
@@ -1897,10 +1893,6 @@ class Boresch(ReceptorLigandRestraint):
         Future updates can further refine this algorithm.
 
         """
-        # No need to determine parameters if atoms have been given.
-        if self._are_restrained_atoms_defined:
-            return self.restrained_receptor_atoms + self.restrained_ligand_atoms
-
         # If receptor and ligand atoms are explicitly provided, use those.
         heavy_ligand_atoms = self.restrained_ligand_atoms
         heavy_receptor_atoms = self.restrained_receptor_atoms

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1674,6 +1674,10 @@ class Boresch(ReceptorLigandRestraint):
                 if self._is_analytical_correction_robust(thermodynamic_state.kT) is True:
                     break
 
+                # Unpick atoms for another attempt
+                self._are_restrained_atoms_defined = False
+
+
         # Check if the analytical standard state correction is robust with these parameters.
         # This check is must be performed both in the case where the user has provided the
         # restrained atoms, and in the case where we exhausted the number of attempts.

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1675,8 +1675,8 @@ class Boresch(ReceptorLigandRestraint):
                     break
 
                 # Unpick atoms for another attempt
-                self._are_restrained_atoms_defined = False
-
+                self.restrained_receptor_atoms = None
+                self.restrained_ligand_atoms = None
 
         # Check if the analytical standard state correction is robust with these parameters.
         # This check is must be performed both in the case where the user has provided the

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -256,8 +256,8 @@ class TestMultiPhaseAnalyzer(object):
         assert fe.shape == (self.n_states + 2, self.n_states + 2)
         stored_fe_dict = phase._computed_observables['free_energy']
         stored_fe, stored_dfe = stored_fe_dict['value'], stored_fe_dict['error']
-        assert np.all(stored_fe == fe)
-        assert np.all(stored_dfe == dfe)
+        assert np.all(stored_fe == fe), "stored_fe = {}, fe = {}".format(stored_fe, fe)
+        assert np.all(stored_dfe == dfe), "stored_dfe = {}, dfe = {}".format(stored_dfe, dfe)
         # Test reference states and full work up creation
         iinit, jinit = phase.reference_states
         output = phase.analyze_phase()


### PR DESCRIPTION
This critical bugfix PR fixes a bug in automated Boresch atom picking where picked atoms were not  being cleared before next attempt.

The bug resulted in YANK never being able to recover from an initial failure.