### PR TITLE
Make the test_charged_ligand faster

### DIFF
--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -1837,7 +1837,9 @@ def test_charged_ligand():
     """Check that there are alchemical counterions for charged ligands."""
     imatinib_path = examples_paths()['imatinib']
     with mmtools.utils.temporary_directory() as tmp_dir:
-        receptors = {'Asp': -1, 'Abl': -8}  # receptor name -> net charge
+        # receptors = {'Asp': -1, 'Abl': -8}  # receptor name -> net charge
+        # Only run `Asp` on CI as Abl can be very slow
+        receptors = {'Asp': -1}  # receptor name -> net charge
         solvent_names = ['PME', 'PMEionic']
         updates = yank_load("""
         molecules:


### PR DESCRIPTION
Only tests on the small `asp` system and not the `abl`, this should cut down the test length to about 10% of what it currently is. (~>200s down to ~20 locally)