### PR TITLE
 Fix alchemical Ions were part of ligand

### DIFF
--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -116,7 +116,7 @@ class Topography(object):
         of the atom indices.
 
         """
-        return self._ligand_atoms
+        return copy.deepcopy(self._ligand_atoms)
 
     @ligand_atoms.setter
     def ligand_atoms(self, value):
@@ -169,7 +169,7 @@ class Topography(object):
         built from common solvent residue names.
 
         """
-        return self._solvent_atoms
+        return copy.deepcopy(self._solvent_atoms)
 
     @solvent_atoms.setter
     def solvent_atoms(self, value):
@@ -324,6 +324,7 @@ class Topography(object):
 
         """
 
+        selection = copy.deepcopy(selection)
         # Handle subset. Define a subset topology to manipulate, then define a common call to convert subset atom
         # into absolute atom
         if subset is not None:

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,10 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.22.2 Topography Property Copy
+------------------------------
+- Critical bug fix for Topology where ions of charged ligands were considered part of the ligand
+
 0.22.1 Online Analysis Default
 ------------------------------
 - Online analysis will always run by default now, with no target error, run every checkpoint interval, and with at least 200 iterations

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -7,7 +7,7 @@ This section features and improvements of note in each release.
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
 0.22.2 Topography Property Copy
-------------------------------
+-------------------------------
 - Critical bug fix for Topology where ions of charged ligands were considered part of the ligand
 
 0.22.1 Online Analysis Default


### PR DESCRIPTION
Topography ligand_atoms` and solvent_atoms` were returning the internal object, meaning counter-ions added on behalf of the ligand were being treated as the ligand in `top.ligand_atoms`

@andrrizzi and I have determined this should not have affected any of the SAMPL or APR calculations we have, however, this will cause the center of mass in Harmonic based restraints to be shifted slightly. Unbiasing the restraint corrects for this.

The fix is that these two properties now return copies of the internal objects they are protecting. The trade off is you will be unable to set `top.ligand_atoms[i] = x`, although this will not raise an error. You will need to set the whole property with `top.ligand_atoms = X` instead.
