### PR TITLE
Fix tests and more robust netcdf opening

### DIFF
--- a/Yank/multistate/multistatereporter.py
+++ b/Yank/multistate/multistatereporter.py
@@ -368,6 +368,12 @@ class MultiStateReporter(object):
                 logger.debug('Attempt {}/{} to open {} failed. Retrying '
                              'in {} seconds'.format(i+1, n_attempts, sleep_time))
                 time.sleep(sleep_time)
+
+        # At the very last attempt, we try setting the environment variable
+        # controlling the locking mechanism of HDF5 (see choderalab/yank#1165).
+        if n_attempts > 1:
+            os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
+
         # Last attempt finally raises any error.
         return netcdf.Dataset(*args, **kwargs)
 

--- a/Yank/multistate/replicaexchange.py
+++ b/Yank/multistate/replicaexchange.py
@@ -254,8 +254,8 @@ class ReplicaExchangeSampler(MultiStateSampler):
                 # otherwise fall back to Python-accelerated code.
                 try:
                     self._mix_all_replicas_cython()
-                except ValueError as e:
-                    logger.warning(e.message)
+                except (ValueError, ImportError) as e:
+                    logger.warning(str(e))
                     self._mix_all_replicas()
             else:
                 assert self.replica_mixing_scheme is None

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -753,7 +753,7 @@ def test_validation_correct_systems():
 
 
 def test_validation_wrong_systems():
-    """YAML validation raises exception with wrong experiments specification."""
+    """YAML validation raises exception with wrong systems specification."""
     data_paths = examples_paths()
     exp_builder = ExperimentBuilder()
     basic_script = """
@@ -779,10 +779,10 @@ def test_validation_wrong_systems():
         ("regions\(s\) clashing",
             {'receptor': 'rec_region', 'ligand': 'lig_region', 'solvent': 'solv'}),
 
-        ("ligand: \[must be of string type\]",
+        ("ligand:\n- must be of string type",
             {'receptor': 'rec', 'ligand': 1, 'solvent': 'solv'}),
 
-        ("solvent: \[must be of string type\]",
+        ("solvent:\n- must be of string type",
             {'receptor': 'rec', 'ligand': 'lig', 'solvent': ['solv', 'solv']}),
 
         ("unallowed value unknown",
@@ -792,11 +792,11 @@ def test_validation_wrong_systems():
             {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv4',
              'leap': {'parameters': ['leaprc.gaff', 'leaprc.ff14SB']}}),
 
-        ("parameters: \[unknown field\]",
+        ("parameters:\n- unknown field",
             {'receptor': 'rec', 'ligand': 'lig', 'solvent': 'solv3',
              'parameters': 'leaprc.ff14SB'}),
 
-        ("phase1_path: \[must be of list type\]",
+        ("phase1_path:\n- must be of list type",
             {'phase1_path': data_paths['bentol-complex'][0],
              'phase2_path': data_paths['bentol-solvent'],
              'ligand_dsl': 'resname BEN', 'solvent': 'solv'}),
@@ -806,7 +806,7 @@ def test_validation_wrong_systems():
             'phase2_path': data_paths['bentol-solvent'],
             'ligand_dsl': 'resname BEN', 'solvent': 'solv'}),
 
-        ("ligand_dsl: \[must be of string type\]",
+        ("ligand_dsl:\n- must be of string type",
             {'phase1_path': data_paths['bentol-complex'],
              'phase2_path': data_paths['bentol-solvent'],
              'ligand_dsl': 3.4, 'solvent': 'solv'}),
@@ -828,7 +828,7 @@ def test_validation_wrong_systems():
         ("''ligand'' must not be present with ''solute''",
             {'ligand': 'lig', 'solute': 'lig', 'solvent1': 'solv', 'solvent2': 'solv'}),
 
-        ("leap: \[must be of dict type\]",
+        ("leap:\n- must be of dict type",
             {'solute': 'lig', 'solvent1': 'solv', 'solvent2': 'solv', 'leap': 'leaprc.gaff'})
     ]
     for regexp, system in systems:
@@ -852,10 +852,10 @@ def test_validation_correct_mcmc_moves():
 
 
 def test_validation_wrong_mcmc_moves():
-    """YAML validation raises exception with wrong experiments specification."""
+    """YAML validation raises exception with wrong mcmc move specification."""
     # Each test case is a pair (regexp_error, mcmc_move_description).
     mcmc_moves = [
-        ("The expression 2.0 must be\s+ a string",
+        ("The expression 2.0 must be a string",
             {'type': 'LangevinSplittingDynamicsMove', 'timestep': 2.0}),
         ("Could not find class UnknownMoveClass",
             {'type': 'UnknownMoveClass'}),

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,14 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.24.1 Bugfix release
+---------------------
+
+Bugfixes
+^^^^^^^^
+- Improve the robustness of opening the netcdf file on resuming of the multi-state samplers by setting the environment variable ``HDF5_USE_FILE_LOCKING`` to ``'FALSE'`` after 4 failed attempts (`#1168 <https://github.com/choderalab/yank/pull/1168>`_).
+- Fixed a bug causing a crash during exception handling (`#1168 <https://github.com/choderalab/yank/pull/1168>`_).
+
 0.24.0 Experimental support for online status files
 ---------------------------------------------------
 


### PR DESCRIPTION
- Implement the fix suggested in #1165 to work around the netcdf locking issues.
- Fix a crash during exception handling.
- Fixed some tests that were failing with a different message than the expected one.