### PR TITLE
Analyze pulls from Online analysis if present

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -236,7 +236,7 @@ class AlchemicalPhaseFactory(object):
         'randomize_ligand_close_cutoff': 1.5 * unit.angstrom,
         'number_of_equilibration_iterations': 0,
         'equilibration_timestep': 1.0 * unit.femtosecond,
-        'checkpoint_interval': 10,
+        'checkpoint_interval': 200,
         'store_solute_trajectory': True
     }
 

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -75,7 +75,7 @@ class MultiStateReporter(object):
 
         If None, the storage file won't be open on construction, and a call to
         :func:`Reporter.open` will be needed before attempting read/write operations.
-    checkpoint_interval : int >= 1, Default: 10
+    checkpoint_interval : int >= 1, Default: 200
         The frequency at which checkpointing information is written relative to analysis information.
 
         This is a multiple
@@ -99,10 +99,15 @@ class MultiStateReporter(object):
     Attributes
     ----------
     filepath
+    checkpoint_interval
+    is_periodic
+    n_states
+    n_replicas
+    analysis_particle_indices
 
     """
     def __init__(self, storage, open_mode=None,
-                 checkpoint_interval=10, checkpoint_storage=None,
+                 checkpoint_interval=200, checkpoint_storage=None,
                  analysis_particle_indices=()):
         # Handle checkpointing
         if type(checkpoint_interval) != int:
@@ -179,6 +184,11 @@ class MultiStateReporter(object):
     def analysis_particle_indices(self):
         """Return the tuple of indices of the particles which additional information is stored on for analysis"""
         return self._analysis_particle_indices
+
+    @property
+    def checkpoint_interval(self):
+        """Returns the checkpoint interval"""
+        return self._checkpoint_interval
 
     def storage_exists(self, skip_size=False):
         """

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -1147,7 +1147,8 @@ class MultiStateReporter(object):
         Parameters
         ----------
         iteration : int or None
-            Iteration to fetch data at
+            Iteration to fetch data at. If ``None``, then assumes static data and will attempt to get the entry with the
+            name written assuming no iteration-specific data.
         keys : str
             Variables to fetch data from
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -11,6 +11,7 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 - Online analysis will always run by default now, with no target error, run every checkpoint interval, and with at least 200 iterations
 - Online analysis can now be a set to the checkpoint interval by setting ``online_analysis_interval = "checkpoint"`` in the ``MultiStateSampler``
 - Checkpoint interval increased from default of 10 to 200
+- Analysis now uses the online-analysis data if available by default
 
 0.22.0 RMSD the Casbah
 ----------------------

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,12 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.22.1 Online Analysis Default
+------------------------------
+- Online analysis will always run by default now, with no target error, run every checkpoint interval, and with at least 200 iterations
+- Online analysis can now be a set to the checkpoint interval by setting ``online_analysis_interval = "checkpoint"`` in the ``MultiStateSampler``
+- Checkpoint interval increased from default of 10 to 200
+
 0.22.0 RMSD the Casbah
 ----------------------
 

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -633,7 +633,7 @@ Valid Options (2.0 * femtosecond): <Quantity Time> [1]_
 .. code-block:: yaml
 
    options:
-     checkpoint_interval: 10
+     checkpoint_interval: 200
 
 Specify how frequently checkpoint information should be saved to file relative to iterations. YANK simulations can be
 resumed only from checkpoints, so if something crashes, up to ``checkpoint_interval`` worth of iterations will be lost
@@ -645,7 +645,7 @@ you will get. If you want to write a checkpoint every iteration, set this to ``1
 Checkpoint information includes things like full coordinates and box vectors, as well as more static information such
 as metadata, simulation options, and serialized thermodynamic states.
 
-Valid Options (10): <Integer ``>= 1``>
+Valid Options (200): <Integer ``>= 1``>
 
 
 

--- a/docs/yamlpages/samplers.rst
+++ b/docs/yamlpages/samplers.rst
@@ -136,9 +136,11 @@ Ratio estimate for the free energy is calculated and the error is computed. Some
 speed up future calculations, but this operation will still slow down as more iterations are added. We recommend
 choosing an interval of *at least* 100, if not more.
 
-If set to ``null`` (default), then online analysis is not run.
+If set to ``checkpoint``, then the online analysis is run every :ref:`yaml_options_checkpoint_interval`
 
-Valid Options (``null``): ``null`` or <Int >= 1>
+If set to ``null``, then online analysis is not run.
+
+Valid Options (``checkpoint``): ``checkpoint``, ``null``, or <Int >= 1>
 
 
 .. rst-class:: html-toggle
@@ -163,7 +165,7 @@ is never zero except in very rare cases, so your simulation may never converge i
 
 If :ref:`yaml_samplers_online_analysis_interval` is ``null``, this option does nothing.
 
-Valid Options (0.2): <Float >= 0>
+Valid Options (0.0): <Float >= 0>
 
 
 
@@ -186,13 +188,14 @@ Number of iterations that are skipped at the beginning of the simulation before 
 a speed option since most of the initial iterations will be either equilibration or under sampled. We recommend choosing
 an initial number that is *at least* one or two :ref:`yaml_samplers_online_analysis_interval`'s for speed's sake.
 
-The first iteration at which online analysis is performed is not affected by this number and always tracked as the
-modulo of the current iteration. E.g. if you have ``online_analysis_interval: 100`` and
-``online_analysis_minimum_iterations: 150``, online analysis would happen at iteration 200 first, not iteration 250.
+This number is only the threshold above when online analysis is run, and the iteration at which first analysis is
+performed is tracked as the modulo of the current iteration.
+E.g. if you have ``online_analysis_interval: 100`` and
+``online_analysis_minimum_iterations: 150``, online analysis would happen at iteration 200, not iteration 250.
 
 If :ref:`yaml_samplers_online_analysis_interval` is ``null``, this option does nothing.
 
-Valid Options (50): <Int >=1>
+Valid Options (200): <Int >=1>
 
 
 


### PR DESCRIPTION
This is the realization of #979. It is not everything on that list due to some practical considerations, but here is the full list of things changed:

* Online analysis interval can now be set to checkpoint interval 
* Online analysis runs by default
* Online analysis min iterations now 200
* Checkpoint interval now 200
* Analysis now tries to get the online data by default 
* Online analysis does not attempt unbias harmonic restraints, this can be relaxed when we switch to CustomCVForces for restraint distances

Things not implemented from the issue list:
* Do not allow users to specify where the reference states are in the YAML
* Only uses the f_k as the initial MBAR guess to speed up the process, it does not use anything else. MBAR still has to be solved, but should be much faster with the online guess than not. Generalizing this so each component specifically reads entries in the online data would require re-engineering the entire analysis and online code + making users specify the reference states.

Fix #979