### PR TITLE
Fixes to extract trajectory

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -376,12 +376,19 @@ def extract_trajectory(nc_path, nc_checkpoint_file=None, state_index=None, repli
         n_atoms = trajectory_storage.variables['positions'].shape[2]
         logger.info('Number of frames: {}, atoms: {}'.format(n_frames, n_atoms))
 
-        # Determine frames to extract
+        # Determine frames to extract.
+        # TODO: Convert negative start_frame indices similarly to end_frame?
         if start_frame <= 0:
-            # Discard frame 0 with minimized energy which
-            # throws off automatic equilibration detection.
-            start_frame = 1
+            if n_iterations > 0:
+                # Discard frame 0 with minimized energy which
+                # throws off automatic equilibration detection.
+                start_frame = 1
+            else:
+                # If the simulation crashed right after minimization,
+                # we allow extracting the first (and only) frame.
+                start_frame = 0
         if end_frame < 0:
+            # Convert negative indices to last indices.
             end_frame = n_frames + end_frame + 1
         frame_indices = range(start_frame, end_frame, skip_frame)
         if len(frame_indices) == 0:

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -412,26 +412,36 @@ def extract_trajectory(nc_path, nc_checkpoint_file=None, state_index=None, repli
                 n_equil_frames = n_equil_iterations
             frame_indices = frame_indices[n_equil_frames:-1]
 
-        # Extract state positions and box vectors.
+        # Determine the number of frames that the trajectory will have.
+        if state_index is None:
+            n_trajectory_frames = len(frame_indices)
+        else:
+            # With SAMS, an iteration can have 0 or more replicas in a given state.
+            # Deconvolute state indices.
+            state_indices = [None for _ in frame_indices]
+            for i, iteration in enumerate(frame_indices):
+                replica_indices = reporter._storage_analysis.variables['states'][iteration, :]
+                state_indices[i] = np.where(replica_indices == state_index)[0]
+            n_trajectory_frames = sum(len(x) for x in state_indices)
+
+        # Initialize positions and box vectors arrays.
         # MDTraj Cython code expects float32 positions.
-        positions = np.zeros((len(frame_indices), n_atoms, 3), dtype=np.float32)
+        positions = np.zeros((n_trajectory_frames, n_atoms, 3), dtype=np.float32)
         if is_periodic:
-            box_vectors = np.zeros((len(frame_indices), 3, 3), dtype=np.float32)
+            box_vectors = np.zeros((n_trajectory_frames, 3, 3), dtype=np.float32)
+
+        # Extract state positions and box vectors.
         if state_index is not None:
             logger.info('Extracting positions of state {}...'.format(state_index))
 
-            # Deconvolute state indices
-            state_indices = np.zeros(len(frame_indices))
+            # Extract state positions and box vectors.
+            frame_idx = 0
             for i, iteration in enumerate(frame_indices):
-                replica_indices = reporter._storage_analysis.variables['states'][iteration, :]
-                state_indices[i] = np.where(replica_indices == state_index)[0][0]
-
-            # Extract state positions and box vectors
-            for i, iteration in enumerate(frame_indices):
-                replica_index = state_indices[i]
-                positions[i, :, :] = trajectory_storage.variables['positions'][iteration, replica_index, :, :].astype(np.float32)
-                if is_periodic:
-                    box_vectors[i, :, :] = trajectory_storage.variables['box_vectors'][iteration, replica_index, :, :].astype(np.float32)
+                for replica_index in state_indices[i]:
+                    positions[frame_idx, :, :] = trajectory_storage.variables['positions'][iteration, replica_index, :, :].astype(np.float32)
+                    if is_periodic:
+                        box_vectors[frame_idx, :, :] = trajectory_storage.variables['box_vectors'][iteration, replica_index, :, :].astype(np.float32)
+                    frame_idx += 1
 
         else:  # Extract replica positions and box vectors
             logger.info('Extracting positions of replica {}...'.format(replica_index))

--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -153,18 +153,11 @@ def dispatch_extract_trajectory(args):
     # Extract trajectory
     trajectory = analyze.extract_trajectory(nc_path, **kwargs)
 
-    # Detect output format.
-    extension = os.path.splitext(output_path)[1][1:]  # remove dot
-    try:
-        save_function = getattr(trajectory, 'save_' + extension)
-    except AttributeError:
-        raise ValueError('Cannot detect format from extension of file {}'.format(output_path))
-
     # Create output directory and save trajectory
     output_dir = os.path.dirname(output_path)
     if output_dir != '' and not os.path.isdir(output_dir):
         os.makedirs(output_dir)
-    save_function(output_path)
+    trajectory.save(output_path)
 
     return True
 

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -511,7 +511,7 @@ class TestMultiPhaseAnalyzer(object):
         """extract_trajectory handles checkpointing and skip frame correctly."""
         # Make sure the "solute"-only (analysis atoms) trajectory has the correct properties
         solute_trajectory = analyze.extract_trajectory(self.reporter.filepath, replica_index=0, keep_solvent=False)
-        assert len(solute_trajectory) == self.n_steps - 1
+        assert len(solute_trajectory) == self.n_steps
         assert solute_trajectory.n_atoms == len(self.analysis_atoms)
 
         # Check that only the checkpoint trajectory is returned when keep_solvent is True.
@@ -519,12 +519,12 @@ class TestMultiPhaseAnalyzer(object):
         # Should this change in analyze, then this logic will need to be changed as well.
         # The int() rounds down from sampling to a state in between the interval.
         full_trajectory = analyze.extract_trajectory(self.reporter.filepath, replica_index=0, keep_solvent=True)
-        assert len(full_trajectory) == int((self.n_steps + 1) / self.checkpoint_interval) - 1
+        assert len(full_trajectory) == int((self.n_steps + 1) / self.checkpoint_interval)
 
         # Check that skip_frame reduces the trajectory length correctly.
         skip_frame = 2
         trajectory = analyze.extract_trajectory(self.reporter.filepath, replica_index=0, skip_frame=skip_frame)
-        assert len(trajectory) == int(self.n_steps / self.checkpoint_interval / skip_frame)
+        assert len(trajectory) == int(self.n_steps / self.checkpoint_interval / skip_frame) + 1
 
         # Extracting the trajectory of a state does not incur into errors.
         analyze.extract_trajectory(self.reporter.filepath, state_index=0, keep_solvent=False)

--- a/Yank/tests/test_analyze.py
+++ b/Yank/tests/test_analyze.py
@@ -412,9 +412,6 @@ class TestMultiPhaseAnalyzer(object):
         def check_cached_properties(is_in):
             for cached_property in cached_properties:
                 err_msg = '{} is cached != {}'.format(cached_property, is_in)
-                if not (cached_property in analyzer._cache) is is_in:
-                    print(cached_property)
-                    import pdb; pdb.set_trace()
                 assert (cached_property in analyzer._cache) is is_in, err_msg
             assert (analyzer._computed_observables['free_energy'] is not None) is is_in
 


### PR DESCRIPTION
- Fix #848: Use MDTraj Trajectory.save() method instead of inferring function from extension.
- Fix #635: Allow extract-trajectory to handle trajectories with 1 frame.
- Fix #964: state index argument in extract_trajectory for SAMS calculations.