### PR TITLE
Fix #917: CLI command to setup simulations only

### DIFF
--- a/Yank/commands/script.py
+++ b/Yank/commands/script.py
@@ -23,7 +23,7 @@ usage = """
 YANK script
 
 Usage:
-  yank script (-y FILEPATH | --yaml=FILEPATH) [--jobid=INTEGER] [--njobs=INTEGER] [-o OVERRIDE] [--status] ...
+  yank script (-y FILEPATH | --yaml=FILEPATH) [--setup-only] [--jobid=INTEGER] [--njobs=INTEGER] [-o OVERRIDE] [--status] ...
 
 Description:
   Set up and run free energy calculations from a YAML script. All options can be specified in the YAML script.
@@ -32,6 +32,8 @@ Required Arguments:
   -y, --yaml=FILEPATH           Path to the YAML script specifying options and/or how to set up and run the experiment.
 
 Optional Arguments:
+  --setup-only                  If given, only the automatic setup pipeline is run without running the free energy
+                                calculation.
   --jobid=INTEGER               You can run only a subset of the experiments by specifying jobid and njobs, where
                                 1 <= job_id <= n_jobs. In this case, njobs must be specified as well and YANK will
                                 run only 1/n_jobs of the experiments. This can be used to run several separate YANK
@@ -145,7 +147,12 @@ def dispatch(args):
         yaml_builder = ExperimentBuilder(script=yaml_path, job_id=job_id, n_jobs=n_jobs)
         if override:  # Parse the string present.
             yaml_builder.update_yaml(override)
-        yaml_builder.run_experiments(write_status=write_status)
+
+        # Check if we need to run only the automatic setup pipeline or also the experiments.
+        if args['--setup-only']:
+            yaml_builder.setup_experiments()
+        else:
+            yaml_builder.run_experiments(write_status=write_status)
         return True
 
     return False

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2031,15 +2031,17 @@ class ExperimentBuilder(object):
         # if we run multiple experiments in parallel, we won't have
         # multiple processes running the same one.
         try:
-            if isinstance(yaml_content['experiments'], list):
-                combinatorial_trees = [(exp_name, utils.CombinatorialTree(yaml_content[exp_name]))
-                                       for exp_name in yaml_content['experiments']]
-            else:
-                combinatorial_trees = [('experiments', utils.CombinatorialTree(yaml_content['experiments']))]
-            self._experiments = collections.OrderedDict(combinatorial_trees)
+            experiments_section = yaml_content['experiments']
         except KeyError:
             self._experiments = collections.OrderedDict()
             return
+
+        if isinstance(experiments_section, list):
+            combinatorial_trees = [(exp_name, utils.CombinatorialTree(yaml_content[exp_name]))
+                                   for exp_name in experiments_section]
+        else:
+            combinatorial_trees = [('experiments', utils.CombinatorialTree(experiments_section))]
+        self._experiments = collections.OrderedDict(combinatorial_trees)
 
         # Experiments Schema
         experiment_schema_yaml = """

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -16,7 +16,11 @@ API-breaking changes
 
 New features
 ^^^^^^^^^^^^
-- The trailblaze algorithm used for the authomatic generation of the alchemical path is now capable of resuming after an unexpected interruption or crash. The samples generated during the process are used to initialize the replicas of the replica exchange or SAMS free energy calculation (`#1176 <https://github.com/choderalab/yank/pull/1176>`_).
+- The trailblaze algorithm used for the authomatic generation of the alchemical path is now capable of resuming after an
+  unexpected interruption or crash. The samples generated during the process are used to initialize the replicas of the
+  replica exchange or SAMS free energy calculation (`#1176 <https://github.com/choderalab/yank/pull/1176>`_).
+- Added a ``--setup-only`` flag in the ``yank script`` CLI command to run the automatic setup pipeline without running
+  the free energy calculation (`#1178 <https://github.com/choderalab/yank/pull/1178>`_).
 
 Enhancements
 ^^^^^^^^^^^^

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -22,6 +22,11 @@ New features
 - Added a ``--setup-only`` flag in the ``yank script`` CLI command to run the automatic setup pipeline without running
   the free energy calculation (`#1178 <https://github.com/choderalab/yank/pull/1178>`_).
 
+Bugfixes
+^^^^^^^^
+- Fix a bug in which a list of ``experiments: [exp1, exp2]`` in the YAML file containing an unkown experiment name would
+  fail silently without error (`#1178 <https://github.com/choderalab/yank/pull/1178>`_).
+
 Enhancements
 ^^^^^^^^^^^^
 - By default, the automatic determination of the alchemical path now starts with the harmonic/flat-bottom restraint turned off and activate it in intermediate states instead of keeping the restraint activated throughout the calculation and reweighting in the analysis stage (`#1176 <https://github.com/choderalab/yank/pull/1176>`_).


### PR DESCRIPTION
Fix #917: Add a `--setup-only` flag to the `yank script` to run only the automatic setup pipeline and skip the free energy calculation.

## Status
- [x] Ready to go.