### PR TITLE
Release 0.22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.21.3"  # Primary base version of the build
-DEVBUILD = 0  # Dev build status, Either None or Integer
-ISRELEASED = False  # Are we releasing this as a full cut?
+VERSION = "0.22.0"  # Primary base version of the build
+DEVBUILD = None  # Dev build status, Either None or Integer
+ISRELEASED = True  # Are we releasing this as a full cut?
 __version__ = VERSION
 ########################
 CLASSIFIERS = """\


### PR DESCRIPTION
This PR releases the 0.22 release which includes the RMSD restraint which requires OpenMM 7.3 from the dev branch for now, but does not require OpenMM 7.3 to install.