### PR TITLE
SAMS improvements

### DIFF
--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -440,12 +440,12 @@ class ExperimentAnalyzer(object):
                                    "*something* to analyze.")
                     self._n_discarded = 0
 
-                self.u_ns[phase_name] = analyzer.get_effective_energy_timeseries()[t0:]
+                self.u_ns[phase_name] = analyzer.get_effective_energy_timeseries()[1:]
                 # Timeseries statistics
                 i_t, g_i, n_effective_i = multistate.get_equilibration_data_per_sample(self.u_ns[phase_name])
                 n_effective_max = n_effective_i.max()
                 i_max = n_effective_i.argmax()
-                n_equilibration = i_t[i_max]
+                n_equilibration = i_t[i_max] + t0
                 g_t = g_i[i_max]
                 self.Neff_maxs[phase_name] = n_effective_max
                 self.nequils[phase_name] = n_equilibration

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -428,6 +428,7 @@ class ExperimentAnalyzer(object):
                     self._n_discarded = t0
                 except Exception as e:
                     # No t0 found
+                    logger.debug('Could not find t0: {}'.format(e))
                     pass
 
                 if series.size <= t0:

--- a/Yank/analyze.py
+++ b/Yank/analyze.py
@@ -422,7 +422,7 @@ class ExperimentAnalyzer(object):
                 # Update discard_from_start to match t0 if present
                 try:
                     iteration = len(series)
-                    data = analyzer.reporter.read_online_analysis_data(iteration, 't0')
+                    data = analyzer.reporter.read_online_analysis_data(None, 't0')
                     t0 = max(t0, int(data['t0'][0]))
                     logger.debug('t0 found; using initial t0 = {} instead of 1'.format(t0))
                     self._n_discarded = t0

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1967,7 +1967,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         t0 = 1 # discard minimization frame
         try:
             iteration = len(u_n)
-            data = self._reporter.read_online_analysis_data(iteration, 't0')
+            data = self._reporter.read_online_analysis_data(None, 't0')
             t0 = max(t0, int(data['t0'][0]))
             logger.debug('t0 found; using initial t0 = {} instead of 1'.format(t0))
         except Exception as e:

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1402,8 +1402,9 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
             # Correct for potentially-changing log weights
             if has_log_weights:
-                u_n[iteration] += - np.sum(log_weights[states_slice, iteration]) + (
-                        n_replicas * logsumexp(-f_l[:] + log_weights[:, iteration]))
+                u_n[iteration] += - np.sum(log_weights[states_slice, iteration])
+                    # JDC: Don't include changing normalization of expanded ensemble so as not to pull in unconverged log weight region
+                    #+ (n_replicas * logsumexp(-f_l[:] + log_weights[:, iteration]))
 
         logger.debug("Done.")
         return u_n

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1402,9 +1402,8 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
             # Correct for potentially-changing log weights
             if has_log_weights:
-                u_n[iteration] += - np.sum(log_weights[states_slice, iteration])
-                    # JDC: Don't include changing normalization of expanded ensemble so as not to pull in unconverged log weight region
-                    #+ (n_replicas * logsumexp(-f_l[:] + log_weights[:, iteration]))
+                u_n[iteration] += - np.sum(log_weights[states_slice, iteration]) \
+                    + (n_replicas * logsumexp(-f_l[:] + log_weights[:, iteration]))
 
         logger.debug("Done.")
         return u_n
@@ -1963,17 +1962,29 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         n_uncorrelated_iterations : int
         """
         u_n = self.get_effective_energy_timeseries(energies, replica_state_indices)
+
+        # For SAMS, if there is a second-stage start time, use only the asymptotically optimal data
+        t0 = 1 # discard minimization frame
+        try:
+            iteration = len(u_n)
+            data = self._reporter.read_online_analysis_data(iteration, 't0')
+            t0 = max(t0, int(data['t0'][0]))
+            logger.debug('t0 found; using initial t0 = {} instead of 1'.format(t0))
+        except Exception as e:
+            # No t0 found
+            pass
+
         # Discard equilibration samples.
         # TODO: if we include u_n[0] (the energy right after minimization) in the equilibration detection,
         # TODO:         then number_equilibrated is 0. Find a better way than just discarding first frame.
-        i_t, g_i, n_effective_i = utils.get_equilibration_data_per_sample(u_n[1:])
+        i_t, g_i, n_effective_i = utils.get_equilibration_data_per_sample(u_n[t0:])
         n_effective_max = n_effective_i.max()
         i_max = n_effective_i.argmax()
         n_equilibration = i_t[i_max]
         g_t = g_i[i_max]
         equilibration_data = [n_equilibration, g_t, n_effective_max]
-        # Discard also minimization frame.
-        equilibration_data[0] += 1
+        # Account for initially discarded frames
+        equilibration_data[0] += t0
         self._equilibration_data = tuple(equilibration_data)
         logger.debug('Equilibration data: {}'.format(equilibration_data))
         return self._equilibration_data

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -1972,6 +1972,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
             logger.debug('t0 found; using initial t0 = {} instead of 1'.format(t0))
         except Exception as e:
             # No t0 found
+            logger.debug('Could not find t0: {}'.format(e))
             pass
 
         # Discard equilibration samples.

--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -697,6 +697,7 @@ class MultiStateReporter(object):
 
         """
         iteration = self._map_iteration_to_good(iteration)
+        logger.debug('read_replica_thermodynamic_states: iteration = {}'.format(iteration))
         return self._storage_analysis.variables['states'][iteration].astype(np.int64)
 
     def write_replica_thermodynamic_states(self, state_indices, iteration):

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -637,8 +637,14 @@ class SAMSSampler(MultiStateSampler):
         if self._stage == 1: # asymptotically optimal or one-stage
             self._logZ[:] -= self._logZ[0]
 
-        logger.debug('  logZ: %s' % str(self._logZ))
-
+        # Format logZ
+        msg = '  logZ: ['
+        for i, val in enumerate(self._logZ):
+            if i > 0: msg += ', '
+            msg += '%6.1f' % val
+        msg += ']'
+        logger.debug(msg)
+        
         # Store gamma
         self._reporter.write_online_analysis_data(self._iteration, gamma=gamma)
 

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -346,10 +346,6 @@ class SAMSSampler(MultiStateSampler):
         # Compute log weights from log target probability and logZ estimate
         self._update_log_weights()
 
-        # Determine t0
-        self._initialize_stage()
-        self._update_stage()
-
     @mpi.on_single_node(rank=0, broadcast_result=False, sync_nodes=False)
     @mpi.delayed_termination
     def _report_iteration_items(self):
@@ -644,7 +640,7 @@ class SAMSSampler(MultiStateSampler):
             msg += '%6.1f' % val
         msg += ']'
         logger.debug(msg)
-        
+
         # Store gamma
         self._reporter.write_online_analysis_data(self._iteration, gamma=gamma)
 

--- a/Yank/multistate/sams.py
+++ b/Yank/multistate/sams.py
@@ -263,9 +263,9 @@ class SAMSSampler(MultiStateSampler):
     def _initialize_stage(self):
         self._t0 = 0  # reference iteration to subtract
         if self.update_stages == 'one-stage':
-            self._stage = 'asymptotically-optimal'  # start with asymptotically-optimal stage
+            self._stage = 1 # start with asymptotically-optimal stage
         elif self.update_stages == 'two-stage':
-            self._stage = 'initial'  # start with rapid heuristic adaptation initial stage
+            self._stage = 0 # start with rapid heuristic adaptation initial stage
 
     def _pre_write_create(self, thermodynamic_states: list, sampler_states: list, storage,
                           **kwargs):
@@ -321,8 +321,8 @@ class SAMSSampler(MultiStateSampler):
         # Update log target probabilities
         if self.log_target_probabilities is None:
             self.log_target_probabilities = np.zeros([self.n_states], np.float64) - np.log(self.n_states) # log(1/n_states)
-            logger.debug('Setting log target probabilities: %s' % str(self.log_target_probabilities))
-            logger.debug('Target probabilities: %s' % str(np.exp(self.log_target_probabilities)))
+            #logger.debug('Setting log target probabilities: %s' % str(self.log_target_probabilities))
+            #logger.debug('Target probabilities: %s' % str(np.exp(self.log_target_probabilities)))
 
         # Record initial logZ estimates
         self._logZ = np.zeros([self.n_states], np.float64)
@@ -338,7 +338,10 @@ class SAMSSampler(MultiStateSampler):
     def _restore_sampler_from_reporter(self, reporter):
         super()._restore_sampler_from_reporter(reporter)
         self._cached_state_histogram = self._compute_state_histogram(reporter=reporter)
-        self._logZ = reporter.read_logZ(self._iteration)
+        data = reporter.read_online_analysis_data(self._iteration, 'logZ', 'stage', 't0')
+        self._logZ = data['logZ']
+        self._stage = int(data['stage'][0])
+        self._t0 = int(data['t0'][0])
 
         # Compute log weights from log target probability and logZ estimate
         self._update_log_weights()
@@ -351,7 +354,7 @@ class SAMSSampler(MultiStateSampler):
     @mpi.delayed_termination
     def _report_iteration_items(self):
         super(SAMSSampler, self)._report_iteration_items()
-        self._reporter.write_logZ(self._iteration, self._logZ)
+        self._reporter.write_online_data_dynamic_and_static(self._iteration, logZ=self._logZ, stage=self._stage, t0=self._t0)
         # Split into which states and how many samplers are in each state
         # Trying to do histogram[replica_thermo_states] += 1 does not correctly handle multiple
         # replicas in the same state.
@@ -535,7 +538,7 @@ class SAMSSampler(MultiStateSampler):
         minimum_visits = 1
         N_k = self._state_histogram
         logger.debug('    state histogram counts: {}'.format(self._cached_state_histogram))
-        if (self.update_stages == 'two-stage') and (self._stage == 'initial'):
+        if (self.update_stages == 'two-stage') and (self._stage == 0):
             advance = False
             if N_k.sum() == 0:
                 # No samples yet; don't do anything.
@@ -564,7 +567,7 @@ class SAMSSampler(MultiStateSampler):
 
             if advance or ((self._t0 > 0) and (self._iteration > self._t0)):
                 # Histograms are sufficiently flat; switch to asymptotically optimal scheme
-                self._stage = 'asymptotically-optimal'
+                self._stage = 1 # asymptotically optimal
                 # TODO: On resuming, we need to recompute or restore t0, or use some other way to compute it
                 self._t0 = self._iteration - 1
 
@@ -600,14 +603,14 @@ class SAMSSampler(MultiStateSampler):
             beta_factor = 0.8
             pi_star = pi_k.min()
             t = float(self._iteration)
-            if self._stage == 'initial':
+            if self._stage == 0: # initial stage
                 gamma = self.gamma0 * min(pi_star, t**(-beta_factor)) # Eq. 15 of [1]
-            elif self._stage == 'asymptotically-optimal':
+            elif self._stage == 1:
                 gamma = self.gamma0 * min(pi_star, (t - self._t0 + self._t0**beta_factor)**(-1)) # Eq. 15 of [1]
             else:
-                raise Exception('Programming error:unreachable code')
+                raise Exception('stage {} unknown'.format(self._stage))
 
-            logger.debug('  gamma: %s' % gamma)
+            #logger.debug('  gamma: %s' % gamma)
 
             # Update online logZ estimate
             if self.weight_update_method == 'optimal':
@@ -631,7 +634,7 @@ class SAMSSampler(MultiStateSampler):
                 raise Exception('Programming error: Unreachable code')
 
         # Subtract off logZ[0] to prevent logZ from growing without bound once we reach the asymptotically optimal stage
-        if self._stage == 'asymptotically-optimal':
+        if self._stage == 1: # asymptotically optimal or one-stage
             self._logZ[:] -= self._logZ[0]
 
         logger.debug('  logZ: %s' % str(self._logZ))

--- a/Yank/reports/YANK_Health_Report_Template.ipynb
+++ b/Yank/reports/YANK_Health_Report_Template.ipynb
@@ -120,6 +120,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sams_weights_figure = report.generate_sams_weights_plots()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "equilibration_figure = report.generate_equilibration_plots(discard_from_start=1)"
    ]
   },

--- a/Yank/reports/notebook.py
+++ b/Yank/reports/notebook.py
@@ -167,6 +167,39 @@ class HealthReportData(analyze.ExperimentAnalyzer):
 
         return equilibration_figure
 
+    def generate_sams_weights_plots(self):
+        """Plot SAMS weights.
+
+        Returns None if no SAMS logZ data found, or the Matplotlib figure handle if present.
+        """
+
+        # Return None if no SAMS logZ history data found
+        for phase_index, phase in enumerate(self.analyzers.keys()):
+            try:
+                logZ_history = self.analyzers[phase].reporter._storage[0].groups['online_analysis']['logZ_history']
+            except Exception as e:
+                print('No SAMS logZ history found.')
+                return None
+
+        # Generate logZ history plots
+        import numpy as np
+        import copy
+        n_phases = len(self.analyzers)
+        figure = plt.figure(figsize=(20, 5*n_phases));
+        for phase_index, phase in enumerate(self.analyzers.keys()):
+            logZ_history = np.array(self.analyzers[phase].reporter._storage[0].groups['online_analysis']['logZ_history'][:,:])
+            n_iterations, n_states = logZ_history.shape
+            nthin = 1
+
+            ax = plt.subplot(n_phases, 1, phase_index+1)
+            ax.plot(logZ_history);
+            plt.xlabel('iteration');
+            plt.ylabel('logZ');
+            plt.title(phase)
+
+        plt.tight_layout()
+        return figure
+
     def compute_rmsds(self):
         return NotImplementedError("This function is still a prototype and has segfault issues, please disable for now")
         # """Compute the RMSD of the ligand and the receptor by state"""


### PR DESCRIPTION
Fixes #1112 

* SAMS now properly restores `t0` and `stage`, which should correctly persist the stage across phase switches and resumes
* Added SAMS `logZ_history` plot to notebook reports
* SAMS `self._stage` is now an integer to more easily store this in storage (0 is initial, 1 is asymptotic phase)
* Suppress some verbose outputs
* If an asymptotically optimal stage is present in a SAMS simulation, the initial stage is discarded to equilibration and automatic equilibration detection is applied to the asymptotically optimal weight adjustment region only.
* Jupyter notebook reports now show SAMS weight convergence if present
