### PR TITLE
Use max_n_iterations in generate_mixing_statistics()

### DIFF
--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1118,13 +1118,12 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         if number_equilibrated is None:
             number_equilibrated = self.n_equilibration_iterations
         states = self._reporter.read_replica_thermodynamic_states()
-        n_iterations, n_replicas = states.shape
         n_states = self._reporter.n_states
         n_ij = np.zeros([n_states, n_states], np.int64)
 
         # Compute empirical transition count matrix.
-        for iteration in range(number_equilibrated, n_iterations - 1):
-            for i_replica in range(n_replicas):
+        for iteration in range(number_equilibrated, self.max_n_iterations - 1):
+            for i_replica in range(self.n_replicas):
                 i_state = states[iteration, i_replica]
                 j_state = states[iteration + 1, i_replica]
                 n_ij[i_state, j_state] += 1


### PR DESCRIPTION
Fix a bug where `max_n_iterations` was ignored when computing the mixing statistics of the calculation.