### PR TITLE
Convert Restraints to CV-Based

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -1496,14 +1496,14 @@ class BoreschLike(ReceptorLigandRestraint, ABC):
                                    self.restrained_ligand_atoms[0],
                                    self.restrained_ligand_atoms[1],
                                    [])
-        force_components.append(['TorsionB', torsion_b_force])
+        force_components.append(['boresch_torsion_b', torsion_b_force])
         torsion_c_force = openmm.CustomTorsionForce('theta')
         torsion_c_force.addTorsion(self.restrained_receptor_atoms[2],
                                    self.restrained_ligand_atoms[0],
                                    self.restrained_ligand_atoms[1],
                                    self.restrained_ligand_atoms[2],
                                    [])
-        force_components.append(['TorsionC', torsion_c_force])
+        force_components.append(['boresch_torsion_c', torsion_c_force])
 
         # Construct CustomCVForce
         restraint_force = openmm.CustomCVForce(energy_function)

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1782,6 +1782,7 @@ def generate_development_feature(feature_dict):
         def __init__(self, *args, **kwargs):
             if not self.dev_validate:
                 raise RuntimeError(self.DEV_ERROR)
+            super().__init__(*args, **kwargs)
 
         @classmethod
         def dev_validation(cls, wrapped_function):

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - netcdf4 ==1.3.1  # TODO: Fix this right after bugfix: "always return masked array by default, even if there are no masked values"
     - openmm >=7.2
     - mdtraj >=1.7.2
-    - openmmtools >=0.15.0
+    - openmmtools >=0.16.0
     - pymbar
     - ambermini >=16.16.0
     - docopt

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - scipy
     - cython
     - netcdf4 ==1.3.1  # TODO: Fix this right after bugfix: "always return masked array by default, even if there are no masked values"
-    - openmm >=7.1
+    - openmm >=7.2
     - mdtraj >=1.7.2
     - openmmtools >=0.15.0
     - pymbar

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -11,12 +11,17 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 
 Enhancements and feature
 """"""""""""""""""""""""
-- New ``restraints`` block in YAML application layer for supporting multiple, and reusable restraints (Backwards compatible)
+- New ``restraints`` block in YAML application layer for supporting multiple, and reusable restraints (Backwards compatible with older YAML files)
 - All YANK restraints now use the ``CustomCVForce`` in OpenMM to extract variables for unbiasing
 
 Bugfixes
 """"""""
 - Fixed bug where output minimal YAML file did not include ``samplers`` and ``mcmc_moves` blocks
+
+Compatibility Warnings
+""""""""""""""""""""""
+- YANK now requires OpenMM 7.2 or later
+- YANK now requires OpenMMTools 0.16.0 or later
 
 0.23.1 Multi-Experiment and Online Bug
 --------------------------------------

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -8,7 +8,15 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 
 0.24.0 Multi-Restraint
 ----------------------
-- Work in progress
+
+Enhancements and feature
+""""""""""""""""""""""""
+- New ``restraints`` block in YAML application layer for supporting multiple, and reusable restraints (Backwards compatible)
+- All YANK restraints now use the ``CustomCVForce`` in OpenMM to extract variables for unbiasing
+
+Bugfixes
+""""""""
+- Fixed bug where output minimal YAML file did not include ``samplers`` and ``mcmc_moves` blocks
 
 0.23.1 Multi-Experiment and Online Bug
 --------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from Cython.Build import cythonize
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.23.2"  # Primary base version of the build
+VERSION = "0.24.0"  # Primary base version of the build
 DEVBUILD = 0  # Dev build status, Either None or Integer
 ISRELEASED = False  # Are we releasing this as a full cut?
 __version__ = VERSION


### PR DESCRIPTION
This PR converts ALL of the restraints to `CustomCVForce` objects.

This feature now requires OpenMMTools 0.16.0, which is  still in development, but the local tests pass. The OpenMMTools PR/branch which I am using is here:

choderalab/openmmtools#363

This changes many things so could use a review. Many of the changes here are reflections of the linked OpenMMTools issues 