### PR TITLE
Move CLI imports into functions for speed

### DIFF
--- a/Yank/commands/analyze.py
+++ b/Yank/commands/analyze.py
@@ -13,15 +13,7 @@ Analyze YANK output file.
 # MODULE IMPORTS
 # =============================================================================================
 
-import io
-import re
-import os
-import pickle
-
-from simtk import unit
-
-import pkg_resources
-from .. import utils, analyze, mpi
+# Module imports handled in individual functions since CLI should be faster to boot up
 
 # =============================================================================================
 # COMMAND-LINE INTERFACE
@@ -109,6 +101,11 @@ General Options:
 
 
 def dispatch(args):
+
+    import os
+    import pickle
+    from .. import utils, analyze, mpi
+
     utils.config_root_logger(args['--verbose'])
 
     if args['report']:
@@ -154,6 +151,9 @@ def dispatch(args):
 
 
 def extract_analyzer_kwargs(args, quantities_as_strings=False):
+
+    import simtk.unit as unit
+
     """Return a dictionary with the keyword arguments to pass to the analyzer."""
     analyzer_kwargs = {}
     if args['--skipunbiasing']:
@@ -172,6 +172,10 @@ def extract_analyzer_kwargs(args, quantities_as_strings=False):
 
 
 def dispatch_extract_trajectory(args):
+
+    import os
+    from .. import analyze
+
     # Paths
     output_path = args['--trajectory']
     nc_path = args['--netcdf']
@@ -213,6 +217,12 @@ def dispatch_extract_trajectory(args):
 
 
 def dispatch_report(args):
+
+    import io
+    import os
+    import re
+    import pkg_resources
+    from .. import analyze
 
     # Check modules for render
     store = args['--store']

--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -13,9 +13,7 @@ Set up and run YANK calculation from script.
 # GLOBAL IMPORTS
 # =============================================================================================
 
-import os
-from ..experiment import ExperimentBuilder
-
+# Module imports handled in individual functions since CLI should be faster to boot up
 
 # =============================================================================================
 # COMMAND-LINE INTERFACE
@@ -67,6 +65,10 @@ def dispatch(args):
        Command-line arguments from docopt.
 
     """
+
+    import os
+    from ..experiment import ExperimentBuilder
+
     override = None
     if args['--override']:  # Is False for None and [] (empty list)
         over_opts = args['--override']

--- a/Yank/commands/selftest.py
+++ b/Yank/commands/selftest.py
@@ -13,15 +13,7 @@ Run YANK self tests after installation.
 # MODULE IMPORTS
 # =============================================================================================
 
-import doctest
-import pkgutil
-import subprocess
-import re
-
-from .. import version
-from . import platforms
-import simtk.openmm as mm
-
+# Module imports handled in individual functions since CLI should be faster to boot up
 
 # =============================================================================================
 # COMMAND-LINE INTERFACE
@@ -48,12 +40,21 @@ General Options:
 # COMMAND DISPATCH
 # =============================================================================================
 
+
 class LicenseError(Exception):
     """Error raised by a missing License."""
     pass
 
 
 def dispatch(args):
+
+    import re
+    import doctest
+    import pkgutil
+    import subprocess
+    import simtk.openmm as mm
+    from .. import version
+    from . import platforms
 
     # Determine verbosity in advance
     # TODO: Figure out how to get -v back in to command and allow -vv and -vvv

--- a/Yank/commands/status.py
+++ b/Yank/commands/status.py
@@ -13,11 +13,7 @@ Query output files for quick status.
 # MODULE IMPORTS
 # =============================================================================================
 
-import operator
-import itertools
-import collections
-
-from .. import experiment
+# Module imports handled in individual functions since CLI should be faster to boot up
 
 # =============================================================================================
 # COMMAND-LINE INTERFACE
@@ -62,8 +58,12 @@ def find_contiguous_ids(job_ids):
         The job ids organized in contiguous sets.
 
     """
+
+    import operator
+    import itertools
+
     contiguous_job_ids = []
-    for k, g in itertools.groupby(enumerate(job_ids), lambda x:x[0]-x[1]):
+    for k, g in itertools.groupby(enumerate(job_ids), lambda x: x[0]-x[1]):
         group = list(map(operator.itemgetter(1), g))
         if len(group) == 1:
             contiguous_job_ids.append(str(group[0]))
@@ -73,6 +73,10 @@ def find_contiguous_ids(job_ids):
 
 
 def dispatch(args):
+
+    import collections
+    from .. import experiment
+
     # Handle optional arguments.
     if args['--njobs']:
         n_jobs = int(args['--njobs'])


### PR DESCRIPTION
In order to prevent the CLI from taking long times due to importing everything, especially when the user mis-types a command for docopt to handle, import statements for the CLI functions have been moved to the actual functions instead of the module header