### PR TITLE
Truncated octahedral box geometry in Leap class

### DIFF
--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1852,7 +1852,7 @@ class SetupDatabase:
                                                       _OPENMM_LEAP_SOLVENT_FILES_MAP[solvent_model]))
                 logger.warning(solvent_warning)
             leap_solvent_model = _OPENMM_LEAP_SOLVENT_MODELS_MAP[solvent_model]
-            clearance = float(solvent['clearance'].value_in_unit(unit.angstroms))
+            clearance = solvent['clearance'].value_in_unit(unit.angstroms)
             tleap.solvate(unit_name=unit_to_solvate, solvent_model=leap_solvent_model, clearance=clearance)
 
             # First, determine how many ions we need to add for the ionic strength.

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1852,7 +1852,7 @@ class SetupDatabase:
                                                       _OPENMM_LEAP_SOLVENT_FILES_MAP[solvent_model]))
                 logger.warning(solvent_warning)
             leap_solvent_model = _OPENMM_LEAP_SOLVENT_MODELS_MAP[solvent_model]
-            clearance = solvent['clearance'].value_in_unit(unit.angstroms)
+            clearance = solvent['clearance']
             tleap.solvate(unit_name=unit_to_solvate, solvent_model=leap_solvent_model, clearance=clearance)
 
             # First, determine how many ions we need to add for the ionic strength.

--- a/Yank/tests/test_utils.py
+++ b/Yank/tests/test_utils.py
@@ -13,6 +13,7 @@ import abc
 import textwrap
 
 import openmoltools as omt
+from simtk import openmm, unit
 
 from nose import tools
 from yank.utils import * # TODO: Don't use 'import *'
@@ -290,12 +291,12 @@ def test_TLeap_script():
     tleap.load_unit(unit_name='ligand', file_path='path/to/ligand.gaff.mol2')
     tleap.transform('ligand', np.array([[1, 0, 0, 6], [0, -1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]))
     tleap.combine('complex', '5receptor', 'ligand')
-    tleap.solvate(unit_name='complex', solvent_model='TIP3PBOX', clearance=10.0)
+    tleap.solvate(unit_name='complex', solvent_model='TIP3PBOX', clearance=10.0*unit.angstrom)
     tleap.add_commands('check complex', 'charge complex')
     tleap.new_section('New section')
     tleap.save_unit(unit_name='complex', output_path='complex.prmtop')
     tleap.save_unit(unit_name='complex', output_path='complex.pdb')
-    tleap.solvate(unit_name='ligand', solvent_model='TIP3PBOX', clearance=10.0)
+    tleap.solvate(unit_name='ligand', solvent_model='TIP3PBOX', clearance=10.0*unit.angstrom)
     tleap.save_unit(unit_name='ligand', output_path='solvent.inpcrd')
     tleap.save_unit(unit_name='ligand', output_path='solvent.pdb')
 

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1587,7 +1587,7 @@ class TLeap:
             Name of the existing LEaP unit which will be solvated
         solvent_model : str
             LEaP recognized name of the solvent model to use, e.g. "TIP3PBOX"
-        clearance : simtk.unit.Quantity
+        clearance : unit.Quantity
             Add solvent up to clearance distance away (units of length) from the unit_name (radial)
         box_geometry : "cubic" or "truncated_octahedral"
             Shape of the box to be solvated (Default is "cubic").

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1601,7 +1601,7 @@ class TLeap:
                              "cubic" or "truncated_octahedral".')
 
         self.add_commands('{} {} {} {} iso'.format(solvate_command, unit_name,
-                                                   solvent_model, str(clearance)))
+                                                   solvent_model, str(clearance.value_in_unit(unit.angstroms))))
 
     @_sanitize_tleap_unit_name
     def save_unit(self, unit_name, output_path):

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1575,7 +1575,7 @@ class TLeap:
             self.add_commands('addIons2 {} {} {}'.format(unit_name, ion, num_ions))
 
     @_sanitize_tleap_unit_name
-    def solvate(self, unit_name, solvent_model, clearance):
+    def solvate(self, unit_name, solvent_model, clearance, box_geometry="cubic"):
         """
         Solvate a unit in LEaP isometrically
 
@@ -1589,9 +1589,19 @@ class TLeap:
             LEaP recognized name of the solvent model to use, e.g. "TIP3PBOX"
         clearance : float
             Add solvent up to clearance distance away from the unit_name (radial)
+        box_geometry : "cubic" or "truncated_octahedral"
+            Shape of the box to be solvated (Default is "cubic").
         """
-        self.add_commands('solvateBox {} {} {} iso'.format(unit_name, solvent_model,
-                                                           str(clearance)))
+        if box_geometry=="cubic":
+            solvate_command='solvateBox'
+        elif box_geometry=="truncated_octahedral":
+            solvate_command='solvateOct'
+        else:
+            raise ValueError('The argument box_geometry must take one of the following values: \
+                             "cubic" or "truncated_octahedral".')
+
+        self.add_commands('{} {} {} {} iso'.format(solvate_command, unit_name,
+                                                   solvent_model, str(clearance)))
 
     @_sanitize_tleap_unit_name
     def save_unit(self, unit_name, output_path):

--- a/Yank/utils.py
+++ b/Yank/utils.py
@@ -1587,8 +1587,8 @@ class TLeap:
             Name of the existing LEaP unit which will be solvated
         solvent_model : str
             LEaP recognized name of the solvent model to use, e.g. "TIP3PBOX"
-        clearance : float
-            Add solvent up to clearance distance away from the unit_name (radial)
+        clearance : simtk.unit.Quantity
+            Add solvent up to clearance distance away (units of length) from the unit_name (radial)
         box_geometry : "cubic" or "truncated_octahedral"
             Shape of the box to be solvated (Default is "cubic").
         """


### PR DESCRIPTION
Hi!

Leap class in utils.py can be very useful, even out of yank. Would you support the possibility to produce truncated octahedral boxes with it?

The small modification necessary in Leap.solvate() is included in this PR with a new input argument ` box_geometry` taking the values "cubic" (default) or "truncated_octahedral".

Thanks in advance.