### PR TITLE
We don't need to create an nvcc-cache on cray machines

### DIFF
--- a/Yank/mpi.py
+++ b/Yank/mpi.py
@@ -148,15 +148,6 @@ def get_mpicomm():
     # Report initialization
     logger.debug("MPI initialized on node {}/{}".format(mpicomm.rank+1, mpicomm.size))
 
-    # Cray machines are usually old and sick; prevent them from causing trouble with CUDA caches
-    # by explicitly using different CUDA cache paths for each process
-    if 'ALPS_APP_PE' in os.environ:
-        cuda_cache_path = os.path.abspath(os.path.join('nvcc-cache', str(mpicomm.rank)))
-        if not os.path.exists(cuda_cache_path):
-            os.makedirs(cuda_cache_path)
-        os.environ['CUDA_CACHE_PATH'] = cuda_cache_path
-        print('Cray detected; node {}/{} using CUDA cache path {}'.format(mpicomm.rank+1, mpicomm.size, cuda_cache_path))
-
     return mpicomm
 
 get_mpicomm._is_initialized = False  # Static variable


### PR DESCRIPTION
This PR removes some code I had thought was necessary for Cray machines, but turns out not to be.