### PR TITLE
Added support for CHARMM-format input files (psf/pdb and a list of pr…

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -1706,6 +1706,14 @@ class ExperimentBuilder(object):
             type: string
             dependencies: [phase1_path, phase2_path]
             check_with: directory_exists
+        charmm_parameter_files:
+            required: no
+            type: list
+            schema:
+                type: string
+                check_with: file_exists
+            dependencies: [phase1_path, phase2_path]
+
 
         # Solvents
         solvent:
@@ -3081,6 +3089,7 @@ class ExperimentBuilder(object):
         # Get system files.
         system_files_paths = self._db.get_system(system_id)
         gromacs_include_dir = self._db.systems[system_id].get('gromacs_include_dir', None)
+        charmm_parameter_files = self._db.systems[system_id].get('charmm_parameter_files', None)
 
         # Prepare Yank arguments
         phases = [None, None]
@@ -3107,7 +3116,7 @@ class ExperimentBuilder(object):
             logger.info("Reading phase {}".format(phase_name))
             system, topology, sampler_state = pipeline.read_system_files(
                 positions_file_path, parameters_file_path, system_options,
-                gromacs_include_dir=gromacs_include_dir)
+                gromacs_include_dir=gromacs_include_dir, charmm_parameter_files=charmm_parameter_files)
 
             # Identify system components. There is a ligand only in the complex phase.
             if phase_idx == 0:

--- a/Yank/schema/validator.py
+++ b/Yank/schema/validator.py
@@ -138,7 +138,8 @@ class YANKCerberusValidator(cerberus.Validator):
             ('amber', {'inpcrd', 'prmtop'}),
             ('amber', {'rst7', 'prmtop'}),
             ('gromacs', {'gro', 'top'}),
-            ('openmm', {'pdb', 'xml'})
+            ('openmm', {'pdb', 'xml'}),
+            ('charmm', {'pdb', 'psf'})
         ]
         file_extension_type = None
         for extension_type, valid_extensions in expected_extensions:

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -10,6 +10,10 @@ The full release history can be viewed `at the GitHub yank releases page <https:
 0.25.3 - Development
 --------------------
 
+New features
+^^^^^^^^^^^^
+- Added support for CHARMM-format inputs in arbitrary phase free energies setup by user using ``phase1_path`` and ``phase2_path`` keywords (`#1207 <https://github.com/choderalab/yank/pull/1207>`_).
+
 Bugfixes
 ^^^^^^^^
 - Fixed a bug that causes solute-only trajectories to be extracted with an incorrect order when the ions appear before

--- a/docs/yamlpages/systems.rst
+++ b/docs/yamlpages/systems.rst
@@ -96,7 +96,7 @@ Arbitrary Phase Free Energies Setup by User
        gromacs_include_dir: include/
 
 YANK will allow users to specify arbitrary free energy calculations with systems they have prepared themselves.
-Both Amber and GROMACS input file types are accepted. It is also possible to specify a pair of ``[*.pdb, *.xml]``
+Amber (``[*.prmtop, *.inpcrd]``), GROMACS (``[*.top, *.gro]``) and CHARMM (``[*.psf, *.pdb]``) input file types are accepted. It is also possible to specify a pair of ``[*.pdb, *.xml]``
 files for each phase, where the XML contains a serialized OpenMM system.
 MDTraj is required to use this options since picking the ligand out of the files is done with an MDTraj DSL.
 
@@ -116,3 +116,4 @@ MDTraj is required to use this options since picking the ligand out of the files
 * ``gromacs_include_dir``: *Optional*, Tells YANK where the GROMACS include directory is to pull files and parameters from.
   This is particularly helpful if your topology file does not contain all parameters.
   Path is relative to the YAML script.
+* ``charmm_parameter_files``: *Optional*, Gives YANK a list of CHARMM-format parameter files that provide all the necessary force field parameters for the ``*.psf`` file. For example, ``charmm_parameter_files: [par_all36m_prot.prm, par_all36_carb.prm, toppar_water_ions.str]``. 


### PR DESCRIPTION
The new code allows a psf/pdb combination to used with phase1_path and phase2_path. An additional variable charmm_parameter_files allows any number of CHARMM prm/str files to be included. This commit should fulfill yank github issue  #760 .

One current limitation is that Yank doesn't recognize the CHARMM names for counterions (SOD, CLA). My workaround is to do the replacements "s/SOD/Na+/" and "s/CLA/Cl-/" in the psf, pdb, and toppar_water_ions.str files.

Periodic cell information must be included in the pdb file.