### PR TITLE
Pin cerberus to 1.1

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - pyyaml
     - clusterutils
     - sphinxcontrib-bibtex
-    - cerberus
+    - cerberus ==1.1.*
     - matplotlib
     - jupyter
     - pdbfixer


### PR DESCRIPTION
It will be a much larger pain to convert to 1.2 as there are a few things
which changed. Until we move to the public schema, I don't think its worth
the time sink to fix this proper.

Fixes #950