### PR TITLE
Importing logsumexp from scipy.special in Multistateanalyzer

### DIFF
--- a/Yank/multistate/multistateanalyzer.py
+++ b/Yank/multistate/multistateanalyzer.py
@@ -31,7 +31,7 @@ import mdtraj
 import numpy as np
 from simtk import openmm
 import simtk.unit as units
-from scipy.misc import logsumexp
+from scipy.special import logsumexp
 from pymbar import MBAR, timeseries
 import openmmtools as mmtools
 


### PR DESCRIPTION
There was a `logsumexp` left to be fixed: in the file multistateanalyzer.
This was probably the source of the errors reported by Travis CI.