### PR TITLE
Update travis to test python 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   # Build the recipe
   - conda build devtools/conda-recipe
   # Install the package
-  - conda install --quiet --yes --use-local ${PACKAGENAME}-dev
+  - conda install -c $HOME/miniconda/envs/test/conda-bld/ --quiet --yes --use-local ${PACKAGENAME}-dev
   # Test the package
   - cd devtools && nosetests $PACKAGENAME --with-coverage --nocapture --verbosity=2 --with-timer -a '!slow' && cd .. && if [[ $CONDA_PY = 37 ]]; then devtools/travis-ci/build_docs.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ install:
   - export PYTHONUNBUFFERED=true
   # Add org channel
   - conda config --add channels omnia --add channels conda-forge
-  # Add omnia dev channels
-  - if [ $DEVOMNIA ]; then conda config --add channels omnia/label/dev; fi
+  # Add omnia dev channels if requested
+  - if [ $DEVOMNIA ]; then conda config --add channels omnia-dev; fi
   # Update everything
   - conda update --quiet --yes --all
   # Unpack encrypted OpenEye license file
@@ -43,13 +43,13 @@ script:
   # Install the package
   - conda install --quiet --yes --use-local ${PACKAGENAME}-dev
   # Test the package
-  - cd devtools && nosetests $PACKAGENAME --with-coverage --nocapture --verbosity=2 --with-timer -a '!slow' && cd .. && if [[ $CONDA_PY = 3.5 ]]; then devtools/travis-ci/build_docs.sh; fi
+  - cd devtools && nosetests $PACKAGENAME --with-coverage --nocapture --verbosity=2 --with-timer -a '!slow' && cd .. && if [[ $CONDA_PY = 37 ]]; then devtools/travis-ci/build_docs.sh; fi
 
 env:
   matrix:
-    - python=3.5 CONDA_PY=3.5
-    - python=3.5 CONDA_PY=35 DEVOMNIA=true
-    - python=3.6 CONDA_PY=3.6
+    - python=3.6 CONDA_PY=36
+    - python=3.7 CONDA_PY=37
+    - python=3.7 CONDA_PY=37 DEVOMNIA=true
 
   global:
     - ORGNAME="omnia"
@@ -69,7 +69,7 @@ env:
 
 matrix:
   allow_failures:
-  - env: python=3.5 CONDA_PY=35 DEVOMNIA=true
+  - env: python=3.7 CONDA_PY=37 DEVOMNIA=true
 
 deploy:
     - provider: s3
@@ -80,4 +80,4 @@ deploy:
       local_dir: docs/_deploy
       on:
           branch: master
-          condition: "$CONDA_PY = 3.5"
+          condition: "$CONDA_PY = 3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ env:
 
 matrix:
   allow_failures:
-  - env: python=3.7 CONDA_PY=37 DEVOMNIA=true
+  - env: python=3.7 CONDA_PY=3.7 DEVOMNIA=true
 
 deploy:
     - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ script:
   # Install the package
   - conda install -c $HOME/miniconda/envs/test/conda-bld/ --quiet --yes --use-local ${PACKAGENAME}-dev
   # Test the package
-  - cd devtools && nosetests $PACKAGENAME --with-coverage --nocapture --verbosity=2 --with-timer -a '!slow' && cd .. && if [[ $CONDA_PY = 37 ]]; then devtools/travis-ci/build_docs.sh; fi
+  - cd devtools && nosetests $PACKAGENAME --with-coverage --nocapture --verbosity=2 --with-timer -a '!slow' && cd .. && if [[ $CONDA_PY = 3.7 ]]; then devtools/travis-ci/build_docs.sh; fi
 
 env:
   matrix:
-    - python=3.6 CONDA_PY=36
-    - python=3.7 CONDA_PY=37
-    - python=3.7 CONDA_PY=37 DEVOMNIA=true
+    - python=3.6 CONDA_PY=3.6
+    - python=3.7 CONDA_PY=3.7
+    - python=3.7 CONDA_PY=3.7 DEVOMNIA=true
 
   global:
     - ORGNAME="omnia"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   # Install the package
   - conda install -c $HOME/miniconda/envs/test/conda-bld/ --quiet --yes --use-local ${PACKAGENAME}-dev
   # Test the package
-  - cd devtools && nosetests $PACKAGENAME --with-coverage --nocapture --verbosity=2 --with-timer -a '!slow' && cd .. && if [[ $CONDA_PY = 3.7 ]]; then devtools/travis-ci/build_docs.sh; fi
+  - cd devtools && nosetests $PACKAGENAME --with-coverage --nocapture --verbosity=2 --with-timer -a '!slow' && cd .. && if [[ $CONDA_PY = 3.6 ]]; then devtools/travis-ci/build_docs.sh; fi
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   # Activate the test environment
   - source activate test
   # Install extras for OpenEye, Modeller and testing
-  - conda install --yes --quiet pip nose nose-timer coverage modeller
+  - conda install --yes --quiet pip nose nose-timer coverage modeller conda-verify
   # Install OpenEye toolkit
   - pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Build the recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,9 @@ install:
 
 script:
   # Create a test environment
-  - conda create --quiet --yes -n test python=$python
+  - conda create --quiet --yes -n test python=$python conda-build conda-verify jinja2 pip nose nose-timer coverage modeller
   # Activate the test environment
   - source activate test
-  # Install extras for OpenEye, Modeller and testing
-  - conda install --yes --quiet pip nose nose-timer coverage modeller conda-verify
   # Install OpenEye toolkit
   - pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
   # Build the recipe

--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -917,6 +917,10 @@ class PhaseAnalyzer(ABC):
             else:
                 log_z = self._reporter.read_online_analysis_data(slice(0, None), "logZ")["logZ"]
             log_z = np.moveaxis(log_z, 0, -1)
+
+        # We don't want logZ to be a masked array
+        log_z = np.array(log_z)
+                    
         return log_z
 
     def get_effective_energy_timeseries(self, energies=None, replica_state_indices=None):

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: yank-dev
-  version: !!str 0.0.0
+  version: 0.0.0
 
 source:
   path: ../..
@@ -39,15 +39,6 @@ requirements:
     - jupyter
     - pdbfixer
     - libnetcdf >=4.6.0
-
-test:
-  requires:
-    - nose
-    - nose-timer
-  imports:
-    - yank
-  commands:
-    - yank --help
 
 about:
   home: https://github.com/choderalab/yank

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - pyyaml
     - clusterutils
     - sphinxcontrib-bibtex
-    - cerberus >=1.2 # requires >= 1.2 for py37 builds
+    - cerberus ==1.1 # yank uses buggy cerberus 1.1 behavior as a feature ¯\_(ツ)_/¯
     - matplotlib
     - jupyter
     - pdbfixer
@@ -54,7 +54,7 @@ requirements:
     - pyyaml
     - clusterutils
     - sphinxcontrib-bibtex
-    - cerberus >=1.2 # requires >= 1.2 for py37 builds
+    - cerberus ==1.1 # yank uses buggy cerberus 1.1 behavior as a feature ¯\_(ツ)_/¯
     - matplotlib
     - jupyter
     - pdbfixer

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -13,8 +13,27 @@ build:
 requirements:
   build:
     - python
+    - pandas
+    - numpy >=1.14
+    - scipy
     - cython
-    - setuptools
+    - netcdf4 >=1.4.2 # after bugfix: "always return masked array by default, even if there are no masked values"
+    - libnetcdf >=4.6.2 # workaround for libssl issues
+    - openmm >=7.3
+    - mdtraj >=1.7.2
+    - openmmtools >=0.17.0
+    - pymbar
+    - ambermini >=16.16.0
+    - docopt
+    - openmoltools >=0.7.5
+    - mpi4py
+    - pyyaml
+    - clusterutils
+    - sphinxcontrib-bibtex
+    - cerberus >=1.2 # requires >= 1.2 for py37 builds
+    - matplotlib
+    - jupyter
+    - pdbfixer
 
   run:
     - python

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy >=1.14
     - scipy
     - cython
-    - netcdf4 ==1.3.1  # TODO: Fix this right after bugfix: "always return masked array by default, even if there are no masked values"
+    - netcdf4
     - openmm >=7.1
     - mdtraj >=1.7.2
     - openmmtools >=0.15.0
@@ -42,4 +42,4 @@ requirements:
 
 about:
   home: https://github.com/choderalab/yank
-  license: MIT License
+  license: MIT

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - pyyaml
     - clusterutils
     - sphinxcontrib-bibtex
-    - cerberus ==1.1.*
+    - cerberus >=1.2 # requires >= 1.2 for py37 builds
     - matplotlib
     - jupyter
     - pdbfixer

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -22,8 +22,9 @@ requirements:
     - numpy >=1.14
     - scipy
     - cython
-    - netcdf4
-    - openmm >=7.1
+    - netcdf4 >=1.4.2 # after bugfix: "always return masked array by default, even if there are no masked values"
+    - libnetcdf >=4.6.2 # workaround for libssl issues
+    - openmm >=7.3
     - mdtraj >=1.7.2
     - openmmtools >=0.15.0
     - pymbar
@@ -38,7 +39,6 @@ requirements:
     - matplotlib
     - jupyter
     - pdbfixer
-    - libnetcdf >=4.6.0
 
 about:
   home: https://github.com/choderalab/yank

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   run:
     - python
     - pandas
-    - numpy >=1.11
+    - numpy >=1.14
     - scipy
     - cython
     - netcdf4 ==1.3.1  # TODO: Fix this right after bugfix: "always return masked array by default, even if there are no masked values"

--- a/devtools/travis-ci/build_docs.sh
+++ b/devtools/travis-ci/build_docs.sh
@@ -5,7 +5,7 @@ set -ev
 
 # Install the built package
 conda create --yes -n docenv python=$CONDA_PY
-source activate docenv
+conda activate docenv
 conda install -yq --use-local yank-dev
 
 # Install doc requirements

--- a/devtools/travis-ci/build_docs.sh
+++ b/devtools/travis-ci/build_docs.sh
@@ -6,13 +6,13 @@ set -ev
 # Install the built package
 conda create --yes -n docenv python=$CONDA_PY
 source activate docenv
-conda install -yq --use-local yank-dev sphinx
-
-# We don't use conda for these:
-pip install -I sphinx sphinx_rtd_theme msmb_theme
+conda install -yq --use-local yank-dev
 
 # Install doc requirements
 conda install -yq --file docs/requirements.txt
+
+# Install packages with no conda recipe.
+pip install -I msmb_theme
 
 # Make docs
 cd docs && make html && cd -

--- a/devtools/travis-ci/build_docs.sh
+++ b/devtools/travis-ci/build_docs.sh
@@ -5,11 +5,11 @@ set -ev
 
 # Install the built package
 conda create --yes -n docenv python=$CONDA_PY
-conda activate docenv
-conda install -yq --use-local yank-dev
+source activate docenv
+conda install -yq --use-local yank-dev --file docs/requirements.txt
 
 # Install doc requirements
-conda install -yq --file docs/requirements.txt
+#conda install -yq --file docs/requirements.txt
 
 # Install packages with no conda recipe.
 pip install -I msmb_theme

--- a/devtools/travis-ci/build_docs.sh
+++ b/devtools/travis-ci/build_docs.sh
@@ -6,10 +6,10 @@ set -ev
 # Install the built package
 conda create --yes -n docenv python=$CONDA_PY
 source activate docenv
-conda install -yq --use-local yank-dev sphinx==1.5.6
+conda install -yq --use-local yank-dev sphinx
 
 # We don't use conda for these:
-pip install -I sphinx==1.5.6 sphinx_rtd_theme==0.2.4 msmb_theme==1.2.0
+pip install -I sphinx sphinx_rtd_theme msmb_theme
 
 # Install doc requirements
 conda install -yq --file docs/requirements.txt

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -3,14 +3,14 @@ pushd .
 cd $HOME
 
 # Install Miniconda
-MINICONDA=Miniconda2-latest-Linux-x86_64.sh
+MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 MINICONDA_HOME=$HOME/miniconda
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget -q https://repo.continuum.io/miniconda/$MINICONDA
 # Parse version out of file as fall back
 # Sed cuts out everything before the first digit, then traps the first digit and everything after
 MINICONDA_DL_VER=$(head $MINICONDA | grep VER | sed -n 's/[^0-9]*\([0-9.]*\)/\1/p')
-MINICONDA_FILE_VER="Miniconda2-$MINICONDA_DL_VER-Linux-x86_64.sh"
+MINICONDA_FILE_VER="Miniconda3-$MINICONDA_DL_VER-Linux-x86_64.sh"
 MINICONDA_MD5_VER=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA_FILE_VER | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     if [[ $MINICONDA_MD5_VER != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
@@ -23,8 +23,8 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 # Configure miniconda
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
-conda update --yes conda
-conda install --yes conda-build jinja2 anaconda-client pip
+#conda update --yes conda
+#conda install --yes conda-build jinja2 anaconda-client pip conda-verify
 
 # Restore original directory
 popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,10 @@
 sphinx
 sphinx_rtd_theme
-matplotlib
-boto
-ipython-notebook
+#matplotlib
+#boto
+#ipython-notebook
 jinja2
 runipy
-openmm
-pytables
-scikit-learn
+#openmm
+#pytables
+#scikit-learn

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,4 @@
 sphinx
 sphinx_rtd_theme
-#matplotlib
-#boto
-#ipython-notebook
 jinja2
 runipy
-#openmm
-#pytables
-#scikit-learn

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+sphinx
+sphinx_rtd_theme
 matplotlib
 boto
 ipython-notebook
@@ -6,4 +8,3 @@ runipy
 openmm
 pytables
 scikit-learn
-


### PR DESCRIPTION
Yank, omnia, and conda-forge no longer support python 3.5.

This PR updates travis to test Python 3.6 and 3.7, pushing docs on the 3.7 build.

The Python 3.7 build is now correctly tested with the nightly builds of openmm---that had been broken previously because the wrong channel was specified.
