### PR TITLE
Change timeseries to only consider a subset of nodes for equilibration

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -105,7 +105,35 @@ class YankMultiStateSamplerAnalyzer(multistate.MultiStateSamplerAnalyzer, YankPh
             self._computed_observables['standard_state_correction'] = ssc
         return self._computed_observables['standard_state_correction']
 
-    def analyze_phase(self, cutoff=0.05):
+    def analyze_phase(self, show_mixing=False, cutoff=0.05):
+        """
+        Auto-analysis function for the phase
+
+        Function which broadly handles "auto-analysis" for those that do not wish to call all the methods on their own.
+
+        This variant computes the following:
+
+        * Equilibration data (accessible through ``n_equilibration_iterations`` and ``statistical_inefficiency``
+          properties)
+        * Optional mixing statistics printout
+        * Free Energy difference between all states with error
+        * Enthalpy difference between all states with error (as expectation of the reduced potential)
+        * Free energy of the Standard State Correction for the phase.
+
+        Parameters
+        ----------
+        show_mixing : bool, optional. Default: False
+            Toggle to show mixing statistics or not. This can be a slow step so is disabled for speed by default.
+        cutoff : float, optional. Default: 0.05
+            Threshold below which % of mixing mixing from one state to another is not shown.
+            Makes the output table more clean to read (rendered as whitespace)
+
+        Returns
+        -------
+        data : dict
+            A dictionary of analysis objects, in this case Delta F, Delta H, and Standard State Free Energy
+            In units of kT (dimensionless)
+        """
         number_equilibrated, g_t, _ = self._equilibration_data
         self.show_mixing_statistics(cutoff=cutoff, number_equilibrated=number_equilibrated)
         data = {}

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -135,7 +135,8 @@ class YankMultiStateSamplerAnalyzer(multistate.MultiStateSamplerAnalyzer, YankPh
             In units of kT (dimensionless)
         """
         number_equilibrated, g_t, _ = self._equilibration_data
-        self.show_mixing_statistics(cutoff=cutoff, number_equilibrated=number_equilibrated)
+        if show_mixing:
+            self.show_mixing_statistics(cutoff=cutoff, number_equilibrated=number_equilibrated)
         data = {}
         # Accumulate free energy differences
         Deltaf_ij, dDeltaf_ij = self.get_free_energy()

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1840,7 +1840,12 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         # Discard equilibration samples.
         # TODO: if we include u_n[0] (the energy right after minimization) in the equilibration detection,
         # TODO:         then number_equilibrated is 0. Find a better way than just discarding first frame.
-        equilibration_data = list(utils.get_equilibration_data(u_n[1:]))
+        i_t, g_i, n_effective_i = utils.get_equilibration_data_per_sample(u_n[1:])
+        n_effective_max = n_effective_i.max()
+        i_max = n_effective_i.argmax()
+        n_equilibration = i_t[i_max]
+        g_t = g_i[i_max]
+        equilibration_data = [n_equilibration, g_t, n_effective_max]
         # Discard also minimization frame.
         equilibration_data[0] += 1
         self._equilibration_data = tuple(equilibration_data)

--- a/Yank/multistate/utils.py
+++ b/Yank/multistate/utils.py
@@ -119,7 +119,7 @@ def get_equilibration_data_per_sample(timeseries_to_analyze, fast=True, max_subs
     ----------
     timeseries_to_analyze : np.ndarray
         1-D timeseries to analyze for equilibration
-    max_subset : int or None, optional, default: 1000
+    max_subset : int >= 1 or None, optional, default: 1000
         Maximum number of points in the ``timeseries_to_analyze`` on which to analyze the equilibration on.
         These are distributed uniformly over the timeseries so the final output will be size max_subset where indices
         are placed  approximately every ``(len(timeseries_to_analyze) - 1) / max_subset``.
@@ -152,11 +152,21 @@ def get_equilibration_data_per_sample(timeseries_to_analyze, fast=True, max_subs
     """
     # Cast to array if not already
     series = np.array(timeseries_to_analyze)
+    # Special trap for constant series
     time_size = series.size
     set_size = time_size - 1  # Cannot analyze the last entry
     # Set maximum
     if max_subset is None or set_size < max_subset:
         max_subset = set_size
+    # Special trap for series of size 1
+    if max_subset == 0:
+        max_subset = 1
+    # Special trap for constant or size 1 series
+    if series.std() == 0.0 or max_subset == 1:
+        return (np.arange(max_subset, dtype=int),  # i_t
+                np.array([1]*max_subset),  # g_i
+                np.arange(time_size, time_size-max_subset, -1)  # n_effective_i
+                )
     g_i = np.ones([max_subset], np.float32)
     n_effective_i = np.ones([max_subset], np.float32)
     counter = np.arange(max_subset)

--- a/Yank/multistate/utils.py
+++ b/Yank/multistate/utils.py
@@ -25,6 +25,7 @@ This code is licensed under the latest available version of the MIT License.
 
 """
 import logging
+import warnings
 import numpy as np
 
 from pymbar import timeseries  # for statistical inefficiency analysis
@@ -102,35 +103,114 @@ def get_decorrelation_time(timeseries_to_analyze):
     return timeseries.statisticalInefficiency(timeseries_to_analyze)
 
 
-def get_equilibration_data(timeseries_to_analyze):
+def get_equilibration_data_per_sample(timeseries_to_analyze, fast=True, max_subset=1000):
+    """
+    Compute the correlation time and n_effective per sample with tuning to how you want your data formatted
+
+    This is a modified pass-through to ``pymbar.timeseries.detectEquilibration`` does, returning the per sample data.
+
+    It has been modified to specify the maximum number of time points to consider, evenly spaced over the timeseries.
+    This is different than saying "I want analysis done every X for total points Y = len(timeseries)/X",
+    this is "I want Y total analysis points"
+
+    See the ``pymbar.timeseries.detectEquilibration`` function for full algorithm documentation
+
+    Parameters
+    ----------
+    timeseries_to_analyze : np.ndarray
+        1-D timeseries to analyze for equilibration
+    max_subset : int or None, optional, default: 1000
+        Maximum number of points in the ``timeseries_to_analyze`` on which to analyze the equilibration on.
+        These are distributed uniformly over the timeseries so the final output will be size max_subset where indices
+        are placed  approximately every ``(len(timeseries_to_analyze) - 1) / max_subset``.
+        The full timeseries is used if the timeseries is smaller than ``max_subset`` or if ``max_subset`` is None
+    fast : bool, optional. Default: True
+        If True, will use faster (but less accurate) method to estimate correlation time
+        passed on to timeseries module.
+
+    Returns
+    -------
+    i_t : np.ndarray of int
+        Indices of the timeseries which were sampled from
+    g_i : np.ndarray of float
+        Estimated statistical inefficiency at t in units of index count.
+        Equal to 1 + 2 tau, where tau is the correlation time
+        Will always be >= 1
+
+        e.g. If g_i[x] = 4.3, then choosing x as your equilibration point means the every ``ceil(4.3)`` in
+        ``timeseries_to_analyze`` will be decorrelated, so the fully equilibrated decorrelated timeseries would be
+        indexed by [x, x+5, x+10, ..., X) where X is the final point in the ``timeseries_to_analyze``.
+
+        The "index count" in this case is the by count of the ``timeseries_to_analyze`` indices, NOT the ``i_t``
+
+    n_effective_i : np.ndarray of float
+        Number of effective samples by subsampling every ``g_i`` from index t, does include fractional value, so true
+        number of points will be the floor of this output.
+
+        The "index count" in this case is the by count of the ``timeseries_to_analyze`` indices, NOT the ``i_t``
+
+    """
+    # Cast to array if not already
+    series = np.array(timeseries_to_analyze)
+    time_size = series.size
+    set_size = time_size - 1  # Cannot analyze the last entry
+    # Set maximum
+    if max_subset is None or set_size < max_subset:
+        max_subset = set_size
+    g_i = np.ones([max_subset], np.float32)
+    n_effective_i = np.ones([max_subset], np.float32)
+    counter = np.arange(max_subset)
+    i_t = np.floor(counter * time_size / max_subset).astype(int)
+    for i, t in enumerate(i_t):
+        try:
+            g_i[i] = timeseries.statisticalInefficiency(series[t:], fast=fast)
+        except:
+            g_i[i] = (time_size - t + 1)
+        n_effective_i[i] = (time_size - t + 1) / g_i[i]
+    return i_t, g_i, n_effective_i
+
+
+def get_equilibration_data(timeseries_to_analyze, fast=True, max_subset=1000):
     """
     Compute equilibration method given a timeseries
 
     See the ``pymbar.timeseries.detectEquilibration`` function for full documentation
+
+    Parameters
+    ----------
+    timeseries_to_analyze : np.ndarray
+        1-D timeseries to analyze for equilibration
+    max_subset : int or None, optional, default: 1000
+        Maximum number of points in the ``timeseries_to_analyze`` on which to analyze the equilibration on.
+        These are distributed uniformly over the timeseries so the final output will be size max_subset where indices
+        are placed  approximately every ``(len(timeseries_to_analyze) - 1) / max_subset``.
+        The full timeseries is used if the timeseries is smaller than ``max_subset`` or if ``max_subset`` is None
+    fast : bool, optional. Default: True
+        If True, will use faster (but less accurate) method to estimate correlation time
+        passed on to timeseries module.
+
+    Returns
+    -------
+    n_equilibration : int
+        Iteration at which system becomes equilibrated
+        Computed by point which maximizes the number of samples preserved
+    g_t : float
+        Number of indices between each decorelated sample
+    n_effective_max : float
+        How many indices are preserved at most.
+
+    See Also
+    --------
+    get_equilibration_data_per_sample
     """
-    [n_equilibration, g_t, n_effective_max] = timeseries.detectEquilibration(timeseries_to_analyze)
+    warnings.warn("This function will be removed in future versions of YANK due to redundancy, "
+                  "Please use the more general `get_equilibration_data_per_sample` function instead.")
+    i_t, g_i, n_effective_i = get_equilibration_data_per_sample(timeseries_to_analyze, fast=fast, max_subset=max_subset)
+    n_effective_max = n_effective_i.max()
+    i_max = n_effective_i.argmax()
+    n_equilibration = i_t[i_max]
+    g_t = g_i[i_max]
     return n_equilibration, g_t, n_effective_max
-
-
-def get_equilibration_data_per_sample(timeseries_to_analyze, fast=True, nskip=1):
-    """
-    Compute the correlation time and n_effective per sample.
-
-    This is exactly what ``pymbar.timeseries.detectEquilibration`` does, but returns the per sample data
-
-    See the ``pymbar.timeseries.detectEquilibration`` function for full documentation
-    """
-    A_t = timeseries_to_analyze
-    T = A_t.size
-    g_t = np.ones([T - 1], np.float32)
-    Neff_t = np.ones([T - 1], np.float32)
-    for t in range(0, T - 1, nskip):
-        try:
-            g_t[t] = timeseries.statisticalInefficiency(A_t[t:T], fast=fast)
-        except:
-            g_t[t] = (T - t + 1)
-        Neff_t[t] = (T - t + 1) / g_t[t]
-    return g_t, Neff_t
 
 
 def remove_unequilibrated_data(data, number_equilibrated, axis):

--- a/Yank/multistate/utils.py
+++ b/Yank/multistate/utils.py
@@ -103,7 +103,7 @@ def get_decorrelation_time(timeseries_to_analyze):
     return timeseries.statisticalInefficiency(timeseries_to_analyze)
 
 
-def get_equilibration_data_per_sample(timeseries_to_analyze, fast=True, max_subset=1000):
+def get_equilibration_data_per_sample(timeseries_to_analyze, fast=True, max_subset=100):
     """
     Compute the correlation time and n_effective per sample with tuning to how you want your data formatted
 
@@ -119,7 +119,7 @@ def get_equilibration_data_per_sample(timeseries_to_analyze, fast=True, max_subs
     ----------
     timeseries_to_analyze : np.ndarray
         1-D timeseries to analyze for equilibration
-    max_subset : int >= 1 or None, optional, default: 1000
+    max_subset : int >= 1 or None, optional, default: 100
         Maximum number of points in the ``timeseries_to_analyze`` on which to analyze the equilibration on.
         These are distributed uniformly over the timeseries so the final output will be size max_subset where indices
         are placed  approximately every ``(len(timeseries_to_analyze) - 1) / max_subset``.

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -188,7 +188,7 @@ class HealthReportData(object):
             g_t = g_i[i_max]
             self.Neff_maxs[phase_name] = n_effective_max
             self.nequils[phase_name] = n_equilibration
-            self.g_ts[phase_name] = g_t[int(self.nequils[phase_name])]
+            self.g_ts[phase_name] = g_t
             serial['discarded_from_start'] = int(discard_from_start)
             serial['effective_samples'] = float(self.Neff_maxs[phase_name])
             serial['equilibration_samples'] = int(self.nequils[phase_name])
@@ -243,7 +243,7 @@ class HealthReportData(object):
             # SECOND SUBPLOT: g_t trace
             x = i_t
             g = equilibration_figure.add_subplot(sub_grid[1])
-            g.plot(x, g_t)
+            g.plot(x, g_i)
             ylim = g.get_ylim()
             g.vlines(self.nequils[phase_name], *ylim, colors='b', linewidth=4)
             g.set_ylim(*ylim)  # Reset limits in case vlines expanded them

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,8 +6,9 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
-0.21.3 Post-Triage Bugfixes
----------------------------
+0.22.0 RMSD the Casbah
+----------------------
+- Added RMSD Type restraint, requires OpenMM 7.3 or greater to access. You can have older versions of OpenMM, but this feature is unavailable and will raise a graceful error should you attempt to use it.
 - Added more robust last good iteration saving
 - Added more robust restore from checkpoint access
 - Exposed checkpoint interval iterations in ``MultiStateReporter``
@@ -18,7 +19,7 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 - Boresch restraints no longer accept ``standard_state_correction_method`` as an option
 - Added new Haversined Torsion Boresch Torsion (``PeriodicTorsionBoresch``) Boresch-like restraint where functional form of torsion is periodic support more numerically stable energy functions
 - Temporarily pinned NetCDF4 to 1.3.1 until we can fix the bug introduced in 1.4.0 where masked arrays are always returned. This pin will be lifted in future releases.
-- Added RMSD Type restraint, requires OpenMM 7.3 or greater to access. You can have older versions of OpenMM, but this feature is unavailable and will raise a graceful error should you attempt to use it.
+- Changed the timeseries analysis to only consider a maximum number of points on which to evaluate "is this equilibrium" to speed up process.
 
 0.21.2 More Post-Sams Bugfixes
 ------------------------------


### PR DESCRIPTION
The analyze modules now will only consider up to 1000 points by default in the timeseries fed into them for equilibration. This is a tunable parameter.

Added warning for future removal of the `get_equilibration_data` in `multistate.utils`

The mixing stats do not print out by default anymore when you invoke `analyze_phase`

All of these changes should make analysis faster.

Fixes #980