### PR TITLE
Remove "sudo" keyword from Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: c
-sudo: false
 addons:
   apt:
     sources:


### PR DESCRIPTION
... as its usage is deprecated, cf
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration