### PR TITLE
Post-Multi/Online-Analyze Bugfixes

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -786,15 +786,21 @@ def print_analysis_data(analysis_data, header=None):
 
     if header is not None:
         print(header)
-    fe_data = analysis_data['free_energy']
-    delta_f = fe_data['free_energy_diff']
-    delta_h = fe_data['enthalpy_diff']
-    delta_f_err = fe_data['free_energy_diff_error']
-    delta_h_err = fe_data['enthalpy_diff_error']
-    delta_f_unit = fe_data['free_energy_diff_unit']
-    delta_h_unit = fe_data['enthalpy_diff_unit']
-    delta_f_err_unit = fe_data['free_energy_diff_error_unit']
-    delta_h_err_unit = fe_data['enthalpy_diff_error_unit']
+    try:
+        fe_data = analysis_data['free_energy']
+        delta_f = fe_data['free_energy_diff']
+        delta_h = fe_data['enthalpy_diff']
+        delta_f_err = fe_data['free_energy_diff_error']
+        delta_h_err = fe_data['enthalpy_diff_error']
+        delta_f_unit = fe_data['free_energy_diff_unit']
+        delta_h_unit = fe_data['enthalpy_diff_unit']
+        delta_f_err_unit = fe_data['free_energy_diff_error_unit']
+        delta_h_err_unit = fe_data['enthalpy_diff_error_unit']
+    except (KeyError, TypeError):
+        # Trap error in formatted data
+        print("Error in reading analysis data! It may be the analysis threw an error, please see below for what "
+              "was received instead:\n\n{}\n\n".format(analysis_data))
+        return
 
     # Attempt to guess type of calculation
     calculation_type = ''

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1581,6 +1581,14 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         # Copy old values.
         N_l_new[1:-1] = N_l
         u_ln_new[1:-1, :] = u_ln
+        # Expand the f_k_i if need be
+        try:
+            f_k_i_new = np.zeros(n_states_new, N_l.dtype)
+            f_k_i_new[1:-1] = self._extra_analysis_kwargs['initial_f_k']  # This triggers the KeyError Trap
+            self._extra_analysis_kwargs['initial_f_k'] = f_k_i_new  # This triggers the ValueError trap
+        except (KeyError, ValueError):
+            # Not there, move on, or already set nothing to do
+            pass
 
         # Cache new values.
         self._unbiased_decorrelated_u_ln = u_ln_new

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -261,7 +261,8 @@ class MultiStateSampler(object):
         # Search for last cached free energies only if online analysis is activated.
         target_error = None
         last_err_free_energy = None
-        if options['online_analysis_interval'] is not None:
+        # Check if online analysis is set AND that the target error is a stopping condition (> 0)
+        if options['online_analysis_interval'] is not None and options['online_analysis_target_error'] != 0.0:
             target_error = options['online_analysis_target_error']
             try:
                 last_err_free_energy = cls._read_last_free_energy(reporter, iteration)[1][1]

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,9 +6,13 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
-0.23.1 Multi-Experiment Path Bug
---------------------------------
-- Fixed bug in ``MultiExperimentAnalyzer`` where a path ending in the folder separator (e.g. `/`) caused all files to write to the same place.
+0.23.1 Multi-Experiment and Online Bug
+--------------------------------------
+- Fixed bug in ``MultiExperimentAnalyzer`` where a path ending in the folder separator (e.g. ``/``) caused all files to write to the same place.
+- Fixed bug where increasing number of iterations did not continue experiment if online analysis was turned on and previously hit the max number of iterations
+- Fixed bug where online analysis and harmonic unbiasing caused MBAR to not form due to misformed ``initial_f_k``
+- ``MultiExperimentAnalyzer`` now gracefully traps an error caught by one experiment without crashing others
+- Fixed bug in ``MultiStateReporter`` when there were unsampled thermodynamic states as end-states but they referenced sampled thermodynamic states for their standard system
 
 0.23.0 Multi-Analysis
 ---------------------


### PR DESCRIPTION
This fixes a number of things

* Fixed bug where increasing number of iterations did not continue experiment if online analysis was turned on and previously hit the max number of iterations (Fixes #1031)
* Fixed bug where online analysis and harmonic unbiasing caused MBAR to not form due to misformed ``initial_f_k``
* ``MultiExperimentAnalyzer`` now gracefully traps an error caught by one experiment without crashing others
* Fixed bug in ``MultiStateReporter`` when there were unsampled thermodynamic states as end-states but they referenced sampled thermodynamic states for their standard system (Fixes #1032)

@nividic this should fix most the issues you have raised recently. Thank you for testing these things and bringing them to our attention!
@steven-albanese This should fix the couple of bugs you were seeing you raised on Slack
@andrrizzi @jchodera This could use a look over to make sure I did not break anything new. My tests pass locally