### PR TITLE
Implementation of Multi-Restraint

### DIFF
--- a/Yank/schema/validator.py
+++ b/Yank/schema/validator.py
@@ -102,10 +102,7 @@ class YANKCerberusValidator(cerberus.Validator):
 
     def _validator_is_restraint_constructor(self, field, constructor_description):
         # Pop out name construct if present
-        name = constructor_description.pop('name', 'restraints')
         self._check_subclass_constructor(field, call_restraint_constructor, constructor_description)
-        # Restore pop'ed fields
-        constructor_description['name'] = name
 
     def _validator_is_mcmc_move_constructor(self, field, constructor_description):
         self._check_subclass_constructor(field, call_mcmc_move_constructor, constructor_description)

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -1016,12 +1016,12 @@ def test_validation_wrong_protocols():
 def get_valid_restraints():
     harmonic = {'type': 'Harmonic'}
     detailed_harmonic = {'type': 'Harmonic', 'spring_constant': '8*kilojoule_per_mole/nanometers**2',
-                         'name':'super_harmonic'}
+                         'restraint_name': 'super_harmonic'}
     flat_bottom = {'type': 'FlatBottom', 'well_radius': '5.2*nanometers', 'restrained_receptor_atoms': 1644}
     bor = {'type': 'Boresch', 'restrained_receptor_atoms': [1335, 1339, 1397],
            'restrained_ligand_atoms': [2609, 2607, 2606], 'r_aA0': '0.35*nanometer',
            'K_r': '20.0*kilocalories_per_mole/angstrom**2'}
-    period_tor_bor = {**bor, 'type': 'PeriodicTorsionBoresch', 'name': 'some_name_you_can_set'}
+    period_tor_bor = {**bor, 'type': 'PeriodicTorsionBoresch', 'restraint_name': 'some_name_you_can_set'}
     list_of_restraints = [harmonic, detailed_harmonic, flat_bottom, bor, period_tor_bor]
     return list_of_restraints
 
@@ -1039,7 +1039,7 @@ def test_validation_wrong_restraints():
     """Wrong restraints throw errors"""
     exp_builder = ExperimentBuilder(get_template_script())
     empty_key = {}
-    missing_type = {'name': 'something'}
+    missing_type = {'restraint_name': 'something'}
     missing_type2 = {'spring_constant': '8*kilojoule_per_mole/nanometers**2'}
     unknown_type = {'type': 'Shenanigans'}
     bad_key = {'type': 'Harmonic', 'doesnt_exist': '3*meter'}

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -171,6 +171,8 @@ def general_restraint_run(options):
             # ... and waffles are tasty.
             # Number of spaces in this must match indentation level from the restraint_test_yaml
             options['waffle_augment'] = '\n        lambda_restraints_waffle: [0.0, 0.25, 0.5, 0.75, 1.0]'
+        else:
+            options['waffle_augment'] = ''
         # run both setup and experiment
         yaml_builder = experiment.ExperimentBuilder(restraint_test_yaml.format(**options))
         yaml_builder.run_experiments()

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -186,7 +186,6 @@ def general_restraint_run(options):
         DeltaF_restraints = reporter.read_dict('metadata')['standard_state_correction']
         # DeltaF_restraints = ncfile.groups['metadata'].variables['standard_state_correction'][0]
         ncfile.close()
-        import pdb; pdb.set_trace()
     # Check if they are close
     assert np.allclose(DeltaF_restraints, DeltaF_simulated, rtol=dDeltaF_simulated)
 

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -287,6 +287,23 @@ as a per mole quantity. More detail of how this free energy fits into the thermo
 
 .. The \unicode{xC5} creates the angstrom symbol (A with circle above), \AA and \r{A} are mangled by sphinx and don't render
 
+In theory, it might be possible to numerically compute the true standard state correction from multiple restraints
+applied to the same system. In practice though, we have not devised a general way to do this for an arbitrary number and
+type of restraints, especially when those restraints can be centered on- or affect different atom indices. Because of this,
+we enforce in YANK that at most 1 restraint which has a standard state correction be on in the fully decoupled state,
+otherwise an error is raised.
+
+This restriction is not as limiting as it may first appear. One possibility is to have a Boresch-Like restraint
+affecting the ligand and receptor in the fully decoupled state, but have an RMSD restraint keeping the ligand rigid
+in the intermediate states. This way, the ligand cannot deform and escape the pocket through its non-restrainted
+atoms before swapping back into the decoupled state, resulting in long time-scale artifacts brought on by the
+restraint scheme.
+
+In the future, we plan to support allowing RMSD restraints to be on regardless of other restraints so long as
+*identical* RMSD restraints are applied to the ligand in the decoupled solvent phase. These conditions would result
+in a standard state correction induced by the RMSD restraint alone equal to 0 analytically. There would still need to be
+a correction from a change of box volumes, but that can be handled separately.
+
 
 Restraint types
 ---------------

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -9,10 +9,14 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 0.24.0 Multi-Restraint
 ----------------------
 
-Enhancements and feature
-""""""""""""""""""""""""
+Enhancements and Features
+"""""""""""""""""""""""""
 - New ``restraints`` block in YAML application layer for supporting multiple, and reusable restraints (Backwards compatible with older YAML files)
-- All YANK restraints now use the ``CustomCVForce`` in OpenMM to extract variables for unbiasing
+- Multiple restraints can now be applied to a YANK system, both through the API and YAML
+- Restraints can now use separate protocol variables through the ``restraint_name`` keyword arg in YAML and the API. These
+  are non-unique so multiple restraints can use the same variables. Variables in the ``protocol`` will be of form
+  ``lambda_restraints_{restraint_name}`` but will default to ``lambda_restraints`` if ``restraint_name`` is not set,
+- All YANK restraints are now ``CustomCVForce`` in OpenMM to extract variables for unbiasing.
 
 Bugfixes
 """"""""

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -15,7 +15,11 @@ Enhancements and Features
 - Multiple restraints can now be applied to a YANK system, both through the API and YAML
 - Restraints can now use separate protocol variables through the ``restraint_name`` keyword arg in YAML and the API. These
   are non-unique so multiple restraints can use the same variables. Variables in the ``protocol`` will be of form
-  ``lambda_restraints_{restraint_name}`` but will default to ``lambda_restraints`` if ``restraint_name`` is not set,
+  ``lambda_restraints_{restraint_name}`` but will default to ``lambda_restraints`` if ``restraint_name`` is not set.
+
+    - Science Note: Having multiple restraints which bear a Standard State Correction that are on in the decoupled state
+      will result in an Error (poorly defined)
+
 - All YANK restraints are now ``CustomCVForce`` in OpenMM to extract variables for unbiasing.
 
 Bugfixes

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -193,7 +193,7 @@ Detailed Options List
 * :doc:`restraints <restraints>`
 
   * :ref:`type <yaml_restraints_type>`
-  * :ref:`name <yaml_restraints_name>`
+  * :ref:`restraint_name <yaml_restraints_restraint_name>`
   * :ref:`Restraint-type dependent options <yaml_restraints_other>`
 
 * :doc:`protocols <protocols>`

--- a/docs/yamlpages/mcmc.rst
+++ b/docs/yamlpages/mcmc.rst
@@ -50,11 +50,11 @@ The default moves used by YANK are equivalent to the following:
     mcmc_moves:
         default1:
             type: LangevinSplittingDynamicsMove
-            timestep: 2.0*femtoseconds, # 2 fs timestep
+            timestep: 2.0*femtoseconds # 2 fs timestep
             collision_rate: 1.0 / picosecond, # weak collision rate
-            n_steps: 500, # 500 steps/iteration
-            reassign_velocities: yes, # reassign Maxwell-Boltzmann velocities each iteration
-            n_restart_attempts: 6, # attempt to recover from NaNs
+            n_steps: 500 # 500 steps/iteration
+            reassign_velocities: yes # reassign Maxwell-Boltzmann velocities each iteration
+            n_restart_attempts: 6 # attempt to recover from NaNs
             splitting: 'VRORV' # use the high-quality BAOAB integrator
         default2:
             type: SequenceMove

--- a/docs/yamlpages/protocols.rst
+++ b/docs/yamlpages/protocols.rst
@@ -81,8 +81,8 @@ Here is an example:
 
 .. _yaml_protocols_alchemical_path:
 
-``alchemical_path``, ``lambda_electrostatics``, ``lambda_sterics``, and ``lambda_restraints``
----------------------------------------------------------------------------------------------
+``alchemical_path``, ``lambda_electrostatics``, ``lambda_sterics``, and ``lambda_restraints_{suffix}``
+------------------------------------------------------------------------------------------------------
 
 The ``lambda_electrostatics``, ``lambda_sterics``, and ``lambda_restraints`` directives define the alchemical states that YANK will sample at.
 Each directive accepts an equal sized list of floats as arguments and each index of the list corresponds to what value of lambda those interactions will be controlled by at that state.
@@ -92,7 +92,16 @@ Syntax is identical to the example above.
 
 Only ``lambda_restraints`` are optional and do not need to be specified for each phase and system. Further, the directive
 only applies if ``restraint`` :ref:`in experiments is specified <yaml_experiments_syntax>`. How and where the
-``lambda_restraints`` should be will be up to the user. To see use cases of this directive, please see any of the following:
+``lambda_restraints`` should be will be up to the user.
+
+The individual restraints can be controlled
+by a **different variable in the protocol** if the :ref:`yaml_restraints_restraint_name` variable is set for
+any of the restraints. If you wish to control a restraint with a set :ref:`yaml_restraints_restraint_name`, you will
+use ``lambda_restraints_{restraint_name}`` where ``{restraint_name}`` is replaced by the appropriate name. If this is
+*not* set for a give restraint, it the default ``lambda_restraints`` variable is used.
+Multiple restraints can be controlled through the same variable.
+
+To see use cases of this directive, please see any of the following:
 
 * :ref:`The Harmonic restraint in our detailed binding free energy tutorial <p-xylene-explicit>`
 * :ref:`The FlatBottom restraint in our host-guest binding free energy tutorial <host_guest_implicit>`

--- a/docs/yamlpages/restraints.rst
+++ b/docs/yamlpages/restraints.rst
@@ -65,10 +65,15 @@ Feel free to check how each restraint works and should be applied through their 
         restraint_name: {UserDefinedName}
 
 The only other universal option in this block. The ``restraint_name`` is an **OPTIONAL** setting which will map to
-the ``lambda_restraints_{restraint_name}` variable
+the ``lambda_restraints_{restraint_name}`` variable
 in the :doc:`protocols <protocols>` block. These do not have to be unique so each restraint can be controlled by the
 same variable if so chosen. If this is not set, it defaults to ``null`` so the variable controlling it will be
 ``lambda_restraints`` in the :doc:`protocols <protocols>` block.
+
+.. warning::
+
+    Having multiple restraints which have a Standard State Correction on in the fully decoupled state will result
+    in an error. See reasoning in :ref:`the standard state correction theory <standard_state_algorithm>`
 
 
 .. _yaml_restraints_other:

--- a/docs/yamlpages/restraints.rst
+++ b/docs/yamlpages/restraints.rst
@@ -21,8 +21,8 @@ compatibility (YANK 0.24.0 is compatible with the same YAML files as version 0.2
         {Restraint Parameter}
         ...
 
-The universal options are :ref:`yaml_restraints_type` and :ref:`yaml_restraints_name`. The ``{Restraint Parameter}``
-are optional and :ref:`unique to each restraint type <yaml_restraints_other>`.
+The universal options are :ref:`yaml_restraints_type` and :ref:`yaml_restraints_restraint_name`. The
+``{Restraint Parameter}`` are optional and :ref:`unique to each restraint type <yaml_restraints_other>`.
 
 
 .. _yaml_restraints_type:
@@ -38,7 +38,7 @@ are optional and :ref:`unique to each restraint type <yaml_restraints_other>`.
      {UserDefinedRestraint}:
         type: {ValidRestraintType}
 
-Select what type of restraint to use, *required*.
+Select what type of restraint to use, this is **the only required** argument.
 
 Valid types are: ``FlatBottom``/``Harmonic``/``Boresch``/``RMSD``/``PeriodicTorsionBoresch``
 
@@ -51,22 +51,23 @@ Feel free to check how each restraint works and should be applied through their 
 * :class:`RMSD Protein-Ligand Restraints <RMSD>`
 
 
-.. _yaml_restraints_name:
+.. _yaml_restraints_restraint_name:
 
 .. rst-class:: html-toggle
 
-``name``
---------
+``restraint_name``
+------------------
 
 .. code-block:: yaml
 
    restraints:
      {UserDefinedRestraint}:
-        name: {UserDefinedName or restraints}
+        restraint_name: {UserDefinedName}
 
-The only other universal option in this block. The ``name`` setting which will map to the ``lambda_{name}` variable
+The only other universal option in this block. The ``restraint_name`` is an **OPTIONAL** setting which will map to
+the ``lambda_restraints_{restraint_name}` variable
 in the :doc:`protocols <protocols>` block. These do not have to be unique so each restraint can be controlled by the
-same variable if so chosen. If this is not set, it defaults to ``restraints`` so the variable controlling it will be
+same variable if so chosen. If this is not set, it defaults to ``null`` so the variable controlling it will be
 ``lambda_restraints`` in the :doc:`protocols <protocols>` block.
 
 


### PR DESCRIPTION
This PR completes the Multi-restraint implementation, including the ability to control the restraints through different variables.. There are some outstanding things still.

* What is the correct way to handle the Standard State Correction for multiple restraints? It won't be additive and depends on the restrained atoms and restraints themselves.
* Making the analysis actually use the CustomCVForce features is missing. But that can be implemented separate from this PR
* I'm not sure what the best way to test this feature in a way that does not require long simulation (and I don't know what the validation would be, see the first point)