### PR TITLE
Reduce the number of calls to NetCDF writing in SamplerState storage

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -236,7 +236,7 @@ class AlchemicalPhaseFactory(object):
         'randomize_ligand_close_cutoff': 1.5 * unit.angstrom,
         'number_of_equilibration_iterations': 0,
         'equilibration_timestep': 1.0 * unit.femtosecond,
-        'checkpoint_interval': 200,
+        'checkpoint_interval': 50,
         'store_solute_trajectory': True
     }
 

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -75,7 +75,7 @@ class MultiStateReporter(object):
 
         If None, the storage file won't be open on construction, and a call to
         :func:`Reporter.open` will be needed before attempting read/write operations.
-    checkpoint_interval : int >= 1, Default: 200
+    checkpoint_interval : int >= 1, Default: 50
         The frequency at which checkpointing information is written relative to analysis information.
 
         This is a multiple
@@ -107,7 +107,7 @@ class MultiStateReporter(object):
 
     """
     def __init__(self, storage, open_mode=None,
-                 checkpoint_interval=200, checkpoint_storage=None,
+                 checkpoint_interval=50, checkpoint_storage=None,
                  analysis_particle_indices=()):
         # Handle checkpointing
         if type(checkpoint_interval) != int:

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -1545,8 +1545,10 @@ class MultiStateReporter(object):
         storage = self._storage_dict[storage_file]
         # Check if the schema must be initialized, do this regardless of the checkpoint_interval for consistency
         is_periodic = True if (sampler_states[0].box_vectors is not None) else False
-        self._initialize_sampler_variables_on_file(storage, sampler_states[0].n_particles,
-                                                   len(sampler_states), is_periodic,
+        n_particles = sampler_states[0].n_particles
+        n_replicas = len(sampler_states)
+        self._initialize_sampler_variables_on_file(storage, n_particles,
+                                                   n_replicas, is_periodic,
                                                    iteration_chunk=self._storage_chunks[storage_file])
         if obey_checkpoint_interval:
             write_iteration = self._calculate_checkpoint_iteration(iteration)
@@ -1555,18 +1557,26 @@ class MultiStateReporter(object):
         # Write the sampler state if we are on the checkpoint interval OR if told to ignore the interval
         if write_iteration is not None:
             # Store sampler states.
+            # Create a numpy array to avoid making multiple (possibly inefficient) calls to netCDF assignments
+            positions = np.zeros([n_replicas, n_particles, 3])
             for replica_index, sampler_state in enumerate(sampler_states):
-                # Store positions
+                # Store positions in memory first
                 x = sampler_state.positions / unit.nanometers
-                storage.variables['positions'][write_iteration, replica_index, :, :] = x[:, :]
+                positions[replica_index, :, :] = x[:, :]
+            # Store positions
+            storage.variables['positions'][write_iteration, :, :, :] = positions
 
-                if is_periodic:
-                    # Store box vectors and volume.
-                    for i in range(3):
-                        vector_i = sampler_state.box_vectors[i] / unit.nanometers
-                        storage.variables['box_vectors'][write_iteration, replica_index, i, :] = vector_i
-                        storage.variables['volumes'][write_iteration, replica_index] = \
-                            sampler_state.volume / unit.nanometers ** 3
+            if is_periodic:
+                # Store box vectors and volume.
+                # Allocate whole write to memory first
+                box_vectors = np.zeros([n_replicas, 3, 3])
+                volumes = np.zeros([n_replicas])
+                for replica_index, sampler_state in enumerate(sampler_states):
+                    box_vectors[replica_index, :, :] = sampler_state.box_vectors / unit.nanometers
+                    volumes[replica_index] = sampler_state.volume / unit.nanometers ** 3
+                storage.variables['box_vectors'][write_iteration, :, :, :] = box_vectors
+                storage.variables['volumes'][write_iteration, :] = volumes
+
         else:
             logger.debug("Iteration {} not on the Checkpoint Interval of {}. "
                          "Sampler State not written.".format(iteration, self._checkpoint_interval))

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -441,6 +441,10 @@ def test_online_reads_checkpoint():
             sampler = experiment.phases[0].sampler
         return sampler
 
+    # Testing Note: All the test numbers for the checkpoint_interval below are different from the default and each
+    # other to ensure making changes actually has the intended effect odd settings get carried over between tests
+    # respectively.
+
     # Test that setting "checkpoint" for online analysis gets the checkpoint interval default
     template_script = copy.deepcopy(base_template_script)
     template_script['options'].pop("checkpoint_interval", None)
@@ -449,9 +453,9 @@ def test_online_reads_checkpoint():
     assert sampler.online_analysis_interval == AlchemicalPhaseFactory.DEFAULT_OPTIONS['checkpoint_interval']
 
     # Test that setting "checkpoint" for online analysis gets the checkpoint interval that is set
-    template_script['options']["checkpoint_interval"] = 50
+    template_script['options']["checkpoint_interval"] = 10
     sampler = spinup_sampler(template_script)
-    assert sampler.online_analysis_interval == 50
+    assert sampler.online_analysis_interval == 10
 
     # Test that not setting online analysis gets the checkpoint interval default
     template_script = copy.deepcopy(base_template_script)

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,11 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.22.3 Balance Checkpoint with IO
+---------------------------------
+- Reduced default checkpoint interval to 50 (was 200) to balance disk IO time with time between checkpoints
+- Fixed bug in DSL selection string from YAML
+
 0.22.2 Topography Property Copy
 -------------------------------
 - Critical bug fix for Topology where ions of charged ligands were considered part of the ligand

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -633,11 +633,19 @@ Valid Options (2.0 * femtosecond): <Quantity Time> [1]_
 .. code-block:: yaml
 
    options:
-     checkpoint_interval: 200
+     checkpoint_interval: 50
 
 Specify how frequently checkpoint information should be saved to file relative to iterations. YANK simulations can be
 resumed only from checkpoints, so if something crashes, up to ``checkpoint_interval`` worth of iterations will be lost
 and YANK will resume from the most recent checkpoint.
+
+.. note::
+
+   The checkpoint also impacts disk IO times; Larger intervals consume less disk space, read faster but write slower,
+   as a function of number of replicas. The reverse is also true.
+   For SAMS type samplers, longer checkpoints such as 200 are fine; for replica exchange, especially in serial, lower
+   checkpoint intervals around 10 are better. We have chosen the default of 50 to try and balance the IO and the
+   different schemes.
 
 This option helps control write-to-disk time and file sizes. The fewer times a checkpoint is written, the less of both
 you will get. If you want to write a checkpoint every iteration, set this to ``1``.


### PR DESCRIPTION
This changes the `_write_sampler_states_to_given_file` function to put all `SamplerState` positions and box vectors into a single NumPy array before storing to disk. This reduces the number of times the data has to be accessed, which gets slower as the chunk size of the iteration increases (which is now the checkpoint interval). 

This is a pseudo fix to #1008 of which it reduces the write time from 100s to about 5s on 1 GTX 1080. Its still not as fast as if we put the chunksize for the iterations to 1, but its much better. We could reduce the chunksize, but that will then slow down the read access.

Some potential problems which we may have to address later. Not really a "need to answer now," but mostly for documentation.
* We may need to come around on another pass to limit the maximum chunk size so we don't wind up with massive chunks. Not a problem now, but could be with larger checkpoint intervals.
* Systems with huge numbers of particles may run out of memory assigning all replica positions to a single numpy array. 