### PR TITLE
Make restoration and last iteration more robust

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -362,7 +362,7 @@ def extract_trajectory(nc_path, nc_checkpoint_file=None, state_index=None, repli
 
         # Get dimensions
         # Assume full iteration until proven otherwise
-        full_iteration = True
+        last_checkpoint = True
         trajectory_storage = reporter._storage_checkpoint
         if not keep_solvent:
             # If tracked solute particles, use any last iteration, set with this logic test
@@ -371,7 +371,7 @@ def extract_trajectory(nc_path, nc_checkpoint_file=None, state_index=None, repli
                 trajectory_storage = reporter._storage_analysis
                 topology = topology.subset(reporter.analysis_particle_indices)
 
-        n_iterations = reporter.read_last_iteration(full_iteration=full_iteration)
+        n_iterations = reporter.read_last_iteration(last_checkpoint=last_checkpoint)
         n_frames = trajectory_storage.variables['positions'].shape[0]
         n_atoms = trajectory_storage.variables['positions'].shape[2]
         logger.info('Number of frames: {}, atoms: {}'.format(n_frames, n_atoms))

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -595,7 +595,7 @@ class PhaseAnalyzer(ABC):
         """int: The total number of iterations of the phase."""
         if self._n_iterations is None:
             # The + 1 accounts for iteration 0.
-            self._n_iterations = self._reporter.read_last_iteration(full_iteration=False)
+            self._n_iterations = self._reporter.read_last_iteration(last_checkpoint=False)
         return self._n_iterations
 
     @property

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -251,7 +251,7 @@ class MultiStateSampler(object):
         # Read iteration and online analysis info.
         reporter.open(mode='r')
         options = reporter.read_dict('options')
-        iteration = reporter.read_last_iteration(full_iteration=False)
+        iteration = reporter.read_last_iteration(last_checkpoint=False)
         # Search for last cached free energies only if online analysis is activated.
         if options['online_analysis_interval'] is not None:
             target_error = options['online_analysis_target_error']
@@ -886,26 +886,53 @@ class MultiStateSampler(object):
         reporter.open(mode='r')
         # Read the last iteration reported to ensure we don't include junk
         # data written just before a crash.
-        iteration = reporter.read_last_iteration()
-
-        # Retrieve other attributes.
         logger.debug("Reading storage file {}...".format(reporter.filepath))
-        thermodynamic_states, unsampled_states = reporter.read_thermodynamic_states()
-        sampler_states = reporter.read_sampler_states(iteration=iteration)
-        state_indices = reporter.read_replica_thermodynamic_states(iteration=iteration)
-        energy_thermodynamic_states, neighborhoods, energy_unsampled_states = reporter.read_energies(iteration=iteration)
-        n_accepted_matrix, n_proposed_matrix = reporter.read_mixing_statistics(iteration=iteration)
         metadata = reporter.read_dict('metadata')
+        thermodynamic_states, unsampled_states = reporter.read_thermodynamic_states()
 
-        # Search for last cached free energies only if online analysis is activated.
-        if self.online_analysis_interval is not None:
-            online_analysis_info = self._read_last_free_energy(reporter, iteration)
-            last_mbar_f_k, (_, last_err_free_energy) = online_analysis_info
-        else:
-            last_mbar_f_k, last_err_free_energy = None, None
+        def _read_options(check_iteration):
+            internal_sampler_states = reporter.read_sampler_states(iteration=check_iteration)
+            internal_state_indices = reporter.read_replica_thermodynamic_states(iteration=check_iteration)
+            internal_energy_thermodynamic_states, internal_neighborhoods, internal_energy_unsampled_states = \
+                reporter.read_energies(iteration=check_iteration)
+            internal_n_accepted_matrix, internal_n_proposed_matrix = \
+                reporter.read_mixing_statistics(iteration=check_iteration)
 
+            # Search for last cached free energies only if online analysis is activated.
+            if self.online_analysis_interval is not None:
+                online_analysis_info = self._read_last_free_energy(reporter, check_iteration)
+                internal_last_mbar_f_k, (_, internal_last_err_free_energy) = online_analysis_info
+            else:
+                internal_last_mbar_f_k, internal_last_err_free_energy = None, None
+            return (internal_sampler_states, internal_state_indices, internal_energy_thermodynamic_states,
+                    internal_neighborhoods, internal_energy_unsampled_states, internal_n_accepted_matrix,
+                    internal_n_proposed_matrix, internal_last_mbar_f_k, internal_last_err_free_energy)
+
+        # Keep trying to resume further and further back from the most recent checkpoint back
+        checkpoints = reporter.read_checkpoint_iterations()
+        checkpoint_reverse_iter = iter(checkpoints[::-1])
+        while True:
+            try:
+                checkpoint = next(checkpoint_reverse_iter)
+                output_data = _read_options(checkpoint)
+                # Found data, can escape loop
+                break
+            except StopIteration:
+                raise self._throw_restoration_error("Attempting to restore from any checkpoint failed. "
+                                                    "Either your data is fully corrupted or something has gone very "
+                                                    "wrong to see this message.\n"
+                                                    "Please open an issue on the GitHub issue tracker if you see this!")
+            except:
+                # Trap all other errors caught by the load process
+                continue
+
+        if checkpoint < checkpoints[-1]:
+            logger.warning("Could not use most recent checkpoint at {}, instead pulled from {}".format(checkpoints[-1],
+                                                                                                       checkpoint))
+        (sampler_states, state_indices, energy_thermodynamic_states, neighborhoods, energy_unsampled_states,
+         n_accepted_matrix, n_proposed_matrix, last_mbar_f_k, last_err_free_energy) = output_data
         # Assign attributes.
-        self._iteration = iteration
+        self._iteration = checkpoint
         self._thermodynamic_states = thermodynamic_states
         self._unsampled_states = unsampled_states
         self._sampler_states = sampler_states
@@ -1069,13 +1096,14 @@ class MultiStateSampler(object):
         partial data if the program gets interrupted.
 
         Subclasses should not attempt to modify this function as it can
-        force either duplicated or missed ``sync()`` calls
+        force either duplicated or missed ``sync()`` calls. In the event
+        that they MUST overwrite this function, the last call in the whole
+        stack should be :func:MultiStateReporter.write_last_iteration
         """
         # Call report_iteration_items for a subclass-friendly function
         self._report_iteration_items()
         self._reporter.write_timestamp(self._iteration)
         self._reporter.write_last_iteration(self._iteration)
-        self._reporter.sync()
 
     @mpi.on_single_node(rank=0, broadcast_result=False, sync_nodes=False)
     @mpi.delayed_termination
@@ -1549,6 +1577,17 @@ class MultiStateSampler(object):
                         last_err_free_energy is not None and last_err_free_energy <= online_analysis_target_error)):
             return True
         return False
+
+    @staticmethod
+    def _throw_restoration_error(message):
+        """Masking function to hide the RestorationError class without exposing it or making it a 'hidden' (_X) error"""
+        class RestorationError(Exception):
+            """Represent errors occurring during attempts to restore simulations."""
+            def __init__(self, error_message):
+                super().__init__(error_message)
+                # Critical messages which have halted a simulation, badly
+                logger.critical(error_message)
+        raise RestorationError(message)
 
     # -------------------------------------------------------------------------
     # Internal-usage: Test globals

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -932,7 +932,7 @@ class MultiStateSampler(object):
         (sampler_states, state_indices, energy_thermodynamic_states, neighborhoods, energy_unsampled_states,
          n_accepted_matrix, n_proposed_matrix, last_mbar_f_k, last_err_free_energy) = output_data
         # Assign attributes.
-        self._iteration = checkpoint
+        self._iteration = int(checkpoint)  # The int() can probably be removed when pinned to NetCDF4 >=1.4.0
         self._thermodynamic_states = thermodynamic_states
         self._unsampled_states = unsampled_states
         self._sampler_states = sampler_states

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,12 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.21.3 Post-Triage Bugfixes
+---------------------------
+- Added more robust last good iteration saving
+- Added more robust restore from checkpoint access
+- Exposed checkpoint interval iterations in ``MultiStateReporter``
+
 0.21.2 More Post-Sams Bugfixes
 ------------------------------
 - Fix analysis on 32-bit platforms OS agnostic


### PR DESCRIPTION
This is the first of a couple changes to make checkpoint restoration and access more robust.

Next step will to be make `MultiStateAnalyzer` able to detect corruption and back up X number of checkpoints. I split the PRs to minimize amount which has to be reviewed and to set the underlying structure first.

I also changed some logic on masking maximum number of available iterations to prevent unassociated data from being accessed, cut down on some lines.

@jchodera @andrrizzi any other exposed methods/functionality you think we need before I try to make the analyzer able to handle data corruption better?

@andrrizzi what would be the effect in the `MultiStateAnalyzer` if I changed the other `CachedProperty` objects to depend on `max_n_iterations`?