### PR TITLE
Fix error that occurs when DSL selection for ligand is "(mass > 1.5)"

### DIFF
--- a/Yank/cli.py
+++ b/Yank/cli.py
@@ -34,7 +34,6 @@ Commands:
   selftest                      Run selftests
   platforms                     List available OpenMM platforms.
   script                        Set up and run free energy calculations from a YAML script.
-  kinetics                      Initiate kinetics trajectories from checkpoint snapshots for TRAM analysis
   status                        Get the current status
   analyze                       Analyze data OR extract trajectory from a NetCDF file in a common format.
   cleanup                       Clean up (delete) run files.

--- a/Yank/cli.py
+++ b/Yank/cli.py
@@ -34,6 +34,7 @@ Commands:
   selftest                      Run selftests
   platforms                     List available OpenMM platforms.
   script                        Set up and run free energy calculations from a YAML script.
+  kinetics                      Initiate kinetics trajectories from checkpoint snapshots for TRAM analysis
   status                        Get the current status
   analyze                       Analyze data OR extract trajectory from a NetCDF file in a common format.
   cleanup                       Clean up (delete) run files.
@@ -56,7 +57,7 @@ def main(argv=None):
 
     dispatched = False  # Flag set to True if we have correctly dispatched a command.
     # Build the list of commands based on the <command>.py modules in the ./commands folder
-    command_list = [module[0] for module in inspect.getmembers(commands, inspect.ismodule)]         
+    command_list = [module[0] for module in inspect.getmembers(commands, inspect.ismodule)]
 
     # Handle simple arguments.
     if args['--cite']:
@@ -71,7 +72,7 @@ def main(argv=None):
         command_args = docopt(command_usage, version=version.version, argv=argv)
         # Execute Command
         dispatched = getattr(commands, command).dispatch(command_args)
-        
+
     # If unsuccessful, print usage and exit with an error.
     if not dispatched:
         print(usage)

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -341,7 +341,7 @@ def test_restraint_dsl_selection():
 
     restraint_selection_template(topography_ligand_atoms='resname B2',
                                  restrained_receptor_atoms="(resname CUC) and (name =~ 'O[0-9]+')",
-                                 restrained_ligand_atoms='(mass > 1.5) and (resname B2)')
+                                 restrained_ligand_atoms='(mass > 0.5) and (resname B2)')
 
 
 def test_restraint_region_selection():

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -339,6 +339,10 @@ def test_restraint_dsl_selection():
                                  restrained_receptor_atoms="(resname CUC) and (name =~ 'O[0-9]+')",
                                  restrained_ligand_atoms='resname B2')
 
+    restraint_selection_template(topography_ligand_atoms='resname B2',
+                                 restrained_receptor_atoms="(resname CUC) and (name =~ 'O[0-9]+')",
+                                 restrained_ligand_atoms='(mass > 1.5) and (resname B2)')
+
 
 def test_restraint_region_selection():
     """Test that the region atom selection works as expected"""

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -423,7 +423,7 @@ class Topography(object):
                     # The self here is inherited from the outer scope
                     region_output_unmapped = list(self._get_region_set(region_string))
                     region_output = [item for item in region_output_unmapped if item in atom_map]
-                except (SyntaxError, ValueError) as e:
+                except (SyntaxError, ValueError, TypeError) as e:
                     # Make this a local variable
                     region_error = e
                     region_output = None


### PR DESCRIPTION
If `restrained_ligand_atoms` is set to `(mass > 1.5)`, the following error occurs for me (Python 3.6, yank 0.22.1):
```
NoneType: None
Traceback (most recent call last):
  File "/home/chodera/miniconda/bin/yank", line 11, in <module>
    load_entry_point('yank==0.22.1', 'console_scripts', 'yank')()
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/cli.py", line 73, in main
    dispatched = getattr(commands, command).dispatch(command_args)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/commands/script.py", line 136, in dispatch
    yaml_builder.run_experiments()
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/experiment.py", line 793, in run_experiments
    send_results_to='all')
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/mpi.py", line 520, in distribute
    *other_args, **kwargs)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/mpi.py", line 373, in exec_tasks
    raise error
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/mpi.py", line 358, in exec_tasks
    results.append(task(distributed_arg, *other_args, **kwargs))
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/experiment.py", line 3093, in _run_experiment
    built_experiment.run(n_iterations=switch_experiment_interval)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/experiment.py", line 450, in run
    alchemical_phase = phase.initialize_alchemical_phase()
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/experiment.py", line 316, in initialize_alchemical_phase
    alchemical_phase = self.create_alchemical_phase()
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/experiment.py", line 302, in create_alchemical_phase
    **create_kwargs)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/yank.py", line 976, in create
    sampler_states[0], topography)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/restraints.py", line 2749, in determine_missing_parameters
    self._pick_restrained_atoms(topography)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/restraints.py", line 2808, in _pick_restrained_atoms
    defined_atoms = atom_selector.compute_atom_intersect(atoms, top_key)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/restraints.py", line 459, in compute_atom_intersect
    return compute_atom_set(input_atoms)
  File "/home/chodera/miniconda/lib/python3.6/functools.py", line 803, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/restraints.py", line 450, in compute_atom_str
    output = topography.select(input_string, as_set=False)  # Preserve order
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/yank.py", line 509, in select
    selection_output, errors = selector.select(selection)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/yank.py", line 423, in select
    region_output_unmapped = list(self._get_region_set(region_string))
  File "/home/chodera/miniconda/lib/python3.6/site-packages/yank/yank.py", line 605, in _get_region_set
    parsed_output = mmtools.utils.math_eval(region_set_string, variables=variables)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/openmmtools/utils.py", line 324, in math_eval
    return _math_eval(ast.parse(expression, mode='eval').body)
  File "/home/chodera/miniconda/lib/python3.6/site-packages/openmmtools/utils.py", line 316, in _math_eval
    raise TypeError('Cannot parse expression: {}'.format(expression))
TypeError: Group 16/16 Node 1/1: Cannot parse expression: (mass > 1.5)
```
I've added `TypeError` to the list of exceptions that `SelectRegion` catches in order to allow this to proceed onto the `SelectDsl` selector.