### PR TITLE
Fix Cerberus and support for trailblaze options

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -2472,7 +2472,7 @@ class ExperimentBuilder(object):
                                                       restrained_atoms, sigma=3.0*unit.angstroms)
 
             # Find protocol.
-            alchemical_path = pipeline.trailblaze_alchemical_protocol(
+            alchemical_path = pipeline.run_thermodynamic_trailblazing(
                 thermodynamic_state, sampler_state, mcmc_move, state_parameters,
                 checkpoint_dir_path=trailblaze_dir_path, **trailblazer_options)
             optimal_protocols[phase_name] = alchemical_path

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -556,7 +556,8 @@ class ExperimentBuilder(object):
         'hydrogen_mass': 1 * unit.amu,
         'default_nsteps_per_iteration': 500,
         'default_timestep': 2.0 * unit.femtosecond,
-        'default_number_of_iterations': 5000
+        'default_number_of_iterations': 5000,
+        'start_from_trailblaze_samples': True
     }
 
     def __init__(self, script=None, job_id=None, n_jobs=None):
@@ -3029,22 +3030,23 @@ class ExperimentBuilder(object):
             # If we have generated samples with trailblaze, we start the
             # simulation from those samples. Also, we can turn off minimization
             # as it has been already performed before trailblazing.
-            trailblaze_checkpoint_dir_path = self._get_trailblaze_checkpoint_dir_path(
-                experiment_path, phase_name)
-            try:
-                sampler_state = pipeline.read_trailblaze_checkpoint_coordinates(
-                    trailblaze_checkpoint_dir_path)
-            except FileNotFoundError:
-                # Just keep the sampler state read from the inpcrd file.
-                pass
-            else:
-                # If this is SAMS, just use the sampler state associated
-                # to the initial thermodynamic state.
-                if isinstance(sampler, mmtools.multistate.SAMSSampler):
-                    sampler_state = sampler_state[0]
-                # Also, these states have been already minimized so we
-                # can skip a second minimization.
-                phase_opts['minimize'] = False
+            if exp_opts['start_from_trailblaze_samples'] is True:
+                trailblaze_checkpoint_dir_path = self._get_trailblaze_checkpoint_dir_path(
+                    experiment_path, phase_name)
+                try:
+                    sampler_state = pipeline.read_trailblaze_checkpoint_coordinates(
+                        trailblaze_checkpoint_dir_path)
+                except FileNotFoundError:
+                    # Just keep the sampler state read from the inpcrd file.
+                    pass
+                else:
+                    # If this is SAMS, just use the sampler state associated
+                    # to the initial thermodynamic state.
+                    if isinstance(sampler, mmtools.multistate.SAMSSampler):
+                        sampler_state = sampler_state[0]
+                    # Also, these states have been already minimized so we
+                    # can skip a second minimization.
+                    phase_opts['minimize'] = False
 
             # Create phases.
             phases[phase_idx] = AlchemicalPhaseFactory(sampler, thermodynamic_state, sampler_state,

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1485,6 +1485,28 @@ class ExperimentBuilder(object):
             If the syntax for any protocol is not valid.
 
         """
+
+        protocol_value_schema = yaml.load("""
+        alchemical_path:
+            required: yes
+
+            # Must be a string ('auto') or a dictionary specifying the path.
+            type: [string, dict]
+            anyof:
+                - allowed: [auto]
+                - check_with: specify_lambda_electrostatics_and_sterics
+
+            # If a dictionary, check that this is a valid path.
+            keysrules:
+                type: string
+            valuesrules:
+                type: [string, list]
+                check_with: lambda_between_0_and_1
+                schema:
+                    type: [float, quantity]
+                    coerce: str_to_unit
+        """, Loader=yaml.FullLoader)
+
         def sort_protocol(protocol):
             """Reorder phases in dictionary to have complex/solvent1 first."""
             sortables = [('complex', 'solvent'), ('solvent1', 'solvent2')]
@@ -1504,78 +1526,25 @@ class ExperimentBuilder(object):
                                  'OR "solvent1" and "solvent2", the phase names must also be non-ambiguous so each '
                                  'keyword can only appear in a single phase, not multiple.')
 
-        def validate_string_auto(field, value, error):
-            if isinstance(value, str) and value != 'auto':
-                error(field, "Only the exact string 'auto' is accepted as a string argument, not {}.".format(value))
-
-        def cast_quantity_strings(value):
-            """Take an object and try to cast quantity strings to quantity, otherwise return object"""
-            if isinstance(value, str):
-                value = utils.quantity_from_string(value)
-            return value
-
-        def validate_required_entries_dict(field, value, error):
-            """Ensure the required entries are in the dict, string is checked by a separate validator"""
-            if isinstance(value, dict) or isinstance(value, collections.OrderedDict):
-                if 'lambda_sterics' not in value.keys() or 'lambda_electrostatics' not in value.keys():
-                    error(field, "Missing required keys lambda_sterics and/or lambda_electrostatics")
-
-        def validate_lambda_min_max(field, value, error):
-            """Ensure keys which are lambda values are in fact between 0 and 1"""
-            base_error = "Entries with a 'lambda_' must be a float between 0 and 1, inclusive. Values {} are not."
-            collected_bad_values = []
-            if "lambda_" in field:
-                for single_value in value:
-                    if not (isinstance(single_value, float) and 0 <= single_value <= 1.0):
-                        collected_bad_values.append(single_value)
-            if len(collected_bad_values):
-                error(field, base_error.format(collected_bad_values))
-
-        # Define protocol Schema
-        # Note: Cannot cleanly do yaml.dump(v.errors) for nested `schema`/`*of` logic from Cerberus until its 1.2
-        protocol_value_schema = {
-            'alchemical_path': {  # The only literal key
-                'required': True,  # Key is required
-                'type': ['string', 'dict'],  # Must be a string or dictionary
-                # Use this to check the string value until Cerberus 1.2 for `oneof`
-                # Check string with validate_string_auto, pass other values to next validator
-                # Check the dict values with validate_required_entries_doct, ignore other values
-                'check_with': [validate_string_auto, validate_required_entries_dict],
-                'keyschema': {  # Validate the keys of this sub-dictionary against this schema
-                    'type': 'string'
-                },
-                'valueschema': {  # Validate the values of this sub-dictionary against this schema
-                    'type': 'list',  # They must be a list (dont accept single values)
-                    # Check if it has the `lambda_` string that its a float within [0,1]
-                    'check_with': validate_lambda_min_max,
-                    'schema': {
-                        'type': ['float', 'quantity'],  # Ensure the output type is float or quantity
-                        # Cast strings to quantity. Everything else had to validate down to this point
-                        'coerce': cast_quantity_strings,
-                    }
-                }
-            }
-        }
-
-        # Validate the top level keys (cannot be done with Cerberus)
-        def validate_protocol_keys_and_values(protocol_id, protocol):
-            # Ensure the protocol is 2 keys
+        def validate_protocol(protocol_id, protocol):
+            # First, validate the top level keys (cannot be done with Cerberus).
+            # Ensure the protocol has 2 keys.
             if len(protocol) != 2:
                 raise YamlParseError('Protocol {} must only have two phases, found {}'.format(protocol_id,
                                                                                               len(protocol)))
-            # Ensure the protocol keys are in fact strings
-            keys_not_strings = []
-            key_string_error = 'Protocol {} has keys which are not strings: '.format(protocol_id)
-            for key in protocol.keys():
-                if not isinstance(key, str):
-                    keys_not_strings.append(key)
+            # Ensure the protocol keys are strings.
+            keys_not_strings = [k for k in protocol.keys() if not isinstance(k, str)]
             if len(keys_not_strings) > 0:
-                # The join(list_comprehension) forces invalid keys to a string so the join command works
-                raise YamlParseError(key_string_error + ', '.join(['{}'.format(key) for key in keys_not_strings]))
-            # Check for ordered dict or the sorted keys
+                key_string_error = f'Protocol {protocol_id} has keys which are not strings: '
+                # Convert non-string values to string for printing.
+                key_string_error += ', '.join([str(key) for key in keys_not_strings])
+                raise YamlParseError(key_string_error)
+
+            # Order the two phases, unless a ordered dictionary is given.
             if not isinstance(protocol, collections.OrderedDict):
                 protocol = sort_protocol(protocol)
-            # Now user cerberus to validate the alchemical path part
+
+            # Now user cerberus to validate the alchemical_path part.
             errored_phases = []
             for phase_key, phase_entry in protocol.items():
                 phase_validator = schema.YANKCerberusValidator(protocol_value_schema)
@@ -1585,21 +1554,23 @@ class ExperimentBuilder(object):
                 else:
                     # collect the errors
                     errored_phases.append([phase_key, yaml.dump(phase_validator.errors)])
+
+            # Riase informative error about all phases that failed.
             if len(errored_phases) > 0:
-                # Throw error
-                error = "Protocol {} failed because one or more of the phases did not validate, see the errors below " \
-                        "for more information.\n".format(protocol_id)
+                error = (f"Protocol {protocol_id} failed because one or more of the phases"
+                          " did not validate, see the errors below for more information.\n")
                 for phase_id, phase_error in errored_phases:
                     error += "Phase: {}\n----\n{}\n====\n".format(phase_id, phase_error)
                 raise YamlParseError(error)
-            # Finally return if everything is fine
+
+            # Finally return if everything is fine.
             return protocol
 
         validated_protocols = protocols_description.copy()
         # Schema validation
         for protocol_id, protocol_descr in protocols_description.items():
             # Error is raised in the function
-            validated_protocols[protocol_id] = validate_protocol_keys_and_values(protocol_id, protocol_descr)
+            validated_protocols[protocol_id] = validate_protocol(protocol_id, protocol_descr)
 
         return validated_protocols
 

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1224,7 +1224,7 @@ class ExperimentBuilder(object):
             valueschema:
                 anyof:
                     - type: list
-                      validator: positive_int_list
+                      check_with: positive_int_list
                     - type: string
                     - type: integer
                       min: 0
@@ -1248,7 +1248,7 @@ class ExperimentBuilder(object):
             type: string
             excludes: [smiles, name]
             required: yes
-            validator: [is_small_molecule, file_exists]
+            check_with: [is_small_molecule, file_exists]
         openeye:
             required: no
             type: dict
@@ -1272,7 +1272,7 @@ class ExperimentBuilder(object):
         select:
             required: no
             dependencies: filepath
-            validator: int_or_all_string
+            check_with: int_or_all_string
         """
         # Build small molecule Epik by hand as dict since we are fetching from another source
         epik_schema = schema.generate_signature_schema(moltools.schrodinger.run_epik,
@@ -1294,11 +1294,11 @@ class ExperimentBuilder(object):
         filepath:
             required: yes
             type: string
-            validator: [is_peptide, file_exists]
+            check_with: [is_peptide, file_exists]
         select:
             required: no
             dependencies: filepath
-            validator: int_or_all_string
+            check_with: int_or_all_string
         strip_protons:
             required: no
             type: boolean
@@ -1400,13 +1400,13 @@ class ExperimentBuilder(object):
 
         # The nonbonded_cutoff keyword is accepted only if the nonbonded method has a cutoff.
         solvent_schema['nonbonded_cutoff'].update({
-            'validator': 'only_with_cutoff'
+            'check_with': 'only_with_cutoff'
         })
 
         # The implicit_solvent keyword should be accepted only with no cutoff.
         solvent_schema['implicit_solvent'].update({
             'coerce': 'str_to_openmm_app',
-            'validator': 'only_with_no_cutoff'
+            'check_with': 'only_with_no_cutoff'
         })
 
         # Add leap schema.
@@ -1418,36 +1418,36 @@ class ExperimentBuilder(object):
             required: yes
             default: NoCutoff
             coerce: str_to_openmm_app
-            validator: is_valid_nonbonded_method
+            check_with: is_valid_nonbonded_method
 
         # Explicit solvent schema. These keywords are valid
         # only if the nonbonded method has a cutoff.
         clearance:
             type: quantity
             coerce: str_to_distance_unit
-            validator: mandatory_with_cutoff
+            check_with: mandatory_with_cutoff
         solvent_model:
             required: no
             nullable: yes
             type: string
             allowed: [tip3p, tip3pfb, tip4pew, tip5p, spce]
             default_setter: tip4pew_or_none
-            validator: only_with_cutoff
+            check_with: only_with_cutoff
         positive_ion:
             required: no
             type: string
-            validator: only_with_cutoff
+            check_with: only_with_cutoff
         negative_ion:
             required: no
             type: string
-            validator: only_with_cutoff
+            check_with: only_with_cutoff
         ionic_strength:
             required: no
             nullable: yes
             type: quantity
             default_setter: 0_molar_or_none
             coerce: str_to_molar_unit
-            validator: only_with_cutoff
+            check_with: only_with_cutoff
 
         """, Loader=yaml.FullLoader))
 
@@ -1540,14 +1540,14 @@ class ExperimentBuilder(object):
                 # Use this to check the string value until Cerberus 1.2 for `oneof`
                 # Check string with validate_string_auto, pass other values to next validator
                 # Check the dict values with validate_required_entries_doct, ignore other values
-                'validator': [validate_string_auto, validate_required_entries_dict],
+                'check_with': [validate_string_auto, validate_required_entries_dict],
                 'keyschema': {  # Validate the keys of this sub-dictionary against this schema
                     'type': 'string'
                 },
                 'valueschema': {  # Validate the values of this sub-dictionary against this schema
                     'type': 'list',  # They must be a list (dont accept single values)
                     # Check if it has the `lambda_` string that its a float within [0,1]
-                    'validator': validate_lambda_min_max,
+                    'check_with': validate_lambda_min_max,
                     'schema': {
                         'type': ['float', 'quantity'],  # Ensure the output type is float or quantity
                         # Cast strings to quantity. Everything else had to validate down to this point
@@ -1677,21 +1677,21 @@ class ExperimentBuilder(object):
             type: list
             schema:
                 type: string
-                validator: file_exists
+                check_with: file_exists
             dependencies: phase2_path
-            validator: supported_system_file_format
+            check_with: supported_system_file_format
         phase2_path:
             required: no
             type: list
             schema:
                 type: string
-                validator: file_exists
-            validator: supported_system_file_format
+                check_with: file_exists
+            check_with: supported_system_file_format
         gromacs_include_dir:
             required: no
             type: string
             dependencies: [phase1_path, phase2_path]
-            validator: directory_exists
+            check_with: directory_exists
 
         # Solvents
         solvent:
@@ -1699,7 +1699,7 @@ class ExperimentBuilder(object):
             type: string
             excludes: [solvent1, solvent2]
             allowed: SOLVENT_IDS_POPULATED_AT_RUNTIME
-            validator: PIPELINE_SOLVENT_DETERMINED_AT_RUNTIME_WITH_RECEPTOR
+            check_with: PIPELINE_SOLVENT_DETERMINED_AT_RUNTIME_WITH_RECEPTOR
             oneof:
                 - dependencies: [phase1_path, phase2_path]
                 - dependencies: [receptor, ligand]
@@ -1708,7 +1708,7 @@ class ExperimentBuilder(object):
             type: string
             excludes: solvent
             allowed: SOLVENT_IDS_POPULATED_AT_RUNTIME
-            validator: PIPELINE_SOLVENT_DETERMINED_AT_RUNTIME_WITH_SOLUTE
+            check_with: PIPELINE_SOLVENT_DETERMINED_AT_RUNTIME_WITH_SOLUTE
             oneof:
                 - dependencies: [phase1_path, phase2_path, solvent2]
                 - dependencies: [solute, solvent2]
@@ -1717,7 +1717,7 @@ class ExperimentBuilder(object):
             type: string
             excludes: solvent
             allowed: SOLVENT_IDS_POPULATED_AT_RUNTIME
-            validator: PIPELINE_SOLVENT_DETERMINED_AT_RUNTIME_WITH_SOLUTE
+            check_with: PIPELINE_SOLVENT_DETERMINED_AT_RUNTIME_WITH_SOLUTE
             oneof:
                 - dependencies: [phase1_path, phase2_path, solvent1]
                 - dependencies: [solute, solvent1]
@@ -1729,7 +1729,7 @@ class ExperimentBuilder(object):
             dependencies: [ligand, solvent]
             allowed: MOLECULE_IDS_POPULATED_AT_RUNTIME
             excludes: [solute, phase1_path, phase2_path]
-            validator: REGION_CLASH_DETERMINED_AT_RUNTIME_WITH_LIGAND
+            check_with: REGION_CLASH_DETERMINED_AT_RUNTIME_WITH_LIGAND
         ligand:
             required: no
             type: string
@@ -1746,7 +1746,7 @@ class ExperimentBuilder(object):
             type: string
             allowed: MOLECULE_IDS_POPULATED_AT_RUNTIME
             dependencies: [solvent1, solvent2]
-            validator: REGION_CLASH_DETERMINED_AT_RUNTIME
+            check_with: REGION_CLASH_DETERMINED_AT_RUNTIME
             excludes: [receptor, ligand]
         """
         # Load the YAML into a schema into dict format
@@ -1772,16 +1772,16 @@ class ExperimentBuilder(object):
             new_schema = system_schema.copy()
             # Handle the validators
             # Spin up the region clash calculators
-            new_schema['receptor']['validator'] = generate_region_clash_validator(system_descr, 'ligand', 'receptor')
-            new_schema['solute']['validator'] = generate_region_clash_validator(system_descr, 'solute')
+            new_schema['receptor']['check_with'] = generate_region_clash_validator(system_descr, 'ligand', 'receptor')
+            new_schema['solute']['check_with'] = generate_region_clash_validator(system_descr, 'solute')
             # "solvent"
-            new_schema['solvent']['validator'] = generate_is_pipeline_solvent_with_receptor_validator(system_descr,
-                                                                                                      'receptor')
+            new_schema['solvent']['check_with'] = generate_is_pipeline_solvent_with_receptor_validator(system_descr,
+                                                                                                       'receptor')
             # "solvent1" and "solvent2
-            new_schema['solvent1']['validator'] = generate_is_pipeline_solvent_with_receptor_validator(system_descr,
-                                                                                                       'solute')
-            new_schema['solvent2']['validator'] = generate_is_pipeline_solvent_with_receptor_validator(system_descr,
-                                                                                                       'solute')
+            new_schema['solvent1']['check_with'] = generate_is_pipeline_solvent_with_receptor_validator(system_descr,
+                                                                                                        'solute')
+            new_schema['solvent2']['check_with'] = generate_is_pipeline_solvent_with_receptor_validator(system_descr,
+                                                                                                        'solute')
             return new_schema
 
         validated_systems = systems_description.copy()
@@ -1809,7 +1809,7 @@ class ExperimentBuilder(object):
                 type: string
             valueschema:
                 type: dict
-                validator: is_mcmc_move_constructor
+                check_with: is_mcmc_move_constructor
                 keyschema:
                     type: string
         """
@@ -1835,7 +1835,7 @@ class ExperimentBuilder(object):
                 type: string
             valueschema:
                 type: dict
-                validator: is_sampler_constructor
+                check_with: is_sampler_constructor
                 allow_unknown: yes
                 schema:
                     mcmc_moves:
@@ -1942,7 +1942,7 @@ class ExperimentBuilder(object):
         restraint:
             required: no
             type: dict
-            validator: is_restraint_constructor
+            check_with: is_restraint_constructor
             keyschema:
                 type: string
         """

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -2036,7 +2036,7 @@ def read_trailblaze_checkpoint_coordinates(checkpoint_dir_path):
 
 def trailblaze_alchemical_protocol(
         thermodynamic_state, sampler_state, mcmc_move, state_parameters,
-        checkpoint_dir_path=None, std_energy_threshold=0.5,
+        checkpoint_dir_path=None, std_potential_threshold=0.5,
         threshold_tolerance=0.05, n_samples_per_state=100
 ):
     """
@@ -2048,7 +2048,7 @@ def trailblaze_alchemical_protocol(
     between the two states at those configurations.
 
     Two states are chosen for the protocol if their standard deviation is
-    within ``std_energy_threshold +- threshold_tolerance``.
+    within ``std_potential_threshold +- threshold_tolerance``.
 
     The function is capable of resuming when interrupted if ``checkpoint_dir_path``
     is specified. This will create two files called 'protocol.yaml' and
@@ -2074,7 +2074,7 @@ def trailblaze_alchemical_protocol(
         information to resume in case it was previously interrupted. If
         ``None``, no information is stored and it won't be possible to
         resume. Default is ``None``.
-    std_energy_threshold : float
+    std_potential_threshold : float
         The threshold that determines how to separate the states between
         each others.
     threshold_tolerance : float
@@ -2181,12 +2181,12 @@ def trailblaze_alchemical_protocol(
                 sampler_states.append(copy.deepcopy(sampler_state))
 
             # Find first state that doesn't overlap with simulated one
-            # with std(du) within std_energy_threshold +- threshold_tolerance.
+            # with std(du) within std_potential_threshold +- threshold_tolerance.
             # We stop anyway if we reach the last value of the protocol.
             std_energy = 0.0
             current_parameter_value = optimal_protocol[state_parameter][-1]
-            while (abs(std_energy - std_energy_threshold) > threshold_tolerance and
-                   not (current_parameter_value == values[1] and std_energy < std_energy_threshold)):
+            while (abs(std_energy - std_potential_threshold) > threshold_tolerance and
+                   not (current_parameter_value == values[1] and std_energy < std_potential_threshold)):
                 # Determine next parameter value to compute.
                 if np.isclose(std_energy, 0.0):
                     # This is the first iteration or the two state overlap significantly
@@ -2198,7 +2198,7 @@ def trailblaze_alchemical_protocol(
                     derivative_std_energy = ((std_energy - old_std_energy) /
                                              (current_parameter_value - old_parameter_value))
                     old_parameter_value = current_parameter_value
-                    current_parameter_value += (std_energy_threshold - std_energy) / derivative_std_energy
+                    current_parameter_value += (std_potential_threshold - std_energy) / derivative_std_energy
 
                 # Keep current_parameter_value inside bound interval.
                 if search_direction * current_parameter_value > values[1]:

--- a/Yank/pipeline.py
+++ b/Yank/pipeline.py
@@ -1994,7 +1994,7 @@ class _DCDTrajectoryFile(mdtraj.formats.dcd.DCDTrajectoryFile):
 
     def write_sampler_state(self, sampler_state):
         a, b, c, alpha, beta, gamma = mdtraj.utils.box_vectors_to_lengths_and_angles(
-            *(sampler_state.box_vectors / unit.angstrom))
+            *(np.array(sampler_state.box_vectors / unit.angstrom)))
         super().write(sampler_state.positions / unit.angstrom,
                       (a, b, c), (alpha, beta, gamma))
 
@@ -2229,7 +2229,7 @@ def run_thermodynamic_trailblazing(
                                              force_overwrite=True)
         if len_trajectory > 0:
             for i in range(len_trajectory):
-                trajectory_file.write_sampler_state(sampler_state[i])
+                trajectory_file.write_sampler_state(sampler_states[i])
             # Make sure the next search starts from the last saved position
             # unless the previous calculation was interrupted before the
             # first position could be saved.

--- a/Yank/schema/__init__.py
+++ b/Yank/schema/__init__.py
@@ -2,7 +2,9 @@
 A set of tools for validating Cerberus-based schemas
 """
 
-from .validator import YANKCerberusValidator
-from .validator import to_unit_coercer, to_integer_or_infinity_coercer
-from .validator import call_restraint_constructor, call_mcmc_move_constructor, call_sampler_constructor
-from .validator import generate_unknown_type_validator, type_to_cerberus_map, generate_signature_schema
+from .validator import (
+    YANKCerberusValidator,
+    to_openmm_app_coercer, to_unit_coercer, to_integer_or_infinity_coercer,
+    call_restraint_constructor, call_mcmc_move_constructor, call_sampler_constructor,
+    generate_unknown_type_validator, type_to_cerberus_map, generate_signature_schema,
+)

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -997,7 +997,7 @@ def test_validation_correct_protocols():
         {'n_equilibration_iterations': 100, 'n_samples_per_state': 10},
         {'std_potential_threshold': 1.0, 'threshold_tolerance': 0.5},
         {'function_variable_name': 'lambda'},
-        {'function_variable_name': 'lambda', 'reverse_direction': False}
+        {'function_variable_name': 'lambda', 'reversed_direction': False}
     ]
     for opts in trailblazer_options:
         # Use the function protocol if the function variable is specified.

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -395,7 +395,7 @@ def test_yaml_parsing():
     """
 
     exp_builder = ExperimentBuilder(textwrap.dedent(yaml_content))
-    assert len(exp_builder._options) == 32
+    assert len(exp_builder._options) == 33
 
     # The global context cache has been set.
     assert mmtools.cache.global_context_cache.capacity == 9

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -696,13 +696,13 @@ def test_validation_wrong_solvents():
     """YAML validation raises exception with wrong solvents."""
     # Each test case is a pair (regexp_error, solvent_description).
     solvents = [
-        ("nonbonded_cutoff can be specified only with the following nonbonded methods \['CutoffPeriodic',\n  'CutoffNonPeriodic', 'Ewald', 'PME'\]",
+        ("nonbonded_cutoff:\n- can be specified only with the following nonbonded methods \['CutoffPeriodic', 'CutoffNonPeriodic',\n  'Ewald', 'PME'\]",
             {'nonbonded_cutoff': '3*nanometers'}),
         ("solvent_model:\n- unallowed value unknown_solvent_model",
             {'nonbonded_method': 'PME', 'solvent_model': 'unknown_solvent_model'}),
         ("leap:\n- must be of dict type",
             {'nonbonded_method': 'PME', 'solvent_model': 'tip3p', 'leap': 'leaprc.water.tip3p'}),
-        ("implicit_solvent can be specified only if nonbonded method is NoCutoff",
+        ("implicit_solvent:\n- can be specified only if nonbonded method is NoCutoff",
             {'nonbonded_method': 'PME', 'clearance': '3*angstroms', 'implicit_solvent': 'OBC2'}),
         ("blabla:\n- unknown field",
             {'nonbonded_method': 'NoCutoff', 'blabla': '3*nanometers'}),
@@ -1206,9 +1206,9 @@ def test_clashing_atoms():
 
         exp_builder = ExperimentBuilder(yaml_content)
 
-        for system_id in [system_id + '_vacuum', system_id + '_PME']:
+        for sys_id in [system_id + '_vacuum', system_id + '_PME']:
             system_dir = os.path.dirname(
-                exp_builder._db.get_system(system_id)[0].position_path)
+                exp_builder._db.get_system(sys_id)[0].position_path)
 
             # Get positions of molecules in the final system
             prmtop = openmm.app.AmberPrmtopFile(os.path.join(system_dir, 'complex.prmtop'))
@@ -1226,8 +1226,8 @@ def test_clashing_atoms():
             assert min_dist >= pipeline.SetupDatabase.CLASH_THRESHOLD
 
             # For solvent we check that molecule is within the box
-            if system_id == system_id + '_PME':
-                assert max_dist <= yaml_content['solvents']['PME']['clearance']
+            if sys_id == system_id + '_PME':
+                assert max_dist <= exp_builder._db.solvents['PME']['clearance'].value_in_unit(unit.angstrom)
 
 
 @unittest.skipIf(not moltools.schrodinger.is_schrodinger_suite_installed(),

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -981,7 +981,21 @@ def test_validation_correct_protocols():
         modified_protocol['absolute-binding']['complex']['alchemical_path'] = protocol
         yield ExperimentBuilder._validate_protocols, modified_protocol
 
-    # Phases
+    # Trailblazer options.
+    auto_protocol = copy.deepcopy(basic_protocol)
+    auto_protocol['absolute-binding']['complex']['alchemical_path'] = 'auto'
+    trailblazer_options = [
+        {'n_equilibration_iterations': 1000, 'n_samples_per_state': 100,
+         'std_potential_threshold': 0.5, 'threshold_tolerance': 0.05},
+        {'n_equilibration_iterations': 100, 'n_samples_per_state': 10},
+        {'std_potential_threshold': 1.0, 'threshold_tolerance': 0.5},
+    ]
+    for opts in trailblazer_options:
+        modified_protocol = copy.deepcopy(auto_protocol)
+        modified_protocol['absolute-binding']['complex']['trailblazer_options'] = opts
+        yield ExperimentBuilder._validate_protocols, modified_protocol
+
+    # Multiple phases.
     alchemical_path = copy.deepcopy(basic_protocol['absolute-binding']['complex'])
     protocols = [
         {'complex': alchemical_path, 'solvent': alchemical_path},
@@ -1022,6 +1036,18 @@ def test_validation_wrong_protocols():
         modified_protocol = copy.deepcopy(basic_protocol)
         modified_protocol['absolute-binding']['complex']['alchemical_path'] = protocol
         yield assert_raises, YamlParseError, ExperimentBuilder._validate_protocols, modified_protocol
+
+    # Trailblazer options.
+    auto_protocol = copy.deepcopy(basic_protocol)
+    auto_protocol['absolute-binding']['complex']['alchemical_path'] = 'auto'
+    trailblazer_options = [
+        ("n_equilibration_iterations:\n  - must be of integer type",
+            {'n_equilibration_iterations': 'bla'}),
+    ]
+    for regex, opts in trailblazer_options:
+        modified_protocol = copy.deepcopy(auto_protocol)
+        modified_protocol['absolute-binding']['complex']['trailblazer_options'] = opts
+        yield assert_raises_regexp, YamlParseError, regex, ExperimentBuilder._validate_protocols, modified_protocol
 
     # Phases
     alchemical_path = copy.deepcopy(basic_protocol['absolute-binding']['complex'])

--- a/Yank/tests/test_experiment.py
+++ b/Yank/tests/test_experiment.py
@@ -696,13 +696,13 @@ def test_validation_wrong_solvents():
     """YAML validation raises exception with wrong solvents."""
     # Each test case is a pair (regexp_error, solvent_description).
     solvents = [
-        ("nonbonded_cutoff:\n- 'depends on these values: {''nonbonded_method'': \[CutoffPeriodic, CutoffNonPeriodic,\n  Ewald, PME\]}'",
+        ("nonbonded_cutoff can be specified only with the following nonbonded methods \['CutoffPeriodic',\n  'CutoffNonPeriodic', 'Ewald', 'PME'\]",
             {'nonbonded_cutoff': '3*nanometers'}),
-        ("solvent_model:\n- unknown_solvent_model not in the known solvent models map!",
+        ("solvent_model:\n- unallowed value unknown_solvent_model",
             {'nonbonded_method': 'PME', 'solvent_model': 'unknown_solvent_model'}),
         ("leap:\n- must be of dict type",
             {'nonbonded_method': 'PME', 'solvent_model': 'tip3p', 'leap': 'leaprc.water.tip3p'}),
-        ("implicit_solvent:\n- 'depends on these values: {''nonbonded_method'': \[NoCutoff\]}",
+        ("implicit_solvent can be specified only if nonbonded method is NoCutoff",
             {'nonbonded_method': 'PME', 'clearance': '3*angstroms', 'implicit_solvent': 'OBC2'}),
         ("blabla:\n- unknown field",
             {'nonbonded_method': 'NoCutoff', 'blabla': '3*nanometers'}),

--- a/Yank/tests/test_pipeline.py
+++ b/Yank/tests/test_pipeline.py
@@ -187,14 +187,14 @@ class TestThermodynamicTrailblazing:
         # Make sure it's not possible to have a parameter defined as a function and as a parameter state as well.
         err_msg = f"Cannot specify {self.PAR_NAME} in 'state_parameters' and 'global_parameter_functions'"
         with assert_raises_regexp(ValueError, err_msg):
-            run_thermodynamic_trailblazing_from_global_parameter_functions(
+            run_thermodynamic_trailblazing_from_parameter_functions(
                 global_parameter_functions, function_variables,
                 compound_state, sampler_state, mcmc_move,
                 state_parameters=[(self.PAR_NAME, [0.0, 1.0])]
             )
 
         # Trailblaze returns the protocol for the actual parameters, not for the function variables.
-        protocol = run_thermodynamic_trailblazing_from_global_parameter_functions(
+        protocol = run_thermodynamic_trailblazing_from_parameter_functions(
             global_parameter_functions, function_variables,
             compound_state, sampler_state, mcmc_move,
             state_parameters=[('lambda', [0.0, 1.0])]
@@ -203,3 +203,15 @@ class TestThermodynamicTrailblazing:
         parameter_protocol = protocol[self.PAR_NAME]
         assert parameter_protocol[0] == 0
         assert parameter_protocol[-1] == 1
+
+    def test_reversed_direction(self):
+        """Make sure that a trailblaze run in the opposite direction still returns the parameters in the forward order."""
+        # Create a harmonic oscillator system to test.
+        compound_state, sampler_state = self.get_harmonic_oscillator()
+        mcmc_move = self.get_langevin_dynamics_move()
+        protocol = run_thermodynamic_trailblazing(
+            compound_state, sampler_state, mcmc_move,
+            state_parameters=[(self.PAR_NAME, [1.0, 0.0])],
+            reversed_direction=True
+        )
+        assert protocol[self.PAR_NAME] == [1.0, 0.0]

--- a/Yank/tests/test_pipeline.py
+++ b/Yank/tests/test_pipeline.py
@@ -187,17 +187,19 @@ class TestThermodynamicTrailblazing:
         # Make sure it's not possible to have a parameter defined as a function and as a parameter state as well.
         err_msg = f"Cannot specify {self.PAR_NAME} in 'state_parameters' and 'global_parameter_functions'"
         with assert_raises_regexp(ValueError, err_msg):
-            run_thermodynamic_trailblazing_from_parameter_functions(
-                global_parameter_functions, function_variables,
+            run_thermodynamic_trailblazing(
                 compound_state, sampler_state, mcmc_move,
-                state_parameters=[(self.PAR_NAME, [0.0, 1.0])]
+                state_parameters=[(self.PAR_NAME, [0.0, 1.0])],
+                global_parameter_functions=global_parameter_functions,
+                function_variables=function_variables,
             )
 
         # Trailblaze returns the protocol for the actual parameters, not for the function variables.
-        protocol = run_thermodynamic_trailblazing_from_parameter_functions(
-            global_parameter_functions, function_variables,
+        protocol = run_thermodynamic_trailblazing(
             compound_state, sampler_state, mcmc_move,
-            state_parameters=[('lambda', [0.0, 1.0])]
+            state_parameters=[('lambda', [0.0, 1.0])],
+            global_parameter_functions=global_parameter_functions,
+            function_variables=function_variables,
         )
         assert list(protocol.keys()) == [self.PAR_NAME]
         parameter_protocol = protocol[self.PAR_NAME]

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - pyyaml
     - clusterutils
     - sphinxcontrib-bibtex
-    - cerberus ==1.1 # yank uses buggy cerberus 1.1 behavior as a feature ¯\_(ツ)_/¯
+    - cerberus
     - matplotlib
     - jupyter
     - pdbfixer

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -20,7 +20,8 @@ New features
 ^^^^^^^^^^^^
 - The thermodynamic trailblazing algorithm used for the authomatic generation of the alchemical path is now capable of
   resuming after an unexpected interruption or crash. The samples generated during the process are used to initialize
-  the replicas of the replica exchange or SAMS free energy calculation (`#1176 <https://github.com/choderalab/yank/pull/1176>`_).
+  the replicas of the replica exchange or SAMS free energy calculation. This behavior can be controlled through the
+  YAML ``start_from_trailblaze_samples`` option (`#1176 <https://github.com/choderalab/yank/pull/1176>`_, `#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 - It is possible to control more options of the thermodynamic trailblazing algorithm and to discretize an alchemical
   path given through mathematical expressions enslaved to a generic variable (`#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 - Added a ``--setup-only`` flag in the ``yank script`` CLI command to run the automatic setup pipeline without running

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -21,7 +21,7 @@ New features
 - The thermodynamic trailblazing algorithm used for the authomatic generation of the alchemical path is now capable of
   resuming after an unexpected interruption or crash. The samples generated during the process are used to initialize
   the replicas of the replica exchange or SAMS free energy calculation. This behavior can be controlled through the
-  YAML ``start_from_trailblaze_samples`` option (`#1176 <https://github.com/choderalab/yank/pull/1176>`_, `#1180 <https://github.com/choderalab/yank/pull/1180>`_).
+  YAML ``start_from_trailblaze_samples`` `option <http://getyank.org/latest/yamlpages/options.html#start-from-trailblaze-samples>`_ (`#1176 <https://github.com/choderalab/yank/pull/1176>`_, `#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 - It is possible to control more options of the thermodynamic trailblazing algorithm and to discretize an alchemical
   path given through mathematical expressions enslaved to a generic variable (`#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 - Added a ``--setup-only`` flag in the ``yank script`` CLI command to run the automatic setup pipeline without running

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -13,12 +13,16 @@ API-breaking changes
 ^^^^^^^^^^^^^^^^^^^^
 - The ``yank.mpi`` module and the objects in the ``yank.multistate`` package, which were deprecated in 0.24.0, have now
   been removed, and they can be found in the ``mpiplus`` and ``openmmtools`` libraries respectively.
+- The function ``yank.pipeline.trailblaze_alchemical_protocol`` has been renamed
+  ``yank.pipeline.run_thermodynamic_trailblazing`` (`#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 
 New features
 ^^^^^^^^^^^^
-- The trailblaze algorithm used for the authomatic generation of the alchemical path is now capable of resuming after an
-  unexpected interruption or crash. The samples generated during the process are used to initialize the replicas of the
-  replica exchange or SAMS free energy calculation (`#1176 <https://github.com/choderalab/yank/pull/1176>`_).
+- The thermodynamic trailblazing algorithm used for the authomatic generation of the alchemical path is now capable of
+  resuming after an unexpected interruption or crash. The samples generated during the process are used to initialize
+  the replicas of the replica exchange or SAMS free energy calculation (`#1176 <https://github.com/choderalab/yank/pull/1176>`_).
+- It is possible to control more options of the thermodynamic trailblazing algorithm and to discretize an alchemical
+  path given through mathematical expressions enslaved to a generic variable (`#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 - Added a ``--setup-only`` flag in the ``yank script`` CLI command to run the automatic setup pipeline without running
   the free energy calculation (`#1178 <https://github.com/choderalab/yank/pull/1178>`_).
 
@@ -26,10 +30,13 @@ Bugfixes
 ^^^^^^^^
 - Fix a bug in which a list of ``experiments: [exp1, exp2]`` in the YAML file containing an unkown experiment name would
   fail silently without error (`#1178 <https://github.com/choderalab/yank/pull/1178>`_).
+- Fixed a problem that would prevent YANK to work with Cerberus >= 1.2 (`#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 
 Enhancements
 ^^^^^^^^^^^^
-- By default, the automatic determination of the alchemical path now starts with the harmonic/flat-bottom restraint turned off and activate it in intermediate states instead of keeping the restraint activated throughout the calculation and reweighting in the analysis stage (`#1176 <https://github.com/choderalab/yank/pull/1176>`_).
+- By default, the automatic determination of the alchemical path now starts with the harmonic/flat-bottom restraint
+  turned off and activate it in intermediate states instead of keeping the restraint activated throughout the calculation
+  and reweighting in the analysis stage (`#1176 <https://github.com/choderalab/yank/pull/1176>`_).
 
 
 0.24.1 Bugfix release

--- a/docs/yamlpages/options.rst
+++ b/docs/yamlpages/options.rst
@@ -623,6 +623,24 @@ Valid Options (2.0 * femtosecond): <Quantity Time> [1]_
 
 
 
+.. _yaml_options_start_from_trailblaze_samples:
+
+.. rst-class:: html-toggle
+
+``start_from_trailblaze_samples``
+--------------------
+.. code-block:: yaml
+
+   options:
+     start_from_trailblaze_samples: yes
+
+If set to ``true`` or ``yes`` and the thermodynamic trailblazing algorithm is used to automatically determine the
+discretization of the alchemical path, the samples generated during the execution of the algorithm are used to initialize
+the replicas of the replica exchange or SAMS free energy calculation.
+
+Valid Options: [yes]/no
+
+
 
 .. _yaml_options_checkpoint_interval:
 

--- a/docs/yamlpages/protocols.rst
+++ b/docs/yamlpages/protocols.rst
@@ -137,28 +137,29 @@ More options for automatic determination of the alchemical path
 
 .. code-block:: yaml
 
-   protocols:
-     {UserDefinedProtocol}:
-       {PhaseName1}:
-         trailblazer_options:
-           # Number of initial equilibration iterations performed in the first state before running the algorithm.
-           n_equilibration_iterations: 1000
-           # Whether the heavy atoms of the receptor are positionally restrained with a harmonic potential during the algorithm.
-           constrain_receptor: false
-           # Number of samples used to estimate the standard deviation of the potential between two states.
-           n_samples_per_state: 100
-           # The "distance" in potential standard deviation between two intermediate states up to 'threshold_tolerance'.
-           std_potential_threshold: 0.5  # in kT
-           threshold_tolerance: 0.05  # in kT
-           # Whether to traverse the path in the forward (given by 'alchemical_path') or reversed direction.
-           reversed_direction: true
-           # A variable controlling the path if 'alchemical_path' contains mathematical expressions.
-           function_variable_name: lambda
+protocols:
+  {UserDefinedProtocol}:
+    {PhaseName1}:
+      trailblazer_options:
+        # Number of initial equilibration iterations performed in the first state before running the algorithm.
+        n_equilibration_iterations: 1000
+        # Whether the heavy atoms of the receptor are positionally restrained with a harmonic potential during the algorithm.
+        constrain_receptor: false
+        # Number of samples used to estimate the standard deviation of the potential between two states.
+        n_samples_per_state: 100
+        # The "distance" in potential standard deviation between two intermediate states up to 'threshold_tolerance'.
+        std_potential_threshold: 0.5  # in kT
+        threshold_tolerance: 0.05  # in kT
+        # Whether to traverse the path in the forward (given by 'alchemical_path') or reversed direction.
+        reversed_direction: true
+        # A variable controlling the path if 'alchemical_path' contains mathematical expressions.
+        function_variable_name: lambda
 
-         alchemical_path:
-           lambda_electrostatics: 2*(lambda - 0.5) * step(lambda - 0.5)
-           lambda_sterics: step_hm(lambda - 0.5) + 2*lambda * step_hm(0.5 - lambda)
-           lambda: [1.0, 0.0]
+      alchemical_path:
+        # Deactivate electrostatic interactions before decoupling the Lennard-Jones potential.
+        lambda_electrostatics: 2*(lambda - 0.5) * step(lambda - 0.5)
+        lambda_sterics: step_hm(lambda - 0.5) + 2*lambda * step_hm(0.5 - lambda)
+        lambda: [1.0, 0.0]
 
 It is possible to set some of the parameters of the algorithm performing the path discretization in the
 ``trailblazer_options`` tag. Moreover, instead of ``alchemical_path: auto`` you can express the alchemical variables

--- a/docs/yamlpages/protocols.rst
+++ b/docs/yamlpages/protocols.rst
@@ -130,10 +130,53 @@ the path determination are used to seed the replicas of Hamiltonian replica exch
 in the ``options`` section is set to ``yes``, this is the stage where the minimization of the input structure occurs.
 
 
+.. _yaml_protocols_auto_options:
+
+More options for automatic determination of the alchemical path
+---------------------------------------------------------------
+
+.. code-block:: yaml
+
+   protocols:
+     {UserDefinedProtocol}:
+       {PhaseName1}:
+         trailblazer_options:
+           # Number of initial equilibration iterations performed in the first state before running the algorithm.
+           n_equilibration_iterations: 1000
+           # Whether the heavy atoms of the receptor are positionally restrained with a harmonic potential during the algorithm.
+           constrain_receptor: false
+           # Number of samples used to estimate the standard deviation of the potential between two states.
+           n_samples_per_state: 100
+           # The "distance" in potential standard deviation between two intermediate states up to 'threshold_tolerance'.
+           std_potential_threshold: 0.5  # in kT
+           threshold_tolerance: 0.05  # in kT
+           # Whether to traverse the path in the forward (given by 'alchemical_path') or reversed direction.
+           reversed_direction: true
+           # A variable controlling the path if 'alchemical_path' contains mathematical expressions.
+           function_variable_name: lambda
+
+         alchemical_path:
+           lambda_electrostatics: 2*(lambda - 0.5) * step(lambda - 0.5)
+           lambda_sterics: step_hm(lambda - 0.5) + 2*lambda * step_hm(0.5 - lambda)
+           lambda: [1.0, 0.0]
+
+It is possible to set some of the parameters of the algorithm performing the path discretization in the
+``trailblazer_options`` tag. Moreover, instead of ``alchemical_path: auto`` you can express the alchemical variables
+in terms of mathematical Python expressions depending on a variable that will be discretized by the algorihtm. In this
+case, ``alchemical_path`` must contain the value of the end states assumed by the variable. In the example above,
+electrostatic interactions are deactivated beetween the variable ``lambda`` 1.0 and 0.5, while Lennard-Jones potential
+is decoupled between ``lambda`` 0.5 and 0.0.
+
+All functions available in the Python standard module ``math`` are available together with
+* ``step(x)`` : Heaviside step function (1.0 for x=0)
+* ``step_hm(x)`` : Heaviside step function with half-maximum convention.
+* ``sign(x)`` : sign function (0.0 for x=0.0)
+
+
 .. _yaml_protocols_thermodynamic_variables:
 
-``temperature`` and ``pressure``
---------------------------------
+Temperature and pressure
+------------------------
 
 It is possible to vary temperature and pressure along the alchemical path, but the end states must have the same values.
 The number of window must be identical to the other lambda variables. A short example:


### PR DESCRIPTION
* Fix #1141: YANK is now compatible with Cerberus >= 1.2, which means we should be able to remove cerberus from omnia.
* Fix #1139: Expose more options for the trailblaze algorithm in YAML. It is now possible to tweak the trailblaze runs. This is the example that I added to the Sphinx docs.

```yaml
protocols:
  {UserDefinedProtocol}:
    {PhaseName1}:
      trailblazer_options:
        # Number of initial equilibration iterations performed in the first state before running the algorithm.
        n_equilibration_iterations: 1000
        # Whether the heavy atoms of the receptor are positionally restrained with a harmonic potential during the algorithm.
        constrain_receptor: false
        # Number of samples used to estimate the standard deviation of the potential between two states.
        n_samples_per_state: 100
        # The "distance" in potential standard deviation between two intermediate states up to 'threshold_tolerance'.
        std_potential_threshold: 0.5  # in kT
        threshold_tolerance: 0.05  # in kT
        # Whether to traverse the path in the forward (given by 'alchemical_path') or reversed direction.
        reversed_direction: true
        # A variable controlling the path if 'alchemical_path' contains mathematical expressions.
        function_variable_name: lambda

      alchemical_path:
        # Deactivate electrostatic interactions before decoupling the Lennard-Jones potential.
        lambda_electrostatics: 2*(lambda - 0.5) * step(lambda - 0.5)
        lambda_sterics: step_hm(lambda - 0.5) + 2*lambda * step_hm(0.5 - lambda)
        lambda: [1.0, 0.0]
```
``alchemical_path: auto`` is still possible, with or without the new block ``trailblazer_options``.