### PR TITLE
MPI exceptions logging and more robust NetCDF closures

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -21,6 +21,7 @@ created by going through the Command Line Interface with the ``yank script`` com
 
 import collections
 import copy
+import gc
 import logging
 import os
 
@@ -489,8 +490,10 @@ class Experiment(object):
                     iterations_left[phase_id] -= iterations_to_run
                 self._phases_last_iterations[phase_id] = alchemical_phase.iteration
 
-                # Delete alchemical phase and prepare switching.
+                # Delete alchemical phase and prepare switching. We force garbage
+                # collection to make sure that everything finalizes correctly.
                 del alchemical_phase
+                gc.collect()
 
 
 class ExperimentBuilder(object):
@@ -2554,6 +2557,7 @@ class ExperimentBuilder(object):
             sampler_state = alchemical_phase._sampler._sampler_states[0]
             mcmc_move = alchemical_phase._sampler.mcmc_moves[0]
             del alchemical_phase
+            gc.collect()
 
             # Restrain the receptor heavy atoms to avoid drastic
             # conformational changes (possibly after equilibration).

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -268,6 +268,8 @@ class MultiStateReporter(object):
         # Open analysis file.
         self._storage_analysis = self._open_dataset_robustly(self._storage_analysis_file_path,
                                                              mode, version=netcdf_format)
+        # Without set_auto_mask(False) np.inf are read as masked.
+        self._storage_analysis.set_auto_mask(False)
 
         # The analysis netcdf file holds a reference UUID so that we can check
         # that the secondary netcdf files (currently only the checkpoint

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -268,10 +268,6 @@ class MultiStateReporter(object):
         # Open analysis file.
         self._storage_analysis = self._open_dataset_robustly(self._storage_analysis_file_path,
                                                              mode, version=netcdf_format)
-        # TODO - AR: What's the purpose of set_auto_mask(False)? When we create the
-        # TODO - AR:    dataset I think this won't have any effect because any variable
-        # TODO - AR:    created after this call will still have the default behavior.
-        self._storage_analysis.set_auto_mask(False)
 
         # The analysis netcdf file holds a reference UUID so that we can check
         # that the secondary netcdf files (currently only the checkpoint
@@ -294,10 +290,10 @@ class MultiStateReporter(object):
         # Open checkpoint netcdf files.
         msg = ('Could not locate checkpoint subfile. This is okay for analysis if the '
                'solvent trajectory is not needed, but not for production simulation!')
-        dataset = self._open_dataset_robustly(self._storage_checkpoint_file_path, mode,
-                                              catch_io_error=True, io_error_warning=msg,
-                                              version=netcdf_format)
-        self._storage_checkpoint = dataset
+        self._storage_checkpoint = self._open_dataset_robustly(self._storage_checkpoint_file_path,
+                                                               mode, catch_io_error=True,
+                                                               io_error_warning=msg,
+                                                               version=netcdf_format)
         if self._storage_checkpoint is not None:
             # Check that the checkpoint file has the same UUID of the analysis file.
             try:

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -213,15 +213,24 @@ class MultiStateSampler(object):
             last stored iteration.
 
         """
-        sampler, reporter = cls._instantiate_sampler_from_storage(storage)
-        sampler._restore_sampler_from_reporter(reporter)
-        # Close reading reporter.
-        reporter.close()
+        # Handle case in which storage is a string.
+        reporter = cls._reporter_from_storage(storage, check_exist=True)
+
+        try:
+            # Open the reporter to read the data.
+            reporter.open(mode='r')
+            sampler = cls._instantiate_sampler_from_reporter(reporter)
+            sampler._restore_sampler_from_reporter(reporter)
+        finally:
+            # Close reporter in reading mode.
+            reporter.close()
+
         # We open the reporter only in node 0 in append mode ready for use
         sampler._reporter = reporter
         mpi.run_single_node(0, sampler._reporter.open, mode='a',
                             broadcast_result=False, sync_nodes=False)
-        # Don't write the new last iteration, we have not technically written anything yet, so there is no "junk"
+        # Don't write the new last iteration, we have not technically
+        # written anything yet, so there is no "junk".
         return sampler
 
     # TODO use Python 3.6 namedtuple syntax when we drop Python 3.5 support.
@@ -255,21 +264,24 @@ class MultiStateSampler(object):
         reporter = cls._reporter_from_storage(storage, check_exist=True)
 
         # Read iteration and online analysis info.
-        reporter.open(mode='r')
-        options = reporter.read_dict('options')
-        iteration = reporter.read_last_iteration(last_checkpoint=False)
-        # Search for last cached free energies only if online analysis is activated.
-        target_error = None
-        last_err_free_energy = None
-        # Check if online analysis is set AND that the target error is a stopping condition (> 0)
-        if options['online_analysis_interval'] is not None and options['online_analysis_target_error'] != 0.0:
-            target_error = options['online_analysis_target_error']
-            try:
-                last_err_free_energy = cls._read_last_free_energy(reporter, iteration)[1][1]
-            except TypeError:
-                # Trap for undefined free energy (has not been run yet)
-                last_err_free_energy = np.inf
-        reporter.close()
+        try:
+            reporter.open(mode='r')
+            options = reporter.read_dict('options')
+            iteration = reporter.read_last_iteration(last_checkpoint=False)
+            # Search for last cached free energies only if online analysis is activated.
+            target_error = None
+            last_err_free_energy = None
+            # Check if online analysis is set AND that the target error is a stopping condition (> 0)
+            if (options['online_analysis_interval'] is not None and
+                        options['online_analysis_target_error'] != 0.0):
+                target_error = options['online_analysis_target_error']
+                try:
+                    last_err_free_energy = cls._read_last_free_energy(reporter, iteration)[1][1]
+                except TypeError:
+                    # Trap for undefined free energy (has not been run yet)
+                    last_err_free_energy = np.inf
+        finally:
+            reporter.close()
 
         # Check if the calculation is done.
         number_of_iterations = options['number_of_iterations']
@@ -512,9 +524,6 @@ class MultiStateSampler(object):
         if mpi.run_single_node(0, self._reporter.storage_exists, broadcast_result=True):
             raise RuntimeError('Storage file {} already exists; cowardly '
                                'refusing to overwrite.'.format(self._reporter.filepath))
-
-        # Make sure that only the root node has an open reporter.
-        self._reporter.close()
 
         # Make sure sampler_states is an iterable of SamplerStates.
         if isinstance(sampler_states, mmtools.states.SamplerState):
@@ -820,7 +829,7 @@ class MultiStateSampler(object):
         self._energy_unsampled_states = np.zeros([self.n_replicas, len(self._unsampled_states)], np.float64)
 
     @classmethod
-    def _instantiate_sampler_from_storage(cls, storage):
+    def _instantiate_sampler_from_reporter(cls, reporter):
         """
         Creates a new instance of the reporter on disk and sampler which can then be manipulated.
         Does not set any variables, use :func:`_restore_sampler_from_reporter` after calling this to set them.
@@ -828,27 +837,16 @@ class MultiStateSampler(object):
 
         Parameters
         ----------
-        storage : str or Reporter
-            If str: The path to the storage file.
-            If :class:`Reporter`: uses the :class:`Reporter` options
-            In the future this will be able to take a Storage class as well.
+        reporter : Reporter
+            A reporter open for reading.
 
         Returns
         -------
         sampler :  MultiStateSampler
-            A new instance of MultiStateSampler (or subclass) with options restored from disk
-        reporter : MultiStateReporter
-            Loaded instance of the reporter from disk.
-            In case ``storage`` was a reporter  returns the input reporter.
-            Reporter will be closed when returned.
+            A new instance of MultiStateSampler (or subclass) with options
+            restored from disk.
+
         """
-
-        # Handle case in which storage is a string.
-        reporter = cls._reporter_from_storage(storage, check_exist=True)
-
-        # Open a reporter to read the data.
-        reporter.open(mode='r')
-
         # Retrieve options and create new simulation.
         options = reporter.read_dict('options')
         options['mcmc_moves'] = reporter.read_mcmc_moves()
@@ -856,8 +854,7 @@ class MultiStateSampler(object):
 
         # Display papers to be cited.
         sampler._display_citations()
-        reporter.close()
-        return sampler, reporter
+        return sampler
 
     def _restore_sampler_from_reporter(self, reporter):
         """
@@ -876,13 +873,9 @@ class MultiStateSampler(object):
         Parameters
         ----------
         reporter : MultiStateReporter
-            Reporter instance to read options from
+            Reporter open for reading.
 
         """
-        # Ensure reporter is closed for safe keeping first
-        reporter.close()
-        # Reopen in read mode
-        reporter.open(mode='r')
         # Read the last iteration reported to ensure we don't include junk
         # data written just before a crash.
         logger.debug("Reading storage file {}...".format(reporter.filepath))
@@ -1051,7 +1044,7 @@ class MultiStateSampler(object):
         """Return the Reporter object associated to this storage.
 
         If check_exist is True, FileNotFoundError is raised if the files
-        are not found.
+        are not found. The return reporter is closed.
         """
         if isinstance(storage, str):
             # Open a reporter to read the data.
@@ -1061,7 +1054,6 @@ class MultiStateSampler(object):
 
         # Check if netcdf file exists.
         if check_exist and not reporter.storage_exists():
-            reporter.close()
             raise FileNotFoundError('Storage file {} or its subfiles do not exist; '
                                     'cannot read status.'.format(reporter.filepath))
         return reporter

--- a/Yank/multistate/multistatesampler.py
+++ b/Yank/multistate/multistatesampler.py
@@ -1324,19 +1324,17 @@ class MultiStateSampler(object):
 
     def _compute_replica_energies(self, replica_id):
         """Compute the energy for the replica in every ThermodynamicState."""
-        # Initialize replica energies for each thermodynamic state.
-        energy_thermodynamic_states = np.zeros(self.n_states)
-        energy_unsampled_states = np.zeros(len(self._unsampled_states))
-
-        # Retrieve sampler state associated to this replica.
-        sampler_state = self._sampler_states[replica_id]
-
         # Determine neighborhood
         state_index = self._replica_thermodynamic_states[replica_id]
         neighborhood = self._neighborhood(state_index)
-        # Only compute energies over neighborhoods
-        energy_neighborhood_states = energy_thermodynamic_states[neighborhood]  # Array, can be indexed like this
-        neighborhood_thermodynamic_states = [self._thermodynamic_states[n] for n in neighborhood]  # List
+
+        # Only compute energies of the sampled states over neighborhoods.
+        energy_neighborhood_states = np.zeros(len(neighborhood))
+        energy_unsampled_states = np.zeros(len(self._unsampled_states))
+        neighborhood_thermodynamic_states = [self._thermodynamic_states[n] for n in neighborhood]
+
+        # Retrieve sampler state associated to this replica.
+        sampler_state = self._sampler_states[replica_id]
 
         # Compute energy for all thermodynamic states.
         for energies, states in [(energy_neighborhood_states, neighborhood_thermodynamic_states),

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -450,8 +450,8 @@ class SAMSSampler(MultiStateSampler):
             # Compute unnormalized log probabilities for all thermodynamic states.
             log_P_k = np.zeros([n_states], np.float64)
             for state_index in neighborhood:
-                u_k = self._energy_thermodynamic_states[replica_index, state_index]
-                log_P_k[state_index] = self.log_weights[state_index] - u_k
+                u_k = self._energy_thermodynamic_states[replica_index, :]
+                log_P_k[state_index] =  - u_k[state_index] + self.log_weights[state_index]
             log_P_k -= logsumexp(log_P_k)
 
             # Update sampler Context to current thermodynamic state.

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -308,7 +308,7 @@ class SAMSSampler(MultiStateSampler):
         super()._pre_write_create(thermodynamic_states, sampler_states, storage=storage, **kwargs)
 
         if self.state_update_scheme == 'global-jump':
-            self.locality = None # override locality to be global
+            self.locality = None  # override locality to be global
         if self.locality is not None:
             if self.locality < 1:
                 raise Exception('locality must be >= 1')
@@ -373,13 +373,14 @@ class SAMSSampler(MultiStateSampler):
         # TODO: We may be able to refactor this to simply have different update schemes compute neighborhoods differently.
         # TODO: Can we allow "plugin" addition of new update schemes that can be registered externally?
         with mmtools.utils.time_it('Mixing of replicas'):
-            jump_and_mix = self._JumpAndMixPacket(self.n_replicas, self.n_states)
+            # Initialize statistics. This matrix is modified by the jump function and used when updating the logZ estimates.
+            replicas_log_P_k = np.zeros([self.n_replicas, self.n_states], np.float64)
             if self.state_update_scheme == 'global-jump':
-                self._global_jump(jump_and_mix)
+                self._global_jump(replicas_log_P_k)
             elif self.state_update_scheme == 'local-jump':
-                self._local_jump(jump_and_mix)
+                self._local_jump(replicas_log_P_k)
             elif self.state_update_scheme == 'restricted-range-jump':
-                self._restricted_range_jump(jump_and_mix)
+                self._restricted_range_jump(replicas_log_P_k)
             else:
                 raise Exception('Programming error: Unreachable code')
 
@@ -394,12 +395,12 @@ class SAMSSampler(MultiStateSampler):
                                                                        swap_fraction_accepted * 100.0))
 
         # Update logZ estimates
-        self._update_logZ_estimates(jump_and_mix)
+        self._update_logZ_estimates(replicas_log_P_k)
 
         # Update log weights based on target probabilities
         self._update_log_weights()
 
-    def _local_jump(self, jump_and_mix_data):
+    def _local_jump(self, replicas_log_P_k):
         n_replica, n_states, locality = self.n_replicas, self.n_states, self.locality
         for (replica_index, current_state_index) in enumerate(self._replica_thermodynamic_states):
             u_k = np.zeros([n_states], np.float64)
@@ -433,35 +434,37 @@ class SAMSSampler(MultiStateSampler):
             new_state_index = np.random.choice(neighborhood, p=P_k[neighborhood])
             self._replica_thermodynamic_states[replica_index] = new_state_index
             # Accumulate statistics
-            jump_and_mix_data.replica_log_P_k[replica_index,:] = log_P_k[:]
+            replicas_log_P_k[replica_index,:] = log_P_k[:]
             self._n_proposed_matrix[current_state_index, neighborhood] += 1
             self._n_accepted_matrix[current_state_index, new_state_index] += 1
 
-    def _global_jump(self, jump_and_mix_data):
+    def _global_jump(self, replicas_log_P_k):
         """
         Global jump scheme.
         This method is described after Eq. 3 in [2]
         """
         n_replica, n_states = self.n_replicas, self.n_states
-        for (replica_index, current_state_index) in enumerate(self._replica_thermodynamic_states):
-            u_k = np.zeros([n_states], np.float64)
-            log_P_k = np.zeros([n_states], np.float64)
-            # Compute unnormalized log probabilities for all thermodynamic states
+        for replica_index, current_state_index in enumerate(self._replica_thermodynamic_states):
             neighborhood = self._neighborhood(current_state_index)
+
+            # Compute unnormalized log probabilities for all thermodynamic states.
+            log_P_k = np.zeros([n_states], np.float64)
             for state_index in neighborhood:
-                u_k[state_index] = self._energy_thermodynamic_states[replica_index, state_index]
-                log_P_k[state_index] = self.log_weights[state_index] - u_k[state_index]
+                u_k = self._energy_thermodynamic_states[replica_index, state_index]
+                log_P_k[state_index] = self.log_weights[state_index] - u_k
             log_P_k -= logsumexp(log_P_k)
+
             # Update sampler Context to current thermodynamic state.
             P_k = np.exp(log_P_k[neighborhood])
             new_state_index = np.random.choice(neighborhood, p=P_k)
             self._replica_thermodynamic_states[replica_index] = new_state_index
-            # Accumulate statistics
-            jump_and_mix_data.replica_log_P_k[replica_index,:] = log_P_k[:]
+
+            # Accumulate statistics.
+            replicas_log_P_k[replica_index,:] = log_P_k[:]
             self._n_proposed_matrix[current_state_index, neighborhood] += 1
             self._n_accepted_matrix[current_state_index, new_state_index] += 1
 
-    def _restricted_range_jump(self, jump_and_mix_data):
+    def _restricted_range_jump(self, replicas_log_P_k):
         # TODO: This has an major bug in that we also need to compute energies in `proposed_neighborhood`.
         # I'm working on a way to make this work.
         n_replica, n_states, locality = self.n_replicas, self.n_states, self.locality
@@ -495,7 +498,7 @@ class SAMSSampler(MultiStateSampler):
             logger.debug('  new_state_index     : %d' % new_state_index)
             self._replica_thermodynamic_states[replica_index] = new_state_index
             # Accumulate statistics
-            jump_and_mix_data.replica_log_P_k[replica_index,:] = log_P_k[:]
+            replicas_log_P_k[replica_index,:] = log_P_k[:]
             self._n_proposed_matrix[current_state_index, neighborhood] += 1
             self._n_accepted_matrix[current_state_index, new_state_index] += 1
 
@@ -565,7 +568,7 @@ class SAMSSampler(MultiStateSampler):
                 # TODO: On resuming, we need to recompute or restore t0, or use some other way to compute it
                 self._t0 = self._iteration - 1
 
-    def _update_logZ_estimates(self, jump_and_mix_data):
+    def _update_logZ_estimates(self, replicas_log_P_k):
         """
         Update the logZ estimates according to selected SAMS update method
 
@@ -616,7 +619,7 @@ class SAMSSampler(MultiStateSampler):
                 # Based on Eq. 12 of Ref [1]
                 # TODO: This has to be the previous state index and log_P_k used before update; store neighborhood?
                 # TODO: Can we use masked arrays for this purpose?
-                log_P_k = jump_and_mix_data.replica_log_P_k[replica_index,:]
+                log_P_k = replicas_log_P_k[replica_index,:]
                 neighborhood = np.where(self._neighborhoods[replica_index,:])[0] # compact list of states defining neighborhood
                 #logger.debug('  using neighborhood: %s' % str(neighborhood))
                 #logger.debug('  using log_P_k : %s' % str(log_P_k[neighborhood]))
@@ -645,14 +648,6 @@ class SAMSSampler(MultiStateSampler):
         # TODO: If target probabilities are adapted, we need to store them as well
 
         self.log_weights = self.log_target_probabilities[:] - self._logZ[:]
-
-    class _JumpAndMixPacket(object):
-        """
-        Helper class to pass information around between jump, mixing, and parameter update schemes
-        which can be easily created and collapsed as an extendable object
-        """
-        def __init__(self, n_replicas, n_states):
-            self.replica_log_P_k = np.zeros([n_replicas, n_states], np.float64)
 
 
 class SAMSAnalyzer(MultiStateSamplerAnalyzer):

--- a/Yank/tests/test_sampling.py
+++ b/Yank/tests/test_sampling.py
@@ -1031,11 +1031,10 @@ class TestMultiStateSampler(object):
                 restored_ets = restored_dict.pop('_energy_thermodynamic_states')
                 original_eus = original_dict.pop('_energy_unsampled_states')
                 restored_eus = restored_dict.pop('_energy_unsampled_states')
-                for replica_id in range(n_replicas):
-                    if replica_id in node_replica_ids:
-                        assert np.allclose(original_neighborhoods[replica_id], restored_neighborhoods[replica_id])
-                        assert np.allclose(original_ets[replica_id], restored_ets[replica_id])
-                        assert np.allclose(original_eus[replica_id], restored_eus[replica_id])
+                for replica_id in node_replica_ids:
+                    assert np.allclose(original_neighborhoods[replica_id], restored_neighborhoods[replica_id])
+                    assert np.allclose(original_ets[replica_id], restored_ets[replica_id])
+                    assert np.allclose(original_eus[replica_id], restored_eus[replica_id])
 
                 # Only node 0 has updated accepted and proposed exchanges.
                 original_accepted = original_dict.pop('_n_accepted_matrix')
@@ -1051,10 +1050,6 @@ class TestMultiStateSampler(object):
                 restored_mcmc_moves = restored_dict.pop('_mcmc_moves')
                 if len(node_replica_ids) == n_replicas:
                     assert pickle.dumps(original_mcmc_moves) == pickle.dumps(restored_mcmc_moves)
-
-                # Remove cached values that are not resumed.
-                original_dict.pop('_cached_transition_counts', None)
-                original_dict.pop('_cached_last_replica_thermodynamic_states', None)
 
                 # Check all other arrays. Instantiate list so that we can pop from original_dict.
                 for attr, original_value in list(original_dict.items()):

--- a/Yank/yank.py
+++ b/Yank/yank.py
@@ -1218,6 +1218,14 @@ class AlchemicalPhase(object):
         self._sampler.extend(n_iterations)
 
     # -------------------------------------------------------------------------
+    # Magic methods
+    # -------------------------------------------------------------------------
+
+    def __del__(self):
+        # Explicitly delete the sampler so that its reporter will close.
+        del self._sampler
+
+    # -------------------------------------------------------------------------
     # Internal-usage
     # -------------------------------------------------------------------------
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,13 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+Development
+-----------
+
+- Fix bug where the stack trace of an exception raised by an MPI process would be logged incorrectly (`#1084 <https://github.com/choderalab/yank/pull/1084>`_).
+- Improved robustness of NetCDF dataset opening and closing (`#1084 <https://github.com/choderalab/yank/pull/1084>`_).
+
+
 0.23.4 Bugfix release
 ---------------------
 


### PR DESCRIPTION
I've made a few small modifications to fix the stack trace that is logged when an exception is raised in an MPI process and to make more robust the NetCDF handling. In particular,

- I've implemented `AlchemicalPhase.__del__` and make `yank.experiments.Experiment` force garbage collection after deleting the alchemical phase.
- I've minimized the number of `Dataset.open/close()` in the multi-state samplers.
- The reporter now attempts to open the NetCDF file 5 times before giving up and raising the error.

The `switch_phase_interval` is working much better for me after these modifications, which is hopeful.