### PR TITLE
Add option to force full trajectory analysis

### DIFF
--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -30,8 +30,8 @@ usage = """
 YANK analyze
 
 Usage:
-  yank analyze (-s STORE | --store=STORE) [--skipunbiasing] [--distcutoff=DISTANCE] [--energycutoff=ENERGY] [-v | --verbose]
-  yank analyze report (-s STORE | --store=STORE) [-e | --serial] [--skipunbiasing] [--distcutoff=DISTANCE] [--energycutoff=ENERGY] (-o REPORT | --output=REPORT)
+  yank analyze (-s STORE | --store=STORE) [--skipunbiasing] [--distcutoff=DISTANCE] [--energycutoff=ENERGY] [-v | --verbose] [--fulltraj]
+  yank analyze report (-s STORE | --store=STORE) (-o REPORT | --output=REPORT) [-e | --serial] [--skipunbiasing] [--distcutoff=DISTANCE] [--energycutoff=ENERGY] [--fulltraj]
   yank analyze extract-trajectory --netcdf=FILEPATH [--checkpoint=FILEPATH ] (--state=STATE | --replica=REPLICA) --trajectory=FILEPATH [--start=START_FRAME] [--skip=SKIP_FRAME] [--end=END_FRAME] [--nosolvent] [--discardequil] [--imagemol] [-v | --verbose]
 
 Description:
@@ -82,6 +82,10 @@ Extract Trajectory Options:
 
 General Options:
   -v, --verbose                 Print verbose output
+  --fulltraj                    Force ALL analysis run from this command to rely on the full trajectory and not do any 
+                                automatic equilibration detection or decorrelation subsampling. Although the 
+                                equilibration and correlation times will still be computed, no calculation depending on 
+                                them will use this information.
 
 """
 
@@ -118,6 +122,8 @@ def extract_analyzer_kwargs(args, quantities_as_strings=False):
         else:
             distcutoff = float(args['--distcutoff']) * unit.angstroms
         analyzer_kwargs['restraint_distance_cutoff'] = distcutoff
+    if args['--fulltraj']:
+        analyzer_kwargs['use_full_trajectory'] = True
     return analyzer_kwargs
 
 

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -491,6 +491,16 @@ class PhaseAnalyzer(ABC):
 
         If no online data is found, this setting has no effect
 
+    use_full_trajectory : bool, optional, Default: False
+        Force the analysis to use the full trajectory when automatically computing equilibration and decorrelation.
+
+        Normal behavior (when this is False) is to discard the initial trajectory due to automatic equilibration
+        detection, and then subsample that data to generate decorelated samples. Setting this to ``True`` ignores
+        this effect, even if the equilibration data is computed.
+
+        This can be changed after the ``PhaseAnalyzer`` has been created to re-compute properties with or without
+        the full trajectory.
+
     registry : ObservablesRegistry instance
         Instanced ObservablesRegistry with all observables implemented through a ``get_X`` function classified and
         registered. Any cross-phase analysis must use the same instance of an ObservablesRegistry
@@ -508,6 +518,7 @@ class PhaseAnalyzer(ABC):
     reporter
     registry
     use_online_data
+    use_full_trajectory
 
     See Also
     --------
@@ -517,7 +528,8 @@ class PhaseAnalyzer(ABC):
     def __init__(self, reporter, name=None, reference_states=(0, -1),
                  max_n_iterations=None, analysis_kwargs=None,
                  registry=default_observables_registry,
-                 use_online_data=True):
+                 use_online_data=True,
+                 use_full_trajectory=False):
         """
         The reporter provides the hook into how to read the data, all other options control where differences are
         measured from and how each phase interfaces with other phases.
@@ -553,10 +565,14 @@ class PhaseAnalyzer(ABC):
         self.clear()
         self.max_n_iterations = max_n_iterations
 
-        # Check the onlie data
+        # Use full trajectory store or not
+        self.use_full_trajectory = use_full_trajectory
+
+        # Check the online data
         self._online_data = None  # Init the object
         self._use_online_data = use_online_data
         self._read_online_data_if_present()
+
 
     def clear(self):
         """Reset all cached objects.
@@ -779,6 +795,14 @@ class PhaseAnalyzer(ABC):
             new_value = instance.n_iterations
         return new_value
 
+    use_full_trajectory = CachedProperty('use_full_trajectory', check_changes=True)
+
+    @use_full_trajectory.validator
+    def use_full_trajectory(self, _, new_value):
+        if type(new_value) is not bool:
+            raise ValueError("use_full_trajectory must be a boolean!")
+        return new_value
+
     _extra_analysis_kwargs = CachedProperty('_extra_analysis_kwargs', check_changes=True)
 
     # -------------------------------------------------------------------------
@@ -791,7 +815,7 @@ class PhaseAnalyzer(ABC):
 
         Returns
         -------
-       sampled_energy_matrix : np.ndarray of shape [n_replicas, n_states, n_iterations]
+        sampled_energy_matrix : np.ndarray of shape [n_replicas, n_states, n_iterations]
             Potential energy matrix of the sampled states.
         unsampled_energy_matrix : np.ndarray of shape [n_replicas, n_unsamped_states, n_iterations]
             Potential energy matrix of the unsampled states.
@@ -1410,11 +1434,12 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
         logger.info("Assembling uncorrelated energies...")
 
-        for i, energies in enumerate(energy_data):
-            # Discard equilibration iterations.
-            energies = utils.remove_unequilibrated_data(energies, number_equilibrated, -1)
-            # Subsample along the decorrelation data.
-            energy_data[i] = utils.subsample_data_along_axis(energies, g_t, -1)
+        if not self.use_full_trajectory:
+            for i, energies in enumerate(energy_data):
+                # Discard equilibration iterations.
+                energies = utils.remove_unequilibrated_data(energies, number_equilibrated, -1)
+                # Subsample along the decorrelation data.
+                energy_data[i] = utils.subsample_data_along_axis(energies, g_t, -1)
         sampled_energy_matrix, unsampled_energy_matrix, neighborhood, replicas_state_indices = energy_data
 
         # Initialize the MBAR matrices in ln form.
@@ -1964,7 +1989,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
     _decorrelated_state_indices_ln = CachedProperty(
         name='decorrelated_state_indices_ln',
-        dependencies=['equilibration_data'],
+        dependencies=['equilibration_data', 'use_full_trajectory'],
     )
 
     @_decorrelated_state_indices_ln.default
@@ -1990,7 +2015,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
     _decorrelated_u_ln = CachedProperty(
         name='decorrelated_u_ln',
-        dependencies=['equilibration_data'],
+        dependencies=['equilibration_data', 'use_full_trajectory'],
     )
 
     @_decorrelated_u_ln.default
@@ -1999,7 +2024,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
     _decorrelated_N_l = CachedProperty(
         name='decorrelated_N_l',
-        dependencies=['equilibration_data'],
+        dependencies=['equilibration_data', 'use_full_trajectory'],
     )
 
     @_decorrelated_N_l.default
@@ -2009,7 +2034,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
     _unbiased_decorrelated_u_ln = CachedProperty(
         name='unbiased_decorrelated_u_ln',
         dependencies=['unbias_restraint', 'restraint_energy_cutoff', 'restraint_distance_cutoff',
-                      'decorrelated_state_indices_ln', 'decorrelated_u_ln', 'decorrelated_N_l'],
+                      'decorrelated_state_indices_ln', 'decorrelated_u_ln', 'decorrelated_N_l', 'use_full_trajectory'],
     )
 
     @_unbiased_decorrelated_u_ln.default
@@ -2019,7 +2044,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
     _unbiased_decorrelated_N_l = CachedProperty(
         name='unbiased_decorrelated_N_l',
         dependencies=['unbias_restraint', 'restraint_energy_cutoff', 'restraint_distance_cutoff',
-                      'decorrelated_state_indices_ln', 'decorrelated_u_ln', 'decorrelated_N_l'],
+                      'decorrelated_state_indices_ln', 'decorrelated_u_ln', 'decorrelated_N_l', 'use_full_trajectory'],
     )
 
     @_unbiased_decorrelated_N_l.default
@@ -2029,7 +2054,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
     mbar = CachedProperty(
         name='mbar',
         dependencies=['unbiased_decorrelated_u_ln', 'unbiased_decorrelated_N_l',
-                      '_extra_analysis_kwargs'],
+                      '_extra_analysis_kwargs', 'use_full_trajectory'],
     )
 
     @mbar.default

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -2034,7 +2034,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
     _unbiased_decorrelated_u_ln = CachedProperty(
         name='unbiased_decorrelated_u_ln',
         dependencies=['unbias_restraint', 'restraint_energy_cutoff', 'restraint_distance_cutoff',
-                      'decorrelated_state_indices_ln', 'decorrelated_u_ln', 'decorrelated_N_l', 'use_full_trajectory'],
+                      'decorrelated_state_indices_ln', 'decorrelated_u_ln', 'decorrelated_N_l'],
     )
 
     @_unbiased_decorrelated_u_ln.default
@@ -2044,7 +2044,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
     _unbiased_decorrelated_N_l = CachedProperty(
         name='unbiased_decorrelated_N_l',
         dependencies=['unbias_restraint', 'restraint_energy_cutoff', 'restraint_distance_cutoff',
-                      'decorrelated_state_indices_ln', 'decorrelated_u_ln', 'decorrelated_N_l', 'use_full_trajectory'],
+                      'decorrelated_state_indices_ln', 'decorrelated_u_ln', 'decorrelated_N_l'],
     )
 
     @_unbiased_decorrelated_N_l.default
@@ -2054,7 +2054,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
     mbar = CachedProperty(
         name='mbar',
         dependencies=['unbiased_decorrelated_u_ln', 'unbiased_decorrelated_N_l',
-                      '_extra_analysis_kwargs', 'use_full_trajectory'],
+                      '_extra_analysis_kwargs'],
     )
 
     @mbar.default
@@ -2079,6 +2079,8 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
     @property
     def _decorrelated_iterations(self):
         """list of int: the indices of the decorrelated iterations truncated to max_n_iterations."""
+        if self.use_full_trajectory:
+            return np.arange(self.max_n_iterations + 1, dtype=int)
         equilibrium_iterations = np.array(range(self.n_equilibration_iterations, self.max_n_iterations + 1))
         decorrelated_iterations_indices = timeseries.subsampleCorrelatedData(equilibrium_iterations,
                                                                              self.statistical_inefficiency)

--- a/Yank/reports/YANK_Health_Report_Template.ipynb
+++ b/Yank/reports/YANK_Health_Report_Template.ipynb
@@ -443,7 +443,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -64,11 +64,15 @@ class HealthReportData(object):
             phases_names.append(phase)
             signs[phase] = sign
             storage_path = os.path.join(store_directory, phase + '.nc')
-            analyzers[phase] = analyze.get_analyzer(storage_path)
+            analyzers[phase] = analyze.get_analyzer(storage_path, **analyzer_kwargs)
         self.phase_names = phases_names
         self.signs = signs
         self.analyzers = analyzers
         self.nphases = len(phases_names)
+        # Additional data
+        self.use_full_trajectory = False
+        if 'use_full_trajectory' in analyzer_kwargs:
+            self.use_full_trajectory = bool(analyzer_kwargs['use_full_trajectory'])
         # Assign flags for other sections along with their global variables
         # General Data
         self._general_run = False
@@ -692,12 +696,14 @@ class HealthReportData(object):
                     i_max = n_effective_i.argmax()
                     number_equilibrated = i_t[i_max]
                     g_t = g_i[i_max]
-                    energy_sub = analyze.multistate.utils.remove_unequilibrated_data(energy_sub,
-                                                                                     number_equilibrated,
-                                                                                     -1)
-                    state_sub = analyze.multistate.utils.remove_unequilibrated_data(state_sub, number_equilibrated, -1)
-                    energy_sub = analyze.multistate.utils.subsample_data_along_axis(energy_sub, g_t, -1)
-                    state_sub = analyze.multistate.utils.subsample_data_along_axis(state_sub, g_t, -1)
+                    if not self.use_full_trajectory:
+                        energy_sub = analyze.multistate.utils.remove_unequilibrated_data(energy_sub,
+                                                                                         number_equilibrated,
+                                                                                         -1)
+                        state_sub = analyze.multistate.utils.remove_unequilibrated_data(state_sub,
+                                                                                        number_equilibrated, -1)
+                        energy_sub = analyze.multistate.utils.subsample_data_along_axis(energy_sub, g_t, -1)
+                        state_sub = analyze.multistate.utils.subsample_data_along_axis(state_sub, g_t, -1)
                     samples_per_state = np.zeros([n_states], dtype=int)
                     unique_sampled_states, counts = np.unique(state_sub, return_counts=True)
                     # Assign those counts to the correct range of states

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -10,6 +10,7 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 -------------------------------
 - Critical bug fix for Topology where ions of charged ligands were considered part of the ligand
 - Online analysis MBAR failures can no longer halt simulations
+- Added ability for analyze CLI (``--fulltraj``) and API (``use_full_trajectory=True``) to force use the full trajectory
 
 0.22.1 Online Analysis Default
 ------------------------------


### PR DESCRIPTION
Added CLI and API options to force analyzer to use the full trajectory instead of the auto-equilibration and decorelation of the trajectory to compute the free energy.

Decorrelation data can still be computed, but any thing which creates the MBAR object or anything from that automatically will use the full trajectory

