### PR TITLE
Fix trailblaze seeding of initial coordinates

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -3156,7 +3156,7 @@ class ExperimentBuilder(object):
             # If we have generated samples with trailblaze, we start the
             # simulation from those samples. Also, we can turn off minimization
             # as it has been already performed before trailblazing.
-            if exp_opts['start_from_trailblaze_samples'] is True:
+            if not use_dummy_protocol and exp_opts['start_from_trailblaze_samples'] is True:
                 trailblaze_checkpoint_dir_path = self._get_trailblaze_checkpoint_dir_path(
                     experiment_path, phase_name)
                 try:

--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -850,9 +850,9 @@ class ExperimentBuilder(object):
                     iteration = None
                     phase_status = 'pending'
                 except OSError:
-                    # The simulation is probably running.
+                    # The simulation is probably running and the netcdf file is locked.
                     iteration = None
-                    phase_status = 'unavailable'
+                    phase_status = 'unavailable (probably currently running)'
                 else:
                     iteration = phase_status.iteration
                     if _is_phase_completed(phase_status, number_of_iterations):

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - scipy
     - openmm >=7.3
     - mdtraj >=1.7.2
-    - openmmtools >=0.18.3
+    - openmmtools >=0.19.0
     - pymbar
     - docopt
     - openmoltools >=0.7.5

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,15 @@ This section features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+0.25.1 - Bugfix and more robust yank status command
+---------------------------------------------------
+
+Bugfixes
+^^^^^^^^
+- The command ``yank status`` now handles gracefully the case where it attempts to open a locked netcdf file (`#855 <https://github.com/choderalab/yank/pull/855>`_).
+- Fix bug causing YANK to crash sometimes when the option ``bidirectional_redistribution`` was activated (`#1192 <https://github.com/choderalab/yank/pull/1192>`_).
+
+
 0.25.0 - Moved multistate and mpi modules and new trailblaze algorithm
 ----------------------------------------------------------------------
 
@@ -21,7 +30,7 @@ New features
 - The thermodynamic trailblazing algorithm used for the authomatic generation of the alchemical path is now capable of
   resuming after an unexpected interruption or crash. The samples generated during the process are used to initialize
   the replicas of the replica exchange or SAMS free energy calculation. This behavior can be controlled through the
-  YAML ``start_from_trailblaze_samples`` `option <http://getyank.org/latest/yamlpages/options.html#start-from-trailblaze-samples>`_ (`#1176 <https://github.com/choderalab/yank/pull/1176>`_, `#1180 <https://github.com/choderalab/yank/pull/1180>`_).
+  ``start_from_trailblaze_samples`` YAML `option <http://getyank.org/latest/yamlpages/options.html#start-from-trailblaze-samples>`_ (`#1176 <https://github.com/choderalab/yank/pull/1176>`_, `#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 - It is possible to control more options of the thermodynamic trailblazing algorithm and to discretize an alchemical
   path given through mathematical expressions enslaved to a generic variable (`#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 - Added a ``--setup-only`` flag in the ``yank script`` CLI command to run the automatic setup pipeline without running
@@ -29,7 +38,7 @@ New features
 
 Bugfixes
 ^^^^^^^^
-- Fix a bug in which a list of ``experiments: [exp1, exp2]`` in the YAML file containing an unkown experiment name would
+- Fix a bug in which a list of ``experiments: [exp1, exp2]`` in the YAML file containing an unnkown experiment name would
   fail silently without error (`#1178 <https://github.com/choderalab/yank/pull/1178>`_).
 - Fixed a problem that would prevent YANK to work with Cerberus >= 1.2 (`#1180 <https://github.com/choderalab/yank/pull/1180>`_).
 - Fixed the error message displayed when the anisotropic dispersion correction cutoff was too big for the box dimension


### PR DESCRIPTION
In #1189, I've added the option of redistributing the states after the initial trailblazing using the thermodynamic length estimate based on the energy difference std in both directions. When this option is selected, however, the number of initial coordinates generated during trailblazing might be different than the number of states of the protocol after the redistribution and the `MultiStateSampler` complains that the number of samplers states does not match the number of thermodynamic states.

This fixes the resulting crash. I want to avoid doing more sampling to keep the algorithm as cheap as possible so I'm assigning to the new states the coordinates generated at the closest thermodynamic state (closest in thermodynamic length).

I'm planning to make an emergency bugfix release right after the tests pass and I merge this.