### PR TITLE
Add new restraints Application layer interface

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2745,7 +2745,6 @@ class ExperimentBuilder(object):
                 yaml_content += yaml.dump({block_id: block}, **dump_options)
 
         # Export YAML into a file
-        import pdb; pdb.set_trace()
         with open(file_path, 'w') as f:
             f.write(yaml_content)
 

--- a/Yank/schema/validator.py
+++ b/Yank/schema/validator.py
@@ -101,7 +101,11 @@ class YANKCerberusValidator(cerberus.Validator):
                      'files'.format(field, file_paths, file_extension_type))
 
     def _validator_is_restraint_constructor(self, field, constructor_description):
+        # Pop out name construct if present
+        name = constructor_description.pop('name', 'restraints')
         self._check_subclass_constructor(field, call_restraint_constructor, constructor_description)
+        # Restore pop'ed fields
+        constructor_description['name'] = name
 
     def _validator_is_mcmc_move_constructor(self, field, constructor_description):
         self._check_subclass_constructor(field, call_mcmc_move_constructor, constructor_description)

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -265,7 +265,7 @@ Restraints between receptor and ligand are used for two purposes:
   On the other hand, if multiple orientations are relevant but cannot be sampled during the imposition of additional restraints, this can cause the resulting free energy estimate to be heavily biased.
 
 In principle, both types of restraints would be used in tandem: One restraint would define the bound complex, while another restraint would be turned to reduce the amount of sampling required to evaluate alchemical free energy differences.
-In the current version of YANK, only one restraint can be used at a time.
+Multiple restraints can be used at once, and they can all be controlled independently or by the same variables.
 More guidance is given for each restraint type below.
 
 .. _standard_state_algorithm:
@@ -340,8 +340,8 @@ Orientational restraints are used to confine the ligand to a single binding pose
 
 .. _algorithm_boresch:
 
-Boresch-like restraints (``Boresch``)
-"""""""""""""""""""""""""""""""""""""
+Boresch-like restraints (``Boresch`` and ``PeriodicTorsionBoresch``)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 A common type of **orientational restraints** between receptor and ligand :cite:`Boresch2003`.
 These restrain a distance, two angles, and three torsions in an attempt to keep the ligand in a specific relative binding pose.
@@ -365,8 +365,8 @@ Note that the analytical standard state correction described in Eq. 32 of :cite:
 Due to numerical instabilities and the generalization of the Boresch restraints, the analytical free energy
 contribution is no longer supported.
 
-There are a couple variants of the Boresch restraints. The first is the standard one "Boresch," and the second is a
-variant where the torsions are restrained by a periodic restraint instead of harmonic.
+There are a couple variants of the Boresch restraints. The first is the standard one ``Boresch``, and the second is a
+variant where the torsions are restrained by a periodic restraint instead of harmonic "``PeriodicTorsionBoresch``".
 
 
 .. warning:: Symmetry corrections for symmetric ligands are **not** automatically applied; see Ref :cite:`Boresch2003` and :cite:`Mobley2006:orientational-restraints` for more information on correcting for ligand symmetry.

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,10 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.24.0 Multi-Restraint
+----------------------
+- Work in progress
+
 0.23.1 Multi-Experiment and Online Bug
 --------------------------------------
 - Fixed bug in ``MultiExperimentAnalyzer`` where a path ending in the folder separator (e.g. ``/``) caused all files to write to the same place.

--- a/docs/yamlpages/experiments.rst
+++ b/docs/yamlpages/experiments.rst
@@ -26,6 +26,8 @@ Experiments Syntax
        type: FlatBottom
        {Restraint Parameter}
        ...
+     restraint: {UserDefinedRestraint}
+     restraint: [{List}, {of}, {UserDefinedRestraints}]
      options:
        {Any Valid Option}
        {Any Valid Option}
@@ -38,17 +40,15 @@ to create the experiment and are the only required arguments. You can also speci
 :doc:`samplers <samplers>`), however this is optional and will fill in with a default sampler.
 
 The ``restraint`` is an **optional** keyword that applies a restraint to the ligand to keep it close to the receptor.
-The only required keyword is ``type``. Valid types are: ``FlatBottom``/``Harmonic``/``Boresch``/``RMSD``/``PeriodicTorsionBoresch``/``null``. If not
-specified, assumes ``null``. Every restraint has his own set of optional parameters that are passed directly to the
-Python constructor of the restraint. See the API documentation in ``yank.restraints`` for the available parameters; you
-can use the links below to jump to each of individual restraint types, the keyword arguments for each restraint type
-are accepted as arguments in the YAML file:
+There are multiple ways to invoke this key word,
 
-* :class:`FlatBottom Radially-Symmetric Restraints <FlatBottom>`
-* :class:`Harmonic Radially-Symmetric Restraints <Harmonic>`
-* :class:`Boresch Orientational Restraints <Boresch>`
-* :class:`Periodic torsion restrained Boresch-like restraint <PeriodicTorsionBoresch>`
-* :class:`RMSD Protein-Ligand Restraints <RMSD>`
+* Define a singular whole restraint here
+* Specify a single restraint defined in the :doc:`restraints <restraints>` block
+* Specify a list of restraints, each one an entry in the :doc:`restraints <restraints>` block
+
+In the example block above, you have to choose one of the formats, not all of them. To see how to define a restraint
+either here in the ``experiment`` block or as a reference to the ``restraint`` block, please see the
+:doc:`restraints page <restraints>`.
 
 The ``options`` directive lets you overwrite :doc:`any global setting <options>` specified in the header ``options`` for
 this specific experiment.
@@ -57,10 +57,6 @@ One option is to select restrained atoms through :class:`Topgraphical Regions <y
 :ref:`molecule's regions <yaml_molecules_regions>`. You can also select atoms through a
 :func:`compound region <yank.Topography.select>` where regions are combined through set operators
 ``and``/``or``.
-
-**Note:** The Boresch-like and RMSD restraints require that the ligand and receptor are close to each other to make sure
-the standard state correction computation is stable. We recommend only using the ``Boresch``,
-``PeriodicTorsionBoresch``, or ``RMSD``, options if you know the binding mode of your system already!
 
 .. _yaml_experiments_multiple:
 

--- a/docs/yamlpages/experiments.rst
+++ b/docs/yamlpages/experiments.rst
@@ -87,3 +87,73 @@ Here is an example
      restraint:
        type: Boresch
    experiments: [{UserDefinedExperiment}, {ASecondUserDefinedExperiment}]
+
+
+Example YAML File
+=================
+
+.. code-block:: yaml
+
+    options:
+      minimize: yes
+      verbose: yes
+      number_of_iterations: 3000
+      nsteps_per_iteration: 500
+      temperature: 300*kelvin
+      pressure: 1*atmosphere
+      timestep: 2.0*femtoseconds
+      output_dir: explicit
+      resume_setup: yes
+      resume_simulation: yes
+
+    molecules:
+      Abl:
+        filepath: input/2HYY-pdbfixer.pdb
+      STI:
+        filepath: input/STI02.mol2
+        epik:
+          select: !Combinatorial [0, 1, 2]
+          ph: 7.4
+          ph_tolerance: 7.0
+          tautomerize: no
+        openeye:
+          quacpac: am1-bcc
+        antechamber:
+          charge_method: null
+
+    solvents:
+      pme:
+        nonbonded_method: PME
+        switch_distance: 11*angstroms
+        nonbonded_cutoff: 12*angstroms
+        ewald_error_tolerance: 1.0e-4
+        clearance: 9*angstroms
+        positive_ion: Na+
+        negative_ion: Cl-
+
+    systems:
+      Abl-STI:
+        receptor: Abl
+        ligand: STI
+        solvent: pme
+        leap:
+          parameters: [leaprc.protein.ff14SB, leaprc.gaff, leaprc.water.tip4pew]
+
+    restraints:
+        RigidBoresch:
+            type: Boresch
+            rigidify: 15*degrees
+        BasicHarmonic:
+            type: Harmonic
+
+    protocols:
+      absolute-binding:
+        complex:
+          alchemical_path: auto
+        solvent:
+          alchemical_path: auto
+
+    experiments:
+      system: Abl-STI
+      protocol: absolute-binding
+      restraint: [RigidBoresch, BasicHarmonic]

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -23,6 +23,7 @@ All Pages
    systems <systems>
    mcmc <mcmc>
    samplers <samplers>
+   restraints <restraints>
    protocols <protocols>
    experiments <experiments>
    Combinatorial Options <combinatorial>
@@ -188,6 +189,12 @@ Detailed Options List
     * :ref:`yaml_samplers_online_analysis_interval`
     * :ref:`yaml_samplers_online_analysis_target_error`
     * :ref:`yaml_samplers_online_analysis_minimum_iterations`
+
+* :doc:`restraints <restraints>`
+
+  * :ref:`type <yaml_restraints_type>`
+  * :ref:`name <yaml_restraints_name>`
+  * :ref:`Restraint-type dependent options <yaml_restraints_other>`
 
 * :doc:`protocols <protocols>`
 

--- a/docs/yamlpages/mcmc.rst
+++ b/docs/yamlpages/mcmc.rst
@@ -62,11 +62,11 @@ The default moves used by YANK are equivalent to the following:
                 - type: MCDisplacementMove # Monte Carlo ligand displacement
                 - type: MCRotationMove # Monte Carlo ligand rotation
                 - type: LangevinSplittingDynamicsMove
-                  timestep: 2.0*femtoseconds, # 2 fs timestep
-                  collision_rate: 1.0 / picosecond, # weak collision rate
-                  n_steps: 500, # 500 steps/iteration
-                  reassign_velocities: yes, # reassign Maxwell-Boltzmann velocities each iteration
-                  n_restart_attempts: 6, # attempt to recover from NaNs
+                  timestep: 2.0*femtoseconds # 2 fs timestep
+                  collision_rate: 1.0 / picosecond # weak collision rate
+                  n_steps: 500 # 500 steps/iteration
+                  reassign_velocities: yes # reassign Maxwell-Boltzmann velocities each iteration
+                  n_restart_attempts: 6 # attempt to recover from NaNs
                   splitting: 'VRORV' # use the high-quality BAOAB integrator
 
 

--- a/docs/yamlpages/restraints.rst
+++ b/docs/yamlpages/restraints.rst
@@ -1,0 +1,96 @@
+.. py:currentmodule:: yank.restraints
+
+.. _yaml_restraints_head:
+
+Restraints for YAML files
+*************************
+
+The ``restraints`` block is an **optional** block that defines restraints to the ligand to keep it close to the
+receptor. These restraints can be individually or collectively, all controlled through the same or different
+variables in the :doc:`protocols <protocols>` section. Because this block is optional, the old way of setting a
+single restraint in the :ref:`Experiments block <yaml_experiments_syntax>` is still valid to preserve backwards
+compatibility (YANK 0.24.0 is compatible with the same YAML files as version 0.23.1).
+
+.. code-block:: yaml
+
+   restraints:
+     {UserDefinedRestraint}:
+        name: {UserDefinedName or restraints}
+        type: {ValidRestraintType}
+        {Restraint Parameter}
+        {Restraint Parameter}
+        ...
+
+The universal options are :ref:`yaml_restraints_type` and :ref:`yaml_restraints_name`. The ``{Restraint Parameter}``
+are optional and :ref:`unique to each restraint type <yaml_restraints_other>`.
+
+
+.. _yaml_restraints_type:
+
+.. rst-class:: html-toggle
+
+``type``
+--------
+
+.. code-block:: yaml
+
+   restraints:
+     {UserDefinedRestraint}:
+        type: {ValidRestraintType}
+
+Select what type of restraint to use, *required*.
+
+Valid types are: ``FlatBottom``/``Harmonic``/``Boresch``/``RMSD``/``PeriodicTorsionBoresch``
+
+Feel free to check how each restraint works and should be applied through their API docs:
+
+* :class:`FlatBottom Radially-Symmetric Restraints <FlatBottom>`
+* :class:`Harmonic Radially-Symmetric Restraints <Harmonic>`
+* :class:`Boresch Orientational Restraints <Boresch>`
+* :class:`Periodic torsion restrained Boresch-like restraint <PeriodicTorsionBoresch>`
+* :class:`RMSD Protein-Ligand Restraints <RMSD>`
+
+
+.. _yaml_restraints_name:
+
+.. rst-class:: html-toggle
+
+``name``
+--------
+
+.. code-block:: yaml
+
+   restraints:
+     {UserDefinedRestraint}:
+        name: {UserDefinedName or restraints}
+
+The only other universal option in this block. The ``name`` setting which will map to the ``lambda_{name}` variable
+in the :doc:`protocols <protocols>` block. These do not have to be unique so each restraint can be controlled by the
+same variable if so chosen. If this is not set, it defaults to ``restraints`` so the variable controlling it will be
+``lambda_restraints`` in the :doc:`protocols <protocols>` block.
+
+
+.. _yaml_restraints_other:
+
+Other Options
+-------------
+
+Every restraint has his own set of optional parameters that are passed directly to the
+Python constructor of the restraint. See the API documentation in ``yank.restraints`` for the available parameters; you
+can use the links below to jump to each of individual restraint types, the keyword arguments for each restraint type
+are accepted as arguments in the YAML file:
+
+* :class:`FlatBottom Radially-Symmetric Restraints <FlatBottom>`
+* :class:`Harmonic Radially-Symmetric Restraints <Harmonic>`
+* :class:`Boresch Orientational Restraints <Boresch>`
+* :class:`Periodic torsion restrained Boresch-like restraint <PeriodicTorsionBoresch>`
+* :class:`RMSD Protein-Ligand Restraints <RMSD>`
+
+One option is to select restrained atoms through :class:`Topgraphical Regions <yank.Topography>` defined as part of your
+:ref:`molecule's regions <yaml_molecules_regions>`. You can also select atoms through a
+:func:`compound region <yank.Topography.select>` where regions are combined through set operators
+``and``/``or``.
+
+**Note:** The Boresch-like and RMSD restraints require that the ligand and receptor are close to each other to make sure
+the standard state correction computation is stable. We recommend only using the ``Boresch``,
+``PeriodicTorsionBoresch``, or ``RMSD``, options if you know the binding mode of your system already!


### PR DESCRIPTION
Note: This PR is being merged into the new `multirestraint` branch. Much like the SAMS/MultiStateSampler branch, I wanted to make a branch we can all work on that is not master as we start this process, comment, and review as we would normal PRs. I have not configured travis to run on this branch yet, but my local tests are passing. 

* Added new `restraints` block to the YAML
    * Exactly the same as it used to be in `experiments` block but with unique ID string
    * Added new `name` key which can be used to target custom `lambda_name` variables, optional and defaults to `restraints`. Non-unique to let multiple restraints be controlled by same variable.
    * Block is 100% optional
* `experiments` block allows `restraint: target` to target restraint in `restraints` block.
    * Supports old style to preserve backwards compatibility
    * Supports targeting a single restraint from the `restraints` block
    * Supports a list of targets in the `restraints` block to use multi-restraints
* Updated and added tests for new application layer feature
    * Note: Tests should pass but there is no underlying mechanism to use this yet
* Updated docs
    * New `restraints` doc page
    * Updated `experiments` page with behavior changes to the `restraint` keyword
    * Updated index pages to include new page and pointers.

A key thing: These application layer changes should be 100% compatible with the older versions. So we should not have to have users change their YAML files like we did with the MultiStateSampler conversion. That said, this is still a major new feature and the start of the 0.24.0 release.