### PR TITLE
Easy fixes for Milestone 0.22.3

### DIFF
--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1433,6 +1433,10 @@ class MultiStateSampler(object):
             # wasn't below the target threshold before, it won't stop MultiStateSampler now.
             bump_error_counter = True
             self._online_error_bank.append(e)
+            if len(self._online_error_bank) > 6:
+                # Cache only the last set
+                self._online_error_bank.pop(0)
+            free_energy = None
         else:
             self._last_mbar_f_k = mbar.f_k
             free_energy = free_energy[idx, jdx]
@@ -1447,12 +1451,13 @@ class MultiStateSampler(object):
         # Raise an exception after 6 times MBAR gave an error.
         if bump_error_counter:
             self._online_error_trap_counter += 1
-            if self._online_error_trap_counter >= 6:
+            # Will never be true, but code left in place in case we change logic to allow again
+            if self._online_error_trap_counter >= np.inf:
                 logger.debug("Thrown MBAR Errors:")
                 for err in self._online_error_bank:
                     logger.debug(str(err))
                 raise RuntimeError("Online Analysis has failed too many times! Please "
-                                   "check the latest logs to see the thrown errors!")
+                                   "check the latest logs to see the latest thrown errors!")
             # Don't write out the free energy in case of error.
             return
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -9,6 +9,7 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 0.22.2 Topography Property Copy
 -------------------------------
 - Critical bug fix for Topology where ions of charged ligands were considered part of the ligand
+- Online analysis MBAR failures can no longer halt simulations
 
 0.22.1 Online Analysis Default
 ------------------------------

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -172,11 +172,6 @@ Detailed Options List
     .. note:: All options under here are global to the other samplers
 
     * :ref:`yaml_samplers_locality`
-    * :ref:`yaml_samplers_online_analysis_parameters`
-
-      * :ref:`yaml_samplers_online_analysis_interval`
-      * :ref:`yaml_samplers_online_analysis_target_error`
-      * :ref:`yaml_samplers_online_analysis_minimum_iterations`
 
   * :ref:`yaml_samplers_repexsampler`
 
@@ -187,6 +182,12 @@ Detailed Options List
     * :ref:`yaml_samplers_state_update_scheme`
     * :ref:`yaml_samplers_gamm0`
     * :ref:`yaml_samplers_flatness_threshold`
+
+  * :ref:`yaml_samplers_online_analysis_parameters`
+
+    * :ref:`yaml_samplers_online_analysis_interval`
+    * :ref:`yaml_samplers_online_analysis_target_error`
+    * :ref:`yaml_samplers_online_analysis_minimum_iterations`
 
 * :doc:`protocols <protocols>`
 

--- a/docs/yamlpages/samplers.rst
+++ b/docs/yamlpages/samplers.rst
@@ -103,102 +103,6 @@ Valid Options: [``null``]/``int`` > 0
    Later, we want to allow more complex neighborhoods to be specified via lists of lists.
 
 
-
-.. _yaml_samplers_online_analysis_parameters:
-
-.. rst-class:: html-toggle
-
-Online Analysis Parameters
-""""""""""""""""""""""""""
-
-YANK's samplers also supports an online free energy analysis framework which allows running simulations up to some
-target error in the free energy. Note that this will pause the simulation to run this analysis. The longer the
-simulation gets, the slower this process becomes.
-
-
-.. _yaml_samplers_online_analysis_interval:
-
-.. rst-class:: html-toggle
-
-``online_analysis_interval``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code-block:: yaml
-
-   samplers:
-        {UserDefinedSamplerName}:
-            type: MultiStateSampler
-            mcmc_moves: {MCMCName}
-            number_of_iterations: {NumberOfIterations}
-            online_analysis_interval: 100
-
-Both the toggle and iteration count between online analysis operations. Every interval, the Multistate Bennet Acceptance
-Ratio estimate for the free energy is calculated and the error is computed. Some data is preserved each iteration to
-speed up future calculations, but this operation will still slow down as more iterations are added. We recommend
-choosing an interval of *at least* 100, if not more.
-
-If set to ``checkpoint``, then the online analysis is run every :ref:`yaml_options_checkpoint_interval`
-
-If set to ``null``, then online analysis is not run.
-
-Valid Options (``checkpoint``): ``checkpoint``, ``null``, or <Int >= 1>
-
-
-.. rst-class:: html-toggle
-
-.. _yaml_samplers_online_analysis_target_error:
-
-``online_analysis_target_error``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code-block:: yaml
-
-   samplers:
-        {UserDefinedSamplerName}:
-            type: MultiStateSampler
-            mcmc_moves: {MCMCName}
-            number_of_iterations: {NumberOfIterations}
-            online_analysis_target_error: 1.0
-
-The target error for the online analysis measured in kT per phase. Once the free energy is at or below this value,
-the phase will be considered complete.
-This value should be a number greater than 0, even though 0 is a valid option. The error free energy estimate between states
-is never zero except in very rare cases, so your simulation may never converge if you set this to 0.
-
-If :ref:`yaml_samplers_online_analysis_interval` is ``null``, this option does nothing.
-
-Valid Options (0.0): <Float >= 0>
-
-
-
-.. _yaml_samplers_online_analysis_minimum_iterations:
-
-.. rst-class:: html-toggle
-
-``online_analysis_minimum_iterations``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code-block:: yaml
-
-   samplers:
-        {UserDefinedSamplerName}:
-            type: MultiStateSampler
-            mcmc_moves: {MCMCName}
-            number_of_iterations: {NumberOfIterations}
-            online_analysis_minimum_iterations: 50
-
-Number of iterations that are skipped at the beginning of the simulation before online analysis is attempted. This is
-a speed option since most of the initial iterations will be either equilibration or under sampled. We recommend choosing
-an initial number that is *at least* one or two :ref:`yaml_samplers_online_analysis_interval`'s for speed's sake.
-
-This number is only the threshold above when online analysis is run, and the iteration at which first analysis is
-performed is tracked as the modulo of the current iteration.
-E.g. if you have ``online_analysis_interval: 100`` and
-``online_analysis_minimum_iterations: 150``, online analysis would happen at iteration 200, not iteration 250.
-
-If :ref:`yaml_samplers_online_analysis_interval` is ``null``, this option does nothing.
-
-Valid Options (200): <Int >=1>
-
-
-
 |
 |
 
@@ -372,3 +276,101 @@ By default the log target probabilities are all equal, resulting in SAMS attempt
 sample all thermodynamic states.
 
 Valid Options (0.2): float > 0
+
+|
+|
+
+.. _yaml_samplers_online_analysis_parameters:
+
+.. rst-class:: html-toggle
+
+Online Analysis Parameters
+--------------------------
+
+YANK's samplers also supports an online free energy analysis framework which allows running simulations up to some
+target error in the free energy. Note that this will pause the simulation to run this analysis. The longer the
+simulation gets, the slower this process becomes. This is available for all samplers.
+
+
+.. _yaml_samplers_online_analysis_interval:
+
+.. rst-class:: html-toggle
+
+``online_analysis_interval``
+""""""""""""""""""""""""""""
+.. code-block:: yaml
+
+   samplers:
+        {UserDefinedSamplerName}:
+            type: {SamplerOfChoice}
+            mcmc_moves: {MCMCName}
+            number_of_iterations: {NumberOfIterations}
+            online_analysis_interval: 100
+
+Both the toggle and iteration count between online analysis operations. Every interval, the Multistate Bennet Acceptance
+Ratio estimate for the free energy is calculated and the error is computed. Some data is preserved each iteration to
+speed up future calculations, but this operation will still slow down as more iterations are added. We recommend
+choosing an interval of *at least* 100, if not more.
+
+If set to ``checkpoint``, then the online analysis is run every :ref:`yaml_options_checkpoint_interval`
+
+If set to ``null``, then online analysis is not run.
+
+Valid Options (``checkpoint``): ``checkpoint``, ``null``, or <Int >= 1>
+
+
+.. rst-class:: html-toggle
+
+.. _yaml_samplers_online_analysis_target_error:
+
+``online_analysis_target_error``
+""""""""""""""""""""""""""""""""
+.. code-block:: yaml
+
+   samplers:
+        {UserDefinedSamplerName}:
+            type: {SamplerOfChoice}
+            mcmc_moves: {MCMCName}
+            number_of_iterations: {NumberOfIterations}
+            online_analysis_target_error: 1.0
+
+The target error for the online analysis measured in kT per phase. Once the free energy is at or below this value,
+the phase will be considered complete.
+This value should be a number greater than 0, even though 0 is a valid option. The error free energy estimate between states
+is never zero except in very rare cases, so your simulation may never converge if you set this to 0.
+
+If :ref:`yaml_samplers_online_analysis_interval` is ``null``, this option does nothing.
+
+Valid Options (0.0): <Float >= 0>
+
+
+
+.. _yaml_samplers_online_analysis_minimum_iterations:
+
+.. rst-class:: html-toggle
+
+``online_analysis_minimum_iterations``
+""""""""""""""""""""""""""""""""""""""
+.. code-block:: yaml
+
+   samplers:
+        {UserDefinedSamplerName}:
+            type: {SamplerOfChoice}
+            mcmc_moves: {MCMCName}
+            number_of_iterations: {NumberOfIterations}
+            online_analysis_minimum_iterations: 50
+
+Number of iterations that are skipped at the beginning of the simulation before online analysis is attempted. This is
+a speed option since most of the initial iterations will be either equilibration or under sampled. We recommend choosing
+an initial number that is *at least* one or two :ref:`yaml_samplers_online_analysis_interval`'s for speed's sake.
+
+This number is only the threshold above when online analysis is run, and the iteration at which first analysis is
+performed is tracked as the modulo of the current iteration.
+E.g. if you have ``online_analysis_interval: 100`` and
+``online_analysis_minimum_iterations: 150``, online analysis would happen at iteration 200, not iteration 250.
+
+If :ref:`yaml_samplers_online_analysis_interval` is ``null``, this option does nothing.
+
+Valid Options (200): <Int >=1>
+
+


### PR DESCRIPTION
Easy fixes:

Fixes #999 by preventing the online analysis MBAR failure accumulation from stopping the simulation (will still fail if something else goes catastrophically wrong)

Fixes #1000 by doing some doc restructuring. There is a better fix which involves figuring out how to do recursive function calls in the javascript... I decided to do the easier one.