### PR TITLE
Fix yaml combinatorial smiles + no filepath

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1026,7 +1026,13 @@ class ExperimentBuilder(object):
         for comb_mol_name, comb_molecule in expanded_content['molecules'].items():
             if 'select' in comb_molecule and comb_molecule['select'] == 'all':
                 # Get the number of models in the file
-                extension = os.path.splitext(comb_molecule['filepath'])[1][1:]  # remove dot
+                try:
+                    extension = os.path.splitext(comb_molecule['filepath'])[1][1:]  # remove dot
+                except KeyError:
+                    # Trap an error caused by missing a filepath from the combinatorial expansion
+                    # This will ultimately fail cerberus validation, but will be easier to debug than
+                    # random Python error
+                    continue
                 with moltools.utils.temporary_cd(self._script_dir):
                     if extension == 'pdb':
                         n_models = PDBFile(comb_molecule['filepath']).getNumFrames()


### PR DESCRIPTION
There is a corner case which happens when the following conditions are met:
1. `smiles` or `name` is set in a `molecule`
2. `select: all` is set in the same molecule
3. `filepath` is *not* set in the same molecule

This results in a molecule expansion failure pre-Cerberus validation.

This PR ignores this specific set of conditions to allow the rest of the
expansion to continue unhindered, and lets Cerberus trap the schema
failure later on more gracefully.

Fixes #984