### PR TITLE
Bugfix for sampler state handling in samplers

### DIFF
--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -577,12 +577,6 @@ class MultiStateSampler(object):
         # Deep copy sampler states.
         self._sampler_states = [copy.deepcopy(sampler_state) for sampler_state in sampler_states]
 
-        # Make sure all sampler states have box vectors defined; add dummies if needed.
-        default_box_vectors = thermodynamic_states[0].system.getDefaultPeriodicBoxVectors()
-        for sampler_state in self._sampler_states:
-            if sampler_state.box_vectors is None:
-                sampler_state.box_vectors = default_box_vectors
-
         # Set initial thermodynamic state indices if not specified
         if initial_thermodynamic_states is None:
             initial_thermodynamic_states = self._default_initial_thermodynamic_states(thermodynamic_states,

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -507,6 +507,10 @@ class MultiStateSampler(object):
         # Make sure that only the root node has an open reporter.
         self._reporter.close()
 
+        # Make sure sampler_states is an iterable of SamplerStates.
+        if isinstance(sampler_states, mmtools.states.SamplerState):
+            sampler_states = [sampler_states]
+
         # Initialize internal attribute and dataset.
         self._pre_write_create(thermodynamic_states, sampler_states, storage,
                                initial_thermodynamic_states=initial_thermodynamic_states,
@@ -531,10 +535,6 @@ class MultiStateSampler(object):
         :func:`_report_iteration`.
         All calls to this function should be *identical* to :func:`create` itself
         """
-        # Make sure sampler_states is an iterable of SamplerStates for later.
-        if isinstance(sampler_states, mmtools.states.SamplerState):
-            sampler_states = [sampler_states]
-
         # Check all systems are either periodic or not.
         is_periodic = thermodynamic_states[0].is_periodic
         for thermodynamic_state in thermodynamic_states:

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -372,8 +372,7 @@ class MultiStateSampler(object):
                 new_value = self._validate_function(instance, new_value)
             setattr(instance, '_' + self._option_name, new_value)
             # Update storage if we ReplicaExchange is initialized.
-            # TODO: JDC Please review this change!
-            if instance._thermodynamic_states is not None and instance._reporter is not None:
+            if instance._reporter is not None and instance._reporter.is_open():
                 mpi.run_single_node(0, instance._store_options)
 
         # ----------------------------------

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -305,7 +305,7 @@ class SAMSSampler(MultiStateSampler):
            Simulation metadata to be stored in the file.
         """
         # Initialize replica-exchange simulation.
-        super(SAMSSampler, self)._pre_write_create(thermodynamic_states, sampler_states, storage=storage, **kwargs)
+        super()._pre_write_create(thermodynamic_states, sampler_states, storage=storage, **kwargs)
 
         if self.state_update_scheme == 'global-jump':
             self.locality = None # override locality to be global


### PR DESCRIPTION
- Fix #944: ReplicaExchange.create() doesn't accept a single SamplerState anymore.
- Fix a bug where the box vectors of `SamplerState`s were initialized in `MultiStateSampler.create()` using only the first `ThermodynamicState` box vectors. When running NVT simulations, the sampler state should instead have the box vectors of its associated `ThermodynamicState`.