### PR TITLE
Update YANK with new OpenMMTools

### DIFF
--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -205,8 +205,10 @@ class RestraintState(GlobalParameterState):
     lambda_restraints = GlobalParameterState.GlobalParameter('lambda_restraints', standard_value=1.0)
 
     @lambda_restraints.validator
-    def lambda_bonds(self, instance, new_value):
-        if new_value is not None and not (0.0 <= new_value <= 1.0):
+    def lambda_restraints_validator(self, instance, new_value):
+        if new_value is None:
+            return None
+        if not (0.0 <= new_value <= 1.0):
             raise ValueError('lambda_restraints must be between 0.0 and 1.0')
         return float(new_value)
 

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -54,11 +54,6 @@ V0 = 1660.53928 * unit.angstroms**3  # standard state volume
 # CUSTOM EXCEPTIONS
 # ==============================================================================
 
-class RestraintStateError(mmtools.states.GlobalParameterError):
-    """Error raised by an :class:`RestraintState`."""
-    pass
-
-
 class RestraintParameterError(Exception):
     """Error raised by a :class:`ReceptorLigandRestraint`."""
     pass

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -31,6 +31,7 @@ import numpy as np
 import scipy.integrate
 import mdtraj as md
 import openmmtools as mmtools
+from openmmtools.states import GlobalParameterState
 from simtk import openmm, unit
 
 from . import pipeline
@@ -53,7 +54,7 @@ V0 = 1660.53928 * unit.angstroms**3  # standard state volume
 # CUSTOM EXCEPTIONS
 # ==============================================================================
 
-class RestraintStateError(mmtools.states.ComposableStateError):
+class RestraintStateError(mmtools.states.GlobalParameterError):
     """Error raised by an :class:`RestraintState`."""
     pass
 
@@ -133,7 +134,7 @@ def create_restraint(restraint_type, **kwargs):
 # ComposableState class to control the strength of restraints.
 # ==============================================================================
 
-class RestraintState(object):
+class RestraintState(GlobalParameterState):
     """
     The state of a restraint.
 
@@ -196,192 +197,13 @@ class RestraintState(object):
     0.0
 
     """
-    def __init__(self, lambda_restraints):
-        self.lambda_restraints = lambda_restraints
+    lambda_restraints = GlobalParameterState.GlobalParameter('lambda_restraints', standard_value=1.0)
 
-    @property
-    def lambda_restraints(self):
-        """Float: the strength of the applied restraint (between 0 and 1 inclusive)."""
-        return self._lambda_restraints
-
-    @lambda_restraints.setter
-    def lambda_restraints(self, value):
-        assert 0.0 <= value <= 1.0
-        self._lambda_restraints = float(value)
-
-    def apply_to_system(self, system):
-        """
-        Set the strength of the system's restraint to this.
-
-        System is updated in-place
-
-        Parameters
-        ----------
-        system : simtk.openmm.System
-            The system to modify.
-
-        Raises
-        ------
-        RestraintStateError
-            If the system does not have any ``CustomForce`` with a
-            ``lambda_restraint`` global parameter.
-
-        """
-        # Set lambda_restraints in all forces that have it.
-        for force, parameter_id in self._get_system_forces_parameters(system):
-            force.setGlobalParameterDefaultValue(parameter_id, self._lambda_restraints)
-
-    def check_system_consistency(self, system):
-        """
-        Check if the system's restraint is in this restraint state.
-
-        It raises a :class:`RestraintStateError` if the restraint is not consistent
-        with the state.
-
-        Parameters
-        ----------
-        system : simtk.openmm.System
-            The system with the restraint to test.
-
-        Raises
-        ------
-        RestraintStateError
-            If the system is not consistent with this state.
-
-        """
-        # Set lambda_restraints in all forces that have it.
-        for force, parameter_id in self._get_system_forces_parameters(system):
-            force_lambda = force.getGlobalParameterDefaultValue(parameter_id)
-            if force_lambda != self.lambda_restraints:
-                err_msg = 'Consistency check failed: system {}, state {}'
-                raise RestraintStateError(err_msg.format(force_lambda, self._lambda_restraints))
-
-    def apply_to_context(self, context):
-        """Put the restraint in the `Context` into this state.
-
-        Parameters
-        ----------
-        context : simtk.openmm.Context
-            The context to set.
-
-        Raises
-        ------
-        RestraintStateError
-            If the context does not have the required lambda global variables.
-
-        """
-        try:
-            context.setParameter('lambda_restraints', self._lambda_restraints)
-        except Exception:
-            raise RestraintStateError('The context does not have a restraint.')
-
-    def _standardize_system(self, system):
-        """Standardize the given system.
-
-        Set lambda_restraints of the system to 1.0.
-
-        Parameters
-        ----------
-        system : simtk.openmm.System
-            The system to standardize.
-
-        Raises
-        ------
-        RestraintStateError
-            If the system is not consistent with this state.
-
-        """
-        # Set lambda_restraints to 1.0 in all forces that have it.
-        for force, parameter_id in self._get_system_forces_parameters(system):
-            force.setGlobalParameterDefaultValue(parameter_id, 1.0)
-
-    def _on_setattr(self, standard_system, attribute_name):
-        """Check if the standard system needs changes after a state attribute is set.
-
-        Parameters
-        ----------
-        standard_system : simtk.openmm.System
-            The standard system before setting the attribute.
-        attribute_name : str
-            The name of the attribute that has just been set or retrieved.
-
-        Returns
-        -------
-        need_changes : bool
-            True if the standard system has to be updated, False if no change
-            occurred.
-
-        """
-        # There are no attributes that can be set that can alter the standard system.
-        return False
-
-    def _find_force_groups_to_update(self, context, current_context_state, memo):
-        """Find the force groups whose energy must be recomputed after applying self.
-
-        Parameters
-        ----------
-        context : Context
-            The context, currently in `current_context_state`, that will
-            be moved to this state.
-        current_context_state : ThermodynamicState
-            The full thermodynamic state of the given context. This is
-            guaranteed to be compatible with self.
-        memo : dict
-            A dictionary that can be used by the state for memoization
-            to speed up consecutive calls on the same context.
-
-        Returns
-        -------
-        force_groups_to_update : set of int
-            The indices of the force groups whose energy must be computed
-            again after applying this state, assuming the context to be in
-            `current_context_state`.
-        """
-        # Check if lambda_restraints will change.
-        if self.lambda_restraints == current_context_state.lambda_restraints:
-            return set()
-
-        # Update memo if this is the first call for this context.
-        if len(memo) == 0:
-            system = context.getSystem()
-            for force, _ in self._get_system_forces_parameters(system):
-                memo['lambda_restraints'] = force.getForceGroup()
-        return {memo['lambda_restraints']}
-
-    @staticmethod
-    def _get_system_forces_parameters(system):
-        """Yields the system's forces having a ``lambda_restraints`` parameter.
-
-        Yields
-        ------
-        A tuple force, ``parameter_index`` for each force with ``lambda_restraints``.
-
-        """
-        found_restraint = False
-
-        # Retrieve all the forces with global supported parameters.
-        for force_index in range(system.getNumForces()):
-            force = system.getForce(force_index)
-            try:
-                n_global_parameters = force.getNumGlobalParameters()
-            except AttributeError:
-                continue
-            for parameter_id in range(n_global_parameters):
-                parameter_name = force.getGlobalParameterName(parameter_id)
-                if parameter_name == 'lambda_restraints':
-                    found_restraint = True
-                    yield force, parameter_id
-                    break
-
-        # Raise error if the system doesn't have a restraint.
-        if found_restraint is False:
-            raise RestraintStateError('The system does not have a restraint.')
-
-    def __getstate__(self):
-        return dict(lambda_restraints=self._lambda_restraints)
-
-    def __setstate__(self, serialization):
-        self.lambda_restraints = serialization['lambda_restraints']
+    @lambda_restraints.validator
+    def lambda_bonds(self, instance, new_value):
+        if new_value is not None and not (0.0 <= new_value <= 1.0):
+            raise ValueError('lambda_restraints must be between 0.0 and 1.0')
+        return float(new_value)
 
 
 # ==============================================================================

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -205,7 +205,7 @@ class RestraintState(GlobalParameterState):
     lambda_restraints = GlobalParameterState.GlobalParameter('lambda_restraints', standard_value=1.0)
 
     @lambda_restraints.validator
-    def lambda_restraints_validator(self, instance, new_value):
+    def lambda_restraints(self, instance, new_value):
         if new_value is None:
             return None
         if not (0.0 <= new_value <= 1.0):

--- a/Yank/restraints.py
+++ b/Yank/restraints.py
@@ -143,6 +143,11 @@ class RestraintState(GlobalParameterState):
 
     Parameters
     ----------
+    parameters_name_suffix : str, optional
+        If specified, the state will control the parameter
+        ``lambda_restraint_[parameters_name_suffix]`` instead of just
+        ``lambda_restraint``. This is useful if it's necessary to control
+        multiple restraints.
     lambda_restraints : float
         The strength of the restraint. Must be between 0 and 1.
 

--- a/Yank/tests/test_restraints.py
+++ b/Yank/tests/test_restraints.py
@@ -578,7 +578,8 @@ class TestRestraintState(object):
 
             # Changing the attribute changes the internal representation of a system.
             compound_state.lambda_restraints = 0.5
-            for force, parameter_id in compound_state._get_system_forces_parameters(compound_state.system):
+            for force, parameter_name, parameter_id in compound_state._get_system_controlled_parameters(
+                    compound_state.system, parameters_name_suffix=None):
                 assert force.getGlobalParameterDefaultValue(parameter_id) == 0.5
 
     def test_apply_to_context(self):
@@ -606,7 +607,7 @@ class TestRestraintState(object):
             assert compound_state.is_state_compatible(compatible_state)
 
             # Trying to assign a System without a Restraint raises an error.
-            with nose.tools.assert_raises(yank.restraints.RestraintStateError):
+            with nose.tools.assert_raises(mmtools.states.GlobalParameterError):
                 compound_state.system = unrestrained_system
 
     def test_find_force_groups_to_update(self):
@@ -616,7 +617,8 @@ class TestRestraintState(object):
 
             # Find the restraint force group.
             system = context.getSystem()
-            force, _ = next(yank.restraints.RestraintState._get_system_forces_parameters(system))
+            force, _, _ = next(yank.restraints.RestraintState._get_system_controlled_parameters(
+                system, parameters_name_suffix=None))
             force_group = force.getForceGroup()
 
             # No force group should be updated if we don't move.

--- a/Yank/tests/test_yank.py
+++ b/Yank/tests/test_yank.py
@@ -424,8 +424,7 @@ class TestAlchemicalPhase(object):
         name, thermodynamic_state, sampler_state, topography = self.host_guest_implicit
         protocol = {
             'lambda_sterics': [0.0, 0.5, 1.0],
-            'temperature': [300, 320, 300] * unit.kelvin,
-            'update_alchemical_charges': [True, True, False]
+            'temperature': [300, 320, 300] * unit.kelvin
         }
         alchemical_phase = AlchemicalPhase(sampler=ReplicaExchangeSampler())
         with self.temporary_storage_path() as storage_path:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - netcdf4 ==1.3.1  # TODO: Fix this right after bugfix: "always return masked array by default, even if there are no masked values"
     - openmm >=7.1
     - mdtraj >=1.7.2
-    - openmmtools >=0.15.0
+    - openmmtools >=0.17.0
     - pymbar
     - ambermini >=16.16.0
     - docopt

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,12 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.24.0 Development
+------------------
+
+- This release requires OpenMMTools >= 0.17.0, which includes a much faster way of implementing exact treatment of PME
+during alchemical calculations (`#1136 <https://github.com/choderalab/yank/pull/1136>`_).
+
 0.23.7 Bugfix release
 ---------------------
 


### PR DESCRIPTION
A couple of fixes necessary after the new OpenMMTools 0.17.0 release.
- Fix #1133: Remove reference to AlchemicalState(update_alchemical_charges), which was dropped in OpenMMtools 0.17 with the new exact PME scheme.
- `RestraintState` inherits from `openmmtools.states.GlobalParameterState`. This removes the deprecated warnings and add support for the kwarg `parameters_name_suffix`, which is necessary for the multi-restraint feature (this fix was already done in the `multirestraint` branch, but it'll take a little for that to be merged into master).