### PR TITLE
Add draft of "yank analyze cluster" CLI

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - jupyter
     - pdbfixer
     - libnetcdf >=4.6.0
+    - msmbuilder
 
 test:
   requires:


### PR DESCRIPTION
This PR adds an early experimental version of the `yank analyze cluster` CLI option needed by @steven-albanese for analyzing Id1 data.

The algorithm:
* Compute per-snapshot weights (using MBAR) representing the relative weight of each snapshot in the fully interacting state
* Cluster the remaining snapshots
* Assign relative populations to the clusters
* Sort clusters by population, writing only most populous clusters
* Sample representative snapshots from the clusters proportional to their weights, writing out PDB files
* Write out cluster populations

The code could use a lot of refactoring. It currently accesses the `complex.nc` NetCDF directly, but this could be greatly simplified as we reorganize and refactor the `MultiStateAnalyzer` to expose smaller operational chunks via an API.