### PR TITLE
Small fixes to docs and to solute-only trajectory

### DIFF
--- a/Yank/experiment.py
+++ b/Yank/experiment.py
@@ -234,7 +234,7 @@ class AlchemicalPhaseFactory(object):
             if self.options['store_solute_trajectory']:
                 # "Solute" is basically just not water. Includes all non-water atoms and ions
                 # Topography ensures the union of solute_atoms and ions_atoms is a null set
-                solute_atoms = self.topography.solute_atoms + self.topography.ions_atoms
+                solute_atoms = sorted(self.topography.solute_atoms + self.topography.ions_atoms)
                 if checkpoint_interval == 1:
                     logger.warning("WARNING! You have specified both a solute-only trajectory AND a checkpoint "
                                    "interval of 1! You are about write the trajectory of the solute twice!\n"

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,17 @@ This section lists features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub yank releases page <https://github.com/choderalab/yank/releases>`_.
 
+
+0.25.3 - Development
+--------------------
+
+Bugfixes
+^^^^^^^^
+- Fixed a bug that causes solute-only trajectories to be extracted with an incorrect order when the ions appear before
+the solute atoms in the system (`#1213 <https://github.com/choderalab/yank/pull/1213>`_).
+- A few fixes to the documentation (`#1213 <https://github.com/choderalab/yank/pull/1213>`_).
+
+
 0.25.2 - Bugfix release
 -----------------------
 

--- a/docs/yamlpages/index.rst
+++ b/docs/yamlpages/index.rst
@@ -121,7 +121,7 @@ Detailed Options List
     * :ref:`switch_distance <yaml_solvents_switch_distance>`
     * :ref:`rigid_water <yaml_solvents_rigid_water>`
     * :ref:`implicit_solvent <yaml_solvents_implicit_solvent>`
-    * :ref:`implicit_solvent_salt_concentration <yaml_options_implicit_solvent_salt_conc>`
+    * :ref:`implicit_solvent_salt_conc <yaml_options_implicit_solvent_salt_conc>`
     * :ref:`solute_dielectric <yaml_options_solute_dielectric>`
     * :ref:`solvent_dielectric <yaml_options_solvent_dielectric>`
     * :ref:`ewald_error_tolerance <yaml_options_ewald_error_tol>`

--- a/docs/yamlpages/molecules.rst
+++ b/docs/yamlpages/molecules.rst
@@ -45,9 +45,10 @@ way to specify the charges, proteins however can rely on built in force field pa
 
 Valid Filetypes: PDB, mol2, sdf, cvs
 
-**Note:** If CVS is specified and there is only one moleucle, the first column must be a SMILES string.
-If multiple molecules are to be used (for the :doc:`!Combinatorial <combinatorial>` ability),
-then each row is its own molecule where the second column is the SMILES string.
+**Note:** A CVS file is expected to have one molecule per row, each containing the SMILES string of the molecule. The
+``select`` keyword can be used to run a subset of the molecules or ``all`` of them. If CSV is specified and there is
+only one column, the first column must be a SMILES string. If multiple columns are used, then the SMILES should be in
+the second column.
 
 
 

--- a/docs/yamlpages/protocols.rst
+++ b/docs/yamlpages/protocols.rst
@@ -151,11 +151,11 @@ protocols:
         thermodynamic_distance: 1.0  # in kT
         distance_tolerance: 0.05  # in kT
         # Whether to traverse the path in the forward (given by 'alchemical_path') or reversed direction.
-        reversed_direction: true
+        reversed_direction: false
         # If set, the states are redistributed after trailblazing using the std estimated in both directions.
         # Optionally, the samples can be obtained from states at a different thermo length than thermodynamic_distance.
         bidirectional_redistribution: true
-        bidirectional_search_thermo_dist: 0.5
+        bidirectional_search_thermo_dist: 'auto'
         # A variable controlling the path if 'alchemical_path' contains mathematical expressions.
         function_variable_name: lambda
 

--- a/docs/yamlpages/solvents.rst
+++ b/docs/yamlpages/solvents.rst
@@ -168,13 +168,13 @@ Valid Options: HCT / OBC1 / OBC2 / GBn / GBn2
 
 .. rst-class:: html-toggle
 
-``implicit_solvent_salt_concentration``
----------------------------------------
+``implicit_solvent_salt_conc``
+------------------------------
 .. code-block:: yaml
 
    solvents:
      {UserDefinedSolvent}:
-       implicit_solvent_salt_concentration: 1.0 * moles / liter
+       implicit_solvent_salt_conc: 1.0 * moles / liter
 
 Specify the salt concentration of the implicit model. Requires an ``implicit_solvent``.
 

--- a/docs/yank-yaml-cookbook/combinatorial-experiment.yaml
+++ b/docs/yank-yaml-cookbook/combinatorial-experiment.yaml
@@ -127,7 +127,7 @@ solvents:
   GBSA:
     nonbonded_method: NoCutoff                      # Implicit solvent using GBSA/OBC2 model.
     implicit_solvent: OBC2
-    implicit_solvent_salt_concentration: 1.0*mole/liter
+    implicit_solvent_salt_conc: 1.0*mole/liter
     solute_dielectric: 1.5
     solvent_dielectric: 80.0
   PME:


### PR DESCRIPTION
- Fix #1200 and other small fixes to the documentation.
- Fix #1212, which caused a problem with the stored solute-only trajectories for systems prepared without the automatic pipeline.